### PR TITLE
update init from config call

### DIFF
--- a/v2/user-guide/getting-started/hello.py
+++ b/v2/user-guide/getting-started/hello.py
@@ -33,7 +33,7 @@ def main(x_list: list[int] = list(range(10))) -> float:
 if __name__ == "__main__":
 
     # Establish a remote connection from within your script.
-    flyte.init_from_config("config.yaml")
+    flyte.init_from_config()
 
     # Run your tasks remotely inline and pass parameter data.
     run = flyte.run(main, x_list=list(range(10)))

--- a/v2/user-guide/task-configuration/container-images/uv-image-example.py
+++ b/v2/user-guide/task-configuration/container-images/uv-image-example.py
@@ -43,7 +43,7 @@ async def workflow():
 
 
 if __name__ == "__main__":
-    flyte.init_from_config("config.yaml")
+    flyte.init_from_config()
     run = flyte.run(workflow)
     print(run.name)
     print(run.url)

--- a/v2/user-guide/task-programming/error-handling/error_handling.py
+++ b/v2/user-guide/task-programming/error-handling/error_handling.py
@@ -36,7 +36,7 @@ async def failure_recovery() -> int:
 
 
 if __name__ == "__main__":
-    flyte.init_from_config("config.yaml")
+    flyte.init_from_config()
 
     run = flyte.run(failure_recovery)
     print(run.url)


### PR DESCRIPTION
Default behavior of `flyte.init_from_config` searches for config file in `./.flyte/config.yaml`, so specifying `config.yaml` explicitly is no longer needed