### PR TITLE
add basic Streamlit app example with custom domain support

### DIFF
--- a/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
+++ b/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.12"
 # dependencies = [
-#    "flyte>=2.0.0b52",
+#    "flyte>=2.0.0",
 # ]
 # ///
 

--- a/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
+++ b/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
@@ -20,7 +20,7 @@ image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("
 app_env = flyte.app.AppEnvironment(
     name="streamlit-hello-custom-domain",
     image=image,
-    command="streamlit hello --server.port 8080",
+    args=["streamlit", "hello", "--server.port", "8080"],
     resources=flyte.Resources(cpu="1", memory="1Gi"),
     domain=flyte.app.Domain(subdomain="custom-subdomain"),
 )

--- a/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
+++ b/v2/user-guide/serve-and-deploy-apps/create_custom_domain.py
@@ -1,0 +1,33 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# ///
+
+"""A basic streamlit app that uses a custom domain."""
+
+import flyte
+import flyte.app
+
+# {{docs-fragment custom-domain}}
+image = flyte.Image.from_debian_base(python_version=(3, 12)).with_pip_packages("streamlit==1.41.1")
+
+# The `App` declaration.
+# Uses the `ImageSpec` declared above.
+# In this case we do not need to supply any app code
+# as we are using the built-in Streamlit `hello` app.
+app_env = flyte.app.AppEnvironment(
+    name="streamlit-hello-custom-domain",
+    image=image,
+    command="streamlit hello --server.port 8080",
+    resources=flyte.Resources(cpu="1", memory="1Gi"),
+    domain=flyte.app.Domain(subdomain="custom-subdomain"),
+)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    d = flyte.deploy(app_env)
+    print(d[0])
+# {{/docs-fragment custom-domain}}


### PR DESCRIPTION
Docs for apps do not specify how to set a custom url. Customers ask about this frequently. Here is the code that shows how to do this: https://github.com/flyteorg/flyte-sdk/blob/deb28f90611cd1218fbb98c1e26070d14e41ca27/examples/apps/custom_domain.py#L4.

Fixes [DOC-1175](https://linear.app/unionai/issue/DOC-1175/docs-for-apps-should-specify-how-to-set-custom-url)