### PR TITLE
Replace legacy byoc URLs with union in v2 tutorial sources

### DIFF
--- a/v2/tutorials/batching_patterns/batch_processing.ipynb
+++ b/v2/tutorials/batching_patterns/batch_processing.ipynb
@@ -718,7 +718,7 @@
     "- Ensure traced functions are idempotent when possible\n",
     "- Keep traced function signatures simple (serializable inputs/outputs)\n",
     "\n",
-    "See the [Traces](https://www.union.ai/docs/v2/byoc/user-guide/task-programming/traces/) docs for more details on how it works"
+    "See the [Traces](https://www.union.ai/docs/v2/union/user-guide/task-programming/traces/) docs for more details on how it works"
    ]
   },
   {
@@ -983,7 +983,7 @@
     "\n",
     "![](./images/reusable-containers-k8s.png)\n",
     "\n",
-    "This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod that runs the parent task (`a0`). [Learn more about the parent task](https://www.union.ai/docs/v2/byoc/user-guide/considerations/#driver-pod-requirements)."
+    "This is, 10 replicas (as defined in the `TaskEnvironment`) and the driver Pod that runs the parent task (`a0`). [Learn more about the parent task](https://www.union.ai/docs/v2/union/user-guide/considerations/#driver-pod-requirements)."
    ]
   },
   {
@@ -1004,7 +1004,7 @@
     "- Failure tolerance (critical = smaller batches for faster recovery)\n",
     "- Total workload size (larger total = can use larger batches)\n",
     "\n",
-    "Read the [Optimization strategies](https://www.union.ai/docs/v2/byoc/user-guide/run-scaling/scale-your-workflows/#2-batch-workloads-to-reduce-overhead) page to understand the overheads associated with an execution and how to choose the appropiate batch size.\n",
+    "Read the [Optimization strategies](https://www.union.ai/docs/v2/union/user-guide/run-scaling/scale-your-workflows/#2-batch-workloads-to-reduce-overhead) page to understand the overheads associated with an execution and how to choose the appropiate batch size.\n",
     "\n",
     "\n"
    ]

--- a/v2/tutorials/ml/embed_wikipedia.py
+++ b/v2/tutorials/ml/embed_wikipedia.py
@@ -97,7 +97,7 @@ async def get_model(model_name: str = "all-MiniLM-L6-v2") -> SentenceTransformer
 # The DynamicBatcher collects text submissions from all 8 concurrent tasks and
 # assembles them into large GPU batches.  Without it, each task would encode its
 # own small batch independently, leaving the GPU idle between calls.
-# See: https://www.union.ai/docs/v2/byoc/user-guide/run-scaling/batch-inference/
+# See: https://www.union.ai/docs/v2/union/user-guide/run-scaling/batch-inference/
 # {{docs-fragment batcher}}
 @alru_cache(maxsize=1)
 async def get_batcher(model_name: str = "all-MiniLM-L6-v2") -> DynamicBatcher[list[str], torch.Tensor]:


### PR DESCRIPTION
## Summary
- Swap `union.ai/docs/v2/byoc/...` → `union.ai/docs/v2/union/...` in 4 URLs across 2 v2 tutorial files
- `byoc` is a deprecated variant code being phased out; `union` is the canonical replacement

**Files touched:**
- `v2/tutorials/batching_patterns/batch_processing.ipynb` — 3 URLs in markdown cells
- `v2/tutorials/ml/embed_wikipedia.py` — 1 URL in a `# See: ...` comment

Companion generator-fix PR in unionai-docs-infra: https://github.com/unionai/unionai-docs-infra/pull/105

## Test plan
- [ ] Open the notebook on GitHub and confirm the rendered links resolve to live `union` docs paths
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)