### PR TITLE
Add MCP server examples and refactor basic_mcp_app.py

### DIFF
--- a/v2/user-guide/build-mcp/basic_mcp_app.py
+++ b/v2/user-guide/build-mcp/basic_mcp_app.py
@@ -17,40 +17,36 @@ This example shows how to deploy any FastMCP server as a Flyte app using
 
 import flyte
 from flyte.ai.mcp import MCPAppEnvironment
-
+from mcp.server.fastmcp import FastMCP
 
 # {{docs-fragment basic-mcp}}
-def main() -> None:
-    from mcp.server.fastmcp import FastMCP
+mcp = FastMCP(name="demo-generic-mcp")
 
-    # Create a FastMCP instance with custom tools
-    mcp = FastMCP(name="demo-generic-mcp")
 
-    @mcp.tool()
-    def ping() -> str:
-        """Health-style echo for demos."""
-        return "pong"
+@mcp.tool()
+def ping() -> str:
+    """Health-style echo for demos."""
+    return "pong"
 
-    @mcp.tool()
-    def add(a: int, b: int) -> int:
-        """Add two numbers together."""
-        return a + b
 
-    # Create MCP app environment
-    env = MCPAppEnvironment(
-        name="generic-mcp-demo",
-        mcp=mcp,
-        transport="streamable-http",
-        mcp_mount_path="/mcp",
-        resources=flyte.Resources(cpu=1, memory="512Mi"),
-    )
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
 
+
+env = MCPAppEnvironment(
+    name="generic-mcp-demo",
+    mcp=mcp,
+    transport="streamable-http",
+    mcp_mount_path="/mcp",
+    resources=flyte.Resources(cpu=1, memory="512Mi"),
+)
+
+
+if __name__ == "__main__":
     flyte.init_from_config()
     handle = flyte.serve(env)
     handle.activate(wait=True)
     print(f"App is ready at {handle.endpoint}")
-
-
-if __name__ == "__main__":
-    main()
 # {{/docs-fragment basic-mcp}}


### PR DESCRIPTION
## Summary

- Adds MCP server example files for the `build-mcp` documentation: `basic_mcp_app.py`, `flyte_mcp_app.py`, and `flyte_mcp_app_filtered.py`
- Refactors `basic_mcp_app.py` to use module-level MCP setup (moves `FastMCP` instance, tools, and `MCPAppEnvironment` out of a `main()` wrapper) so the example works correctly as a Flyte app entry point

## Test plan

- [ ] Verify `basic_mcp_app.py` runs correctly as a Flyte app (`flyte serve`)
- [ ] Check that MCP example files render correctly in the docs via the `{{< code >}}` shortcode fragments

Made with [Cursor](https://cursor.com)