### PR TITLE
Correct Typo in hello.py

### DIFF
--- a/v2/user-guide/getting-started/hello.py
+++ b/v2/user-guide/getting-started/hello.py
@@ -14,7 +14,7 @@ def fn(x: int) -> int: # Type annotations are required
     return slope * x + intercept
 
 # We also use the `@env.task` decorator to define another task called `main`.
-# This is the is the entrypoint task of the workflow.
+# This is the entrypoint task of the workflow.
 # It calls the `fn` task defined above multiple times using `flyte.map`.
 @env.task
 def main(x_list: list[int] = list(range(10))) -> float:


### PR DESCRIPTION
There's a typo in the comment description of the hello.py function.

Typo: # This is the is the entrypoint task of the workflow.

Correction: # This is the entrypoint task of the workflow.

Fixes [DOC-1180](https://linear.app/unionai/issue/DOC-1180/correct-typo-in-hellopy)