### PR TITLE
Add missing dependencies for Guide # 01

### DIFF
--- a/guides/01_getting_started/ml_workflow/requirements.txt
+++ b/guides/01_getting_started/ml_workflow/requirements.txt
@@ -1,4 +1,6 @@
 scikit-learn==1.4.1.post1
 pandas==2.2.1
 matplotlib==3.8.3
+pyarrow==17.0.0
+fastparquet==2024.5.0
 union


### PR DESCRIPTION
A few dependencies were missing:

- pyarrow
- fastparquet

Resolves https://github.com/unionai/unionai-examples/issues/59

## Repro Environment

**FAILED** https://serverless.union.ai/org/lune-ai-researcher/projects/flytesnacks/domains/development/executions/an7v6n59hghzbprtn8jm/nodes

## Tests / Verification

**SUCCEEDED** https://serverless.union.ai/org/lune-ai-researcher/projects/flytesnacks/domains/development/executions/an8rptntm9qttxqp589k/nodes
