### PR TITLE
Add batch job connector example

### DIFF
--- a/v2/integrations/connectors/batch_job/connector.py
+++ b/v2/integrations/connectors/batch_job/connector.py
@@ -1,0 +1,72 @@
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from flyteidl2.connector.connector_pb2 import (
+    GetTaskLogsResponse,
+    GetTaskLogsResponseBody,
+    GetTaskLogsResponseHeader,
+)
+from flyteidl2.core.execution_pb2 import TaskExecution
+from flyteidl2.logs.dataplane.payload_pb2 import LogLine, LogLineOriginator
+from google.protobuf.timestamp_pb2 import Timestamp
+
+from flyte import logger
+from flyte.connectors import AsyncConnector, ConnectorRegistry, Resource, ResourceMeta
+
+
+@dataclass
+class BatchJobMetadata(ResourceMeta):
+    job_id: str
+    created_at: float
+
+
+class BatchJobConnector(AsyncConnector):
+    name = "Batch Job Connector"
+    task_type_name = "batch_job"
+    metadata_type = BatchJobMetadata
+
+    async def create(self, task_template, inputs: Optional[Dict[str, Any]] = None, **kwargs) -> BatchJobMetadata:
+        job_id = str(uuid.uuid4())[:8]
+        logger.info(f"Submitted batch job {job_id}")
+        return BatchJobMetadata(job_id=job_id, created_at=time.time())
+
+    async def get(self, resource_meta: BatchJobMetadata, **kwargs) -> Resource:
+        elapsed = time.time() - resource_meta.created_at
+        if elapsed < 5:
+            return Resource(phase=TaskExecution.RUNNING, message="Job in progress")
+        return Resource(
+            phase=TaskExecution.SUCCEEDED,
+            message="Job completed",
+            outputs={"result": f"output-from-{resource_meta.job_id}"},
+        )
+
+    async def delete(self, resource_meta: BatchJobMetadata, **kwargs):
+        logger.info(f"Cancelled job {resource_meta.job_id}")
+
+    async def get_logs(self, resource_meta: BatchJobMetadata, token: str = "", **kwargs):
+        def line(message: str, ts: float) -> LogLine:
+            t = Timestamp()
+            t.FromSeconds(int(ts))
+            return LogLine(timestamp=t, message=message, originator=LogLineOriginator.USER)
+
+        start = resource_meta.created_at
+        job_id = resource_meta.job_id
+        pages = {
+            "": GetTaskLogsResponseBody(lines=[
+                line(f"[INFO] Job {job_id} submitted", start),
+                line(f"[INFO] Job {job_id} started", start + 1),
+            ]),
+            "page-2": GetTaskLogsResponseBody(lines=[
+                line(f"[INFO] Job {job_id} finished", start + 5),
+            ]),
+        }
+        next_tokens = {"": "page-2", "page-2": ""}
+        yield GetTaskLogsResponse(body=pages.get(token, GetTaskLogsResponseBody(lines=[])))
+        next_token = next_tokens.get(token, "")
+        if next_token:
+            yield GetTaskLogsResponse(header=GetTaskLogsResponseHeader(token=next_token))
+
+
+ConnectorRegistry.register(BatchJobConnector())

--- a/v2/integrations/connectors/batch_job/task.py
+++ b/v2/integrations/connectors/batch_job/task.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Type
+
+from flyte.connectors import AsyncConnectorExecutorMixin
+from flyte.extend import TaskTemplate
+from flyte.models import NativeInterface, SerializationContext
+
+
+@dataclass
+class BatchJobConfig:
+    timeout_seconds: int = 300
+
+
+class BatchJobTask(AsyncConnectorExecutorMixin, TaskTemplate):
+    _TASK_TYPE = "batch_job"
+
+    def __init__(self, name: str, plugin_config: BatchJobConfig,
+                 inputs: Optional[Dict[str, Type]] = None,
+                 outputs: Optional[Dict[str, Type]] = None, **kwargs):
+        super().__init__(
+            name=name,
+            interface=NativeInterface(
+                {k: (v, None) for k, v in inputs.items()} if inputs else {},
+                outputs or {},
+            ),
+            task_type=self._TASK_TYPE,
+            image=None,
+            **kwargs,
+        )
+        self.plugin_config = plugin_config
+
+    def custom_config(self, sctx: SerializationContext) -> Optional[Dict[str, Any]]:
+        return {"timeout_seconds": self.plugin_config.timeout_seconds}


### PR DESCRIPTION
## Summary

- Adds `v2/integrations/connectors/batch_job/connector.py` — `BatchJobConnector` implementing `AsyncConnector` with `create`, `get`, `delete`, and `get_logs`
- Adds `v2/integrations/connectors/batch_job/task.py` — `BatchJobTask` implementing `AsyncConnectorExecutorMixin`

These files are the canonical source for the connector app documentation in `unionai-docs`, referenced via `{{< code file=... >}}` from both `content/integrations/_index.md` and `content/user-guide/build-apps/connector-app.md`.

## Test plan

- [ ] Verify `connector.py` and `task.py` are importable with `flyte[connector]` installed
- [ ] Confirm docs build picks up the files correctly via the `{{< code file >}}` shortcode