### PR TITLE
Use latest union versions

### DIFF
--- a/tutorials/credit_default/credit_default.py
+++ b/tutorials/credit_default/credit_default.py
@@ -120,7 +120,7 @@ matplotlib_image = ImageSpec(
     packages=[
         "xgboost==2.1.0",
         "matplotlib==3.9.1",
-        "union==0.1.56",
+        "union",
         "scikit-learn==1.4.*",
     ],
 )

--- a/tutorials/credit_default/credit_default.py
+++ b/tutorials/credit_default/credit_default.py
@@ -55,12 +55,12 @@ credit_default_image = ImageSpec(
         "xgboost==2.1.0",
         "nvidia-cuda-runtime-cu12",
         "nvidia-cuda-nvrtc-cu12",
-        "union==0.1.56",
+        "union",
         "cuml-cu12==24.6.*",
         "scikit-learn==1.4.*",
     ],
     python_version="3.11",
-    pip_index="https://pypi.nvidia.com",
+    pip_extra_index_url=["https://pypi.nvidia.com"],
     registry=os.environ.get("IMAGE_SPEC_REGISTRY"),
 )
 

--- a/tutorials/gluonts_time_series/gluonts_time_series.py
+++ b/tutorials/gluonts_time_series/gluonts_time_series.py
@@ -29,7 +29,7 @@ gluon_image = ImageSpec(
         "gluonts[torch]==0.15.1",
         "matplotlib==3.9.1",
         "orjson==3.10.6",
-        "union==0.1.56",
+        "union",
         "pandas==2.2.2",
     ],
     registry=os.environ.get("IMAGE_SPEC_REGISTRY"),

--- a/tutorials/soft_clustering_hdbscan/soft_clustering_hdbscan.py
+++ b/tutorials/soft_clustering_hdbscan/soft_clustering_hdbscan.py
@@ -185,7 +185,7 @@ def soft_clustering(embeddings: FlyteFile) -> Tuple[FlyteFile, FlyteFile]:
 
 plot_image = ImageSpec(
     name="plot_cluster",
-    packages=["numpy==1.26.4", "union==0.1.54", "seaborn==0.13.2", "matplotlib==3.9.1"],
+    packages=["numpy==1.26.4", "union", "seaborn==0.13.2", "matplotlib==3.9.1"],
     registry=os.environ.get("IMAGE_SPEC_REGISTRY"),
 )
 

--- a/tutorials/soft_clustering_hdbscan/soft_clustering_hdbscan.py
+++ b/tutorials/soft_clustering_hdbscan/soft_clustering_hdbscan.py
@@ -52,10 +52,10 @@ image = ImageSpec(
         "nvidia-cuda-runtime-cu12",
         "nvidia-cuda-nvrtc-cu12==12.1.105",
         "nvidia-cublas-cu12",
-        "union==0.1.54",
+        "union",
         "scikit-learn==1.4.*",
     ],
-    pip_index="https://pypi.nvidia.com",
+    pip_extra_index_url=["https://pypi.nvidia.com"],
     registry=os.environ.get("IMAGE_SPEC_REGISTRY"),
 )
 


### PR DESCRIPTION
Union serverless requires the new versions for RBAC.