### PR TITLE
Remove unused nested grouping docs fragment

### DIFF
--- a/v2/user-guide/task-programming/grouping-actions/grouping.py
+++ b/v2/user-guide/task-programming/grouping-actions/grouping.py
@@ -98,21 +98,6 @@ async def multi_phase_workflow(data_size: int) -> str:
     return f"multi_phase_results: {final_results}"
 # {{/docs-fragment multi}}
 
-# {{docs-fragment nested}}
-@env.task
-async def hierarchical_example(raw_data: str) -> str:
-    with flyte.group("data-preparation"):
-        cleaned_data = await process_data(raw_data, "clean_data")
-        split_data = await process_data(cleaned_data, "split_dataset")
-
-    with flyte.group("hyperparameter-tuning"):
-        best_params = await process_data(split_data, "tune_hyperparameters")
-
-    with flyte.group("model-training"):
-        model = await process_data(best_params, "train_final_model")
-    return model
-# {{/docs-fragment nested}}
-
 # {{docs-fragment conditional}}
 @env.task
 async def conditional_processing(use_advanced_features: bool, input_data: str) -> str:


### PR DESCRIPTION
## Summary
- Remove the `nested` docs fragment (`hierarchical_example`) from `grouping.py`
- This fragment duplicates the pattern already shown by `multi_phase_workflow` and is not referenced by any docs page

## Test plan
- [ ] Verify no docs pages reference the `nested` fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)