### PR TITLE
Update retries-and-timeouts examples (RetryStrategy, Backoff, Timeout bounds)

### DIFF
--- a/v2/user-guide/task-configuration/retries-and-timeouts/retries.py
+++ b/v2/user-guide/task-configuration/retries-and-timeouts/retries.py
@@ -8,44 +8,65 @@
 # ///
 
 # {{docs-fragment import-and-env}}
-import random
 from datetime import timedelta
 
 import flyte
+import flyte.errors
 
-
-env = flyte.TaskEnvironment(name="my-env")
+env = flyte.TaskEnvironment(name="retries", resources=flyte.Resources(cpu=1, memory="250Mi"))
 # {{/docs-fragment import-and-env}}
 
 
-# {{docs-fragment retry}}
+async def fetch_from_flaky_upstream() -> str:
+    """Stand-in for a call to an unreliable external service."""
+    return "ok"
+
+
+# {{docs-fragment retry-count}}
 @env.task(retries=3)
-async def retry() -> str:
-    if random.random() < 0.7:  # 70% failure rate
-        raise Exception("Task failed!")
-    return "Success!"
+async def call_service() -> str:
+    # retries=3 -> up to 4 attempts (1 original + 3 retries).
+    # Each retry runs in a fresh pod, so nothing from the failed attempt carries over.
+    return await fetch_from_flaky_upstream()
+# {{/docs-fragment retry-count}}
 
 
-@env.task
-async def main() -> list[str]:
-    results = []
-    try:
-        results.append(await retry())
-    except Exception as e:
-        results.append(f"Failed: {e}")
-    try:
-        results.append(await retry.override(retries=5)())
-    except Exception as e:
-        results.append(f"Failed: {e}")
-    return results
-# {{/docs-fragment retry}}
+# {{docs-fragment retry-backoff}}
+@env.task(
+    retries=flyte.RetryStrategy(
+        count=5,
+        backoff=flyte.Backoff(
+            base=timedelta(seconds=10),  # first retry waits 10s
+            factor=2.0,                  # then 20s, 40s, 80s, ...
+            cap=timedelta(minutes=5),    # never wait longer than 5m between retries
+        ),
+    ),
+)
+async def call_flaky_api() -> str:
+    # The delay before the n-th retry (0-indexed) is min(base * factor**n, cap).
+    # Backoff gives a recovering downstream room to breathe instead of hammering it.
+    return await fetch_from_flaky_upstream()
+# {{/docs-fragment retry-backoff}}
+
+
+# {{docs-fragment non-recoverable}}
+@env.task(retries=3)
+async def validate_and_process(x: int) -> str:
+    if x < 0:
+        # A negative input will never succeed, so don't waste the retry budget on it.
+        # NonRecoverableError fails the action on attempt #1 — no retries are consumed.
+        raise flyte.errors.NonRecoverableError(
+            f"Input x={x} is negative — retrying will not help."
+        )
+    return f"processed({x})"
+# {{/docs-fragment non-recoverable}}
 
 
 # {{docs-fragment run}}
 if __name__ == "__main__":
     flyte.init_from_config()
-    r = flyte.run(main)
-    print(r.name)
-    print(r.url)
-    r.wait()
+    run = flyte.run(validate_and_process, x=-5)
+    print(run.name)
+    print(run.url)
+    run.wait()
 # {{/docs-fragment run}}

--- a/v2/user-guide/task-configuration/retries-and-timeouts/timeouts.py
+++ b/v2/user-guide/task-configuration/retries-and-timeouts/timeouts.py
@@ -8,83 +8,96 @@
 # ///
 
 # {{docs-fragment import-and-env}}
-import random
-from datetime import timedelta
 import asyncio
+from datetime import timedelta
 
 import flyte
 from flyte import Timeout
 
-env = flyte.TaskEnvironment(name="my-env")
+env = flyte.TaskEnvironment(name="timeouts", resources=flyte.Resources(cpu=1, memory="250Mi"))
 # {{/docs-fragment import-and-env}}
 
 
-# {{docs-fragment timeout-seconds}}
-@env.task(timeout=60)  # 60 seconds
-async def timeout_seconds() -> str:
-    await asyncio.sleep(random.randint(0, 120))  # Random wait between 0 and 120 seconds
-    return "timeout_seconds completed"
-# {{/docs-fragment timeout-seconds}}
+# {{docs-fragment max-runtime}}
+@env.task(timeout=Timeout(max_runtime=timedelta(minutes=30)))
+async def train_model() -> str:
+    # max_runtime bounds the RUNNING phase of a single attempt. If the task is
+    # still running after 30 minutes, this attempt is reaped as TIMED_OUT.
+    # The budget is per-attempt: it resets fresh on every retry.
+    ...
+    return "model trained"
+# {{/docs-fragment max-runtime}}
 
 
-# {{docs-fragment timeout-timedelta}}
-@env.task(timeout=timedelta(minutes=1))
-async def timeout_timedelta() -> str:
-    await asyncio.sleep(random.randint(0, 120))  # Random wait between 0 and 120 seconds
-    return "timeout_timedelta completed"
-# {{/docs-fragment timeout-timedelta}}
+# {{docs-fragment max-queued-time}}
+@env.task(timeout=Timeout(max_queued_time=timedelta(minutes=15)))
+async def needs_scarce_gpu() -> str:
+    # max_queued_time bounds the time spent waiting to run (QUEUED +
+    # WAITING_FOR_RESOURCES). If the cluster can't find capacity within 15
+    # minutes, fail fast instead of stalling indefinitely. Per-attempt.
+    ...
+    return "done"
+# {{/docs-fragment max-queued-time}}
 
 
-# {{docs-fragment timeout-advanced}}
-@env.task(timeout=Timeout(
-    max_runtime=timedelta(minutes=1),      # Max execution time per attempt
-    max_queued_time=timedelta(minutes=1)   # Max time in queue before starting
-))
-async def timeout_advanced() -> str:
-    await asyncio.sleep(random.randint(0, 120))  # Random wait between 0 and 120 seconds
-    return "timeout_advanced completed"
-# {{/docs-fragment timeout-advanced}}
+# {{docs-fragment deadline}}
+@env.task(timeout=Timeout(deadline=timedelta(hours=2)))
+async def must_finish_by() -> str:
+    # deadline is an absolute wall-clock budget across ALL attempts, measured
+    # from the first time the action was enqueued. Once 2 hours elapse, the
+    # action is reaped no matter which phase it is in or how many retries remain.
+    ...
+    return "done"
+# {{/docs-fragment deadline}}
 
 
-# {{docs-fragment timeout-with-retry}}
+# {{docs-fragment all-bounds}}
 @env.task(
-    retries=3,
     timeout=Timeout(
-        max_runtime=timedelta(minutes=1),
-        max_queued_time=timedelta(minutes=1)
-    )
+        max_runtime=timedelta(minutes=30),      # per attempt, RUNNING only
+        max_queued_time=timedelta(minutes=15),  # per attempt, waiting to run
+        deadline=timedelta(hours=2),            # absolute, across all attempts
+    ),
 )
-async def timeout_with_retry() -> str:
-    await asyncio.sleep(random.randint(0, 120))  # Random wait between 0 and 120 seconds
-    return "timeout_advanced completed"
-# {{/docs-fragment timeout-with-retry}}
+async def fully_bounded() -> str:
+    ...
+    return "done"
+# {{/docs-fragment all-bounds}}
 
-# {{docs-fragment main}}
-@env.task
-async def main() -> list[str]:
-    tasks = [
-        timeout_seconds(),
-        timeout_seconds.override(timeout=120)(),  # Override to 120 seconds
-        timeout_timedelta(),
-        timeout_advanced(),
-        timeout_with_retry(),
-    ]
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    output = []
-    for r in results:
-        if isinstance(r, Exception):
-            output.append(f"Failed: {r}")
-        else:
-            output.append(r)
-    return output
-# {{/docs-fragment main}}
+
+# {{docs-fragment timeout-shorthand}}
+# A bare int (seconds) or timedelta is shorthand for Timeout(max_runtime=...).
+@env.task(timeout=timedelta(minutes=30))
+async def runtime_only() -> str:
+    ...
+    return "done"
+# {{/docs-fragment timeout-shorthand}}
+
+
+# {{docs-fragment retries-and-deadline}}
+@env.task(
+    retries=flyte.RetryStrategy(
+        count=5,
+        backoff=flyte.Backoff(base=timedelta(seconds=30), factor=2.0, cap=timedelta(minutes=5)),
+    ),
+    timeout=Timeout(
+        max_runtime=timedelta(minutes=10),  # cap any single attempt
+        deadline=timedelta(hours=1),        # but never spend more than 1h total
+    ),
+)
+async def resilient_work() -> str:
+    # Retries continue until either the retry budget is exhausted OR the 1h
+    # deadline fires — whichever comes first. The deadline wins ties.
+    ...
+    return "done"
+# {{/docs-fragment retries-and-deadline}}
 
 
 # {{docs-fragment run}}
 if __name__ == "__main__":
     flyte.init_from_config()
-    r = flyte.run(main)
-    print(r.name)
-    print(r.url)
-    r.wait()
+    run = flyte.run(fully_bounded)
+    print(run.name)
+    print(run.url)
+    run.wait()
 # {{/docs-fragment run}}


### PR DESCRIPTION
Reworks the `v2/user-guide/task-configuration/retries-and-timeouts` examples to cover the full retry/timeout surface, for use by the docs page of the same name.

## What changed

**`retries.py`**
- `retry-count` — plain `retries=N` (N retries = N+1 attempts)
- `retry-backoff` — `flyte.RetryStrategy` with exponential `flyte.Backoff` (base/factor/cap)
- `non-recoverable` — `flyte.errors.NonRecoverableError` to fail terminally without consuming retries

**`timeouts.py`**
- `max-runtime` — per-attempt RUNNING bound
- `max-queued-time` — per-attempt waiting-to-run bound
- `deadline` — absolute wall-clock bound across all attempts
- `all-bounds` — the three combined
- `timeout-shorthand` — bare `timedelta`/`int` == `max_runtime`
- `retries-and-deadline` — backoff-paced retries under an absolute deadline

Each task carries inline comments explaining *why* the control is useful. Fragment markers (`docs-fragment ...`) are consumed by the docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)