### PR TITLE
Add workshop tutorials for docs

### DIFF
--- a/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py
+++ b/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py
@@ -1,0 +1,997 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.1.0",
+#    "transformers>=4.45.0",
+#    "datasets>=3.0.0",
+#    "accelerate>=0.34.0",
+#    "scikit-learn",
+#    "numpy",
+# ]
+# main = "pipeline"
+# params = ""
+# ///
+import json
+import logging
+import os
+import tempfile
+
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+import os
+
+main_img = flyte.Image.from_uv_script(__file__, name="bert-fine-tuning-emotion", pre=True)
+
+gpu_env = flyte.TaskEnvironment(
+    name="bert-fine-tuning-emotion-gpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=4, memory="16Gi", gpu=1),
+    secrets=[flyte.Secret(key="huggingface-token", as_env_var="HF_TOKEN")],
+)
+
+cpu_env = flyte.TaskEnvironment(
+    name="bert-fine-tuning-emotion-cpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="8Gi"),
+    depends_on=[gpu_env],
+)
+
+HF_TOKEN = os.environ.get("HF_TOKEN")
+# {{/docs-fragment env}}
+
+
+from report_helpers import (
+    make_attention_text,
+    make_bar_chart,
+    make_confidence_bars,
+    make_confusion_matrix,
+    make_line_chart,
+    make_token_importance_text,
+    pipeline_step_indicator,
+    wrap_report,
+)
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+EMOTION_LABELS = ["sadness", "joy", "love", "anger", "fear", "surprise"]
+EMOTION_DATASET = "dair-ai/emotion"
+
+
+# ------------------------------------------------------------------
+# Task 1: Get data
+# ------------------------------------------------------------------
+
+@cpu_env.task(cache="auto")
+async def get_data(
+    max_train_samples: int = 10000,
+    max_eval_samples: int = 2000,
+) -> flyte.io.Dir:
+    """Download the emotion dataset and save train/eval splits.
+
+    The dair-ai/emotion dataset contains ~20k English Twitter messages labeled
+    with one of 6 emotions: sadness, joy, love, anger, fear, surprise.
+    """
+    from datasets import DatasetDict, load_dataset
+
+    log.info("Loading emotion dataset...")
+    ds = load_dataset(EMOTION_DATASET)
+
+    train_ds = ds["train"].shuffle(seed=42).select(range(min(max_train_samples, len(ds["train"]))))
+    eval_ds = ds["test"].shuffle(seed=42).select(range(min(max_eval_samples, len(ds["test"]))))
+
+    processed = DatasetDict({"train": train_ds, "eval": eval_ds})
+
+    output_dir = os.path.join(tempfile.mkdtemp(), "dataset")
+    processed.save_to_disk(output_dir)
+    log.info(f"Dataset ready: {len(train_ds)} train, {len(eval_ds)} eval")
+
+    return await flyte.io.Dir.from_local(output_dir)
+
+
+# ------------------------------------------------------------------
+# Task 2: Train
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def train(
+    model_name: str,
+    data_dir: flyte.io.Dir,
+    epochs: int = 3,
+    lr: float = 2e-5,
+    batch_size: int = 16,
+    warmup_steps: int = 100,
+) -> flyte.io.Dir:
+    """Fine-tune a BERT-style model for 6-class emotion classification."""
+    import numpy as np
+    import torch
+    from datasets import load_from_disk
+    from sklearn.metrics import accuracy_score, f1_score
+    from transformers import (
+        AutoModelForSequenceClassification,
+        AutoTokenizer,
+        Trainer,
+        TrainerCallback,
+        TrainingArguments,
+    )
+
+    log.info(f"Training: model={model_name}")
+
+    id2label = {i: l for i, l in enumerate(EMOTION_LABELS)}
+    label2id = {l: i for i, l in enumerate(EMOTION_LABELS)}
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Loading Model...</h2>"
+            f"<h3>{model_name}</h3>"
+            f'<div class="card"><p>Preparing for emotion classification training...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    # -- Load data --
+    data_path = await data_dir.download()
+    dataset = load_from_disk(data_path)
+
+    # -- Tokenize --
+    tokenizer = AutoTokenizer.from_pretrained(model_name, token=HF_TOKEN)
+
+    def tokenize(examples):
+        return tokenizer(examples["text"], truncation=True, max_length=128, padding="max_length")
+
+    dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
+
+    # -- Load model --
+    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        model_name,
+        token=HF_TOKEN,
+        num_labels=6,
+        id2label=id2label,
+        label2id=label2id,
+    )
+
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    log.info(f"Parameters: {trainable_params:,} / {total_params:,}")
+
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_mem = torch.cuda.get_device_properties(0).total_memory / 1e9
+        log.info(f"GPU: {gpu_name} ({gpu_mem:.1f} GB)")
+
+    # -- Metrics tracking for live report --
+    training_log: list[dict] = []
+    eval_log: list[dict] = []
+
+    def _build_training_report(max_steps: int) -> str:
+        stats_html = f"""
+        <h2>Training in Progress...</h2>
+        <h3>{model_name}</h3>
+        <div class="stat-grid">
+          <div class="stat"><div class="value">{len(dataset['train']):,}</div><div class="label">Train Samples</div></div>
+          <div class="stat"><div class="value">{len(dataset['eval']):,}</div><div class="label">Eval Samples</div></div>
+          <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>
+          <div class="stat"><div class="value">{lr}</div><div class="label">Learning Rate</div></div>
+          <div class="stat"><div class="value">{batch_size}</div><div class="label">Batch Size</div></div>
+          <div class="stat"><div class="value">{trainable_params:,}</div><div class="label">Parameters</div></div>
+        </div>
+        """
+
+        charts_html = ""
+
+        if training_log:
+            current = training_log[-1]
+            progress_pct = current["step"] / max_steps * 100 if max_steps else 0
+            loss_display = f"Loss: <span class=\"highlight\">{current['loss']:.4f}</span>" if current.get("loss") else ""
+            charts_html += f"""
+            <div class="card">
+              <b>Step {current['step']}/{max_steps}</b>
+              ({progress_pct:.0f}%) |
+              Epoch {current['epoch']:.2f}/{epochs}
+              {f' | {loss_display}' if loss_display else ''}
+              <div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">
+                <div style="background:#0f3460;width:{progress_pct:.1f}%;height:100%;border-radius:4px;"></div>
+              </div>
+            </div>
+            """
+
+            loss_entries = [e for e in training_log if "loss" in e]
+            if len(loss_entries) >= 2:
+                loss_chart = make_line_chart(
+                    data=loss_entries,
+                    x_key="epoch",
+                    y_keys=["loss"],
+                    title="Training Loss",
+                    x_label="Epoch",
+                    y_label="Loss",
+                    colors=["#5a7db5"],
+                )
+                charts_html += f'<div class="chart-container">{loss_chart}</div>'
+
+        if eval_log:
+            latest_eval = eval_log[-1]
+            best_acc = max(e.get("accuracy", 0) for e in eval_log)
+            best_f1 = max(e.get("f1", 0) for e in eval_log)
+            charts_html += f"""
+            <div class="stat-grid" style="margin-top:16px;">
+              <div class="stat"><div class="value">{latest_eval.get('accuracy', 0):.1%}</div><div class="label">Eval Accuracy</div></div>
+              <div class="stat"><div class="value">{latest_eval.get('f1', 0):.1%}</div><div class="label">Eval F1</div></div>
+              <div class="stat"><div class="value">{best_acc:.1%}</div><div class="label">Best Accuracy</div></div>
+              <div class="stat"><div class="value">{latest_eval.get('eval_loss', 0):.4f}</div><div class="label">Eval Loss</div></div>
+            </div>
+            """
+
+            if len(eval_log) >= 2:
+                eval_chart = make_line_chart(
+                    data=eval_log,
+                    x_key="epoch",
+                    y_keys=["accuracy", "f1"],
+                    title="Eval Metrics Over Training",
+                    x_label="Epoch",
+                    y_label="Score",
+                    colors=["#0f3460", "#06d6a0"],
+                    y_max_cap=1.05,
+                    y_display_names={"accuracy": "Accuracy", "f1": "Weighted F1"},
+                )
+                charts_html += f'<div class="chart-container">{eval_chart}</div>'
+
+                eval_loss_chart = make_line_chart(
+                    data=[e for e in eval_log if "eval_loss" in e],
+                    x_key="epoch",
+                    y_keys=["eval_loss"],
+                    title="Eval Loss",
+                    x_label="Epoch",
+                    y_label="Loss",
+                    colors=["#e63946"],
+                )
+                if any("eval_loss" in e for e in eval_log):
+                    charts_html += f'<div class="chart-container">{eval_loss_chart}</div>'
+
+        return wrap_report(stats_html + charts_html)
+
+    # -- Callbacks --
+    class ReportCallback(TrainerCallback):
+        def on_log(self, args, state, control, logs=None, **kwargs):
+            if not logs:
+                return
+            entry = {
+                "step": state.global_step,
+                "epoch": round(logs.get("epoch", 0), 2),
+            }
+            if "loss" in logs:
+                entry["loss"] = round(logs["loss"], 4)
+            if "eval_accuracy" in logs:
+                eval_log.append({
+                    "epoch": entry["epoch"],
+                    "accuracy": logs["eval_accuracy"],
+                    "f1": logs.get("eval_f1", 0),
+                    "eval_loss": logs.get("eval_loss", 0),
+                })
+            if "loss" in entry:
+                training_log.append(entry)
+
+            flyte.report.replace(
+                _build_training_report(state.max_steps),
+                do_flush=True,
+            )
+
+    # -- Compute metrics --
+    def compute_metrics(eval_pred):
+        logits, labels = eval_pred
+        preds = np.argmax(logits, axis=-1)
+        return {
+            "accuracy": accuracy_score(labels, preds),
+            "f1": f1_score(labels, preds, average="weighted"),
+        }
+
+    # -- Training --
+    output_dir = os.path.join(tempfile.mkdtemp(), "checkpoints")
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
+        per_device_eval_batch_size=batch_size * 2,
+        learning_rate=lr,
+        logging_steps=10,
+        eval_strategy="epoch",
+        save_strategy="epoch",
+        load_best_model_at_end=True,
+        metric_for_best_model="f1",
+        bf16=use_bf16,
+        fp16=not use_bf16 and torch.cuda.is_available(),
+        warmup_steps=warmup_steps,
+        report_to="none",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset["train"],
+        eval_dataset=dataset["eval"],
+        processing_class=tokenizer,
+        compute_metrics=compute_metrics,
+        callbacks=[ReportCallback()],
+    )
+
+    log.info("Starting training...")
+    await flyte.report.replace.aio(
+        _build_training_report(0),
+        do_flush=True,
+    )
+
+    trainer.train()
+    log.info("Training complete.")
+
+    # -- Save model --
+    save_dir = os.path.join(tempfile.mkdtemp(), "finetuned_model")
+    trainer.save_model(save_dir)
+    tokenizer.save_pretrained(save_dir)
+    log.info(f"Model saved to {save_dir}")
+
+    # -- Final eval + report --
+    metrics = trainer.evaluate()
+    final_acc = metrics.get("eval_accuracy", 0)
+    final_f1 = metrics.get("eval_f1", 0)
+
+    final_charts = ""
+    loss_entries = [e for e in training_log if "loss" in e]
+    if len(loss_entries) >= 2:
+        loss_chart = make_line_chart(
+            data=loss_entries,
+            x_key="epoch",
+            y_keys=["loss"],
+            title="Training Loss",
+            x_label="Epoch",
+            y_label="Loss",
+            colors=["#5a7db5"],
+        )
+        final_charts += f'<div class="chart-container">{loss_chart}</div>'
+
+    if len(eval_log) >= 2:
+        eval_chart = make_line_chart(
+            data=eval_log,
+            x_key="epoch",
+            y_keys=["accuracy", "f1"],
+            title="Eval Metrics Over Training",
+            x_label="Epoch",
+            y_label="Score",
+            colors=["#0f3460", "#06d6a0"],
+            y_max_cap=1.05,
+            y_display_names={"accuracy": "Accuracy", "f1": "Weighted F1"},
+        )
+        final_charts += f'<div class="chart-container">{eval_chart}</div>'
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Training Complete</h2>"
+            f"<h3>{model_name}</h3>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{final_acc:.1%}</div><div class="label">Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{final_f1:.1%}</div><div class="label">Weighted F1</div></div>'
+            f'  <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>'
+            f'  <div class="stat"><div class="value">{trainable_params:,}</div><div class="label">Parameters</div></div>'
+            f'</div>'
+            f"{final_charts}"
+        ),
+        do_flush=True,
+    )
+
+    return await flyte.io.Dir.from_local(save_dir)
+
+
+# ------------------------------------------------------------------
+# Task 3: Evaluate
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def evaluate(
+    model_name: str,
+    finetuned_dir: flyte.io.Dir,
+    data_dir: flyte.io.Dir,
+    num_examples: int = 200,
+) -> str:
+    """Compare base model (random head) vs fine-tuned on emotion classification.
+
+    Produces confusion matrix, per-class precision/recall/F1, and overall metrics.
+    """
+    import numpy as np
+    import torch
+    from datasets import load_from_disk
+    from sklearn.metrics import (
+        accuracy_score,
+        classification_report,
+        confusion_matrix as sk_confusion_matrix,
+        f1_score,
+    )
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    log.info("Starting evaluation...")
+    await flyte.report.replace.aio(
+        wrap_report("<h2>Evaluation</h2><p>Loading models...</p>"),
+        do_flush=True,
+    )
+
+    # -- Load eval data --
+    data_path = await data_dir.download()
+    dataset = load_from_disk(data_path)
+    eval_ds = dataset["eval"].select(range(min(num_examples, len(dataset["eval"]))))
+    texts = eval_ds["text"]
+    labels = eval_ds["label"]
+
+    def predict_batch(model, tokenizer, texts, batch_size=32):
+        preds = []
+        probs_all = []
+        for i in range(0, len(texts), batch_size):
+            batch = texts[i : i + batch_size]
+            inputs = tokenizer(batch, truncation=True, max_length=128, padding=True, return_tensors="pt")
+            inputs = {k: v.to(model.device) for k, v in inputs.items()}
+            with torch.no_grad():
+                outputs = model(**inputs)
+            batch_probs = torch.softmax(outputs.logits, dim=-1).cpu()
+            batch_preds = torch.argmax(batch_probs, dim=-1).tolist()
+            preds.extend(batch_preds)
+            probs_all.extend(batch_probs.tolist())
+        return preds, probs_all
+
+    # -- Base model --
+    log.info(f"Loading base model: {model_name}")
+    await flyte.report.replace.aio(
+        wrap_report("<h2>Evaluation</h2><p>Running base model (random classifier head)...</p>"),
+        do_flush=True,
+    )
+
+    base_tokenizer = AutoTokenizer.from_pretrained(model_name, token=HF_TOKEN)
+    base_model = AutoModelForSequenceClassification.from_pretrained(
+        model_name, token=HF_TOKEN, num_labels=6,
+    )
+    base_model.eval()
+    if torch.cuda.is_available():
+        base_model = base_model.cuda()
+
+    base_preds, base_probs = predict_batch(base_model, base_tokenizer, texts)
+    del base_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # -- Fine-tuned model --
+    log.info("Loading fine-tuned model...")
+    await flyte.report.replace.aio(
+        wrap_report("<h2>Evaluation</h2><p>Running fine-tuned model...</p>"),
+        do_flush=True,
+    )
+
+    ft_path = await finetuned_dir.download()
+    ft_tokenizer = AutoTokenizer.from_pretrained(ft_path)
+    ft_model = AutoModelForSequenceClassification.from_pretrained(ft_path)
+    ft_model.eval()
+    if torch.cuda.is_available():
+        ft_model = ft_model.cuda()
+
+    ft_preds, ft_probs = predict_batch(ft_model, ft_tokenizer, texts)
+    del ft_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # -- Compute metrics --
+    base_acc = accuracy_score(labels, base_preds) * 100
+    base_f1 = f1_score(labels, base_preds, average="weighted") * 100
+    ft_acc = accuracy_score(labels, ft_preds) * 100
+    ft_f1 = f1_score(labels, ft_preds, average="weighted") * 100
+
+    log.info(f"Base:      Accuracy={base_acc:.1f}%, F1={base_f1:.1f}%")
+    log.info(f"Fine-tuned: Accuracy={ft_acc:.1f}%, F1={ft_f1:.1f}%")
+
+    # -- Confusion matrix --
+    ft_cm = sk_confusion_matrix(labels, ft_preds, labels=list(range(6)))
+    cm_list = ft_cm.tolist()
+    cm_svg = make_confusion_matrix(cm_list, EMOTION_LABELS, title="Fine-tuned Model — Confusion Matrix")
+
+    # -- Per-class metrics --
+    report_dict = classification_report(labels, ft_preds, target_names=EMOTION_LABELS, output_dict=True, zero_division=0)
+    per_class_html = "<table><tr><th>Emotion</th><th>Precision</th><th>Recall</th><th>F1</th><th>Support</th></tr>"
+    for label_name in EMOTION_LABELS:
+        if label_name in report_dict:
+            m = report_dict[label_name]
+            per_class_html += (
+                f"<tr><td><b>{label_name}</b></td>"
+                f"<td>{m['precision']:.1%}</td>"
+                f"<td>{m['recall']:.1%}</td>"
+                f"<td>{m['f1-score']:.1%}</td>"
+                f"<td>{int(m['support'])}</td></tr>"
+            )
+    per_class_html += "</table>"
+
+    # -- Bar chart: base vs fine-tuned --
+    per_class_base_acc = []
+    per_class_ft_acc = []
+    for cls_idx in range(6):
+        cls_mask = [i for i, l in enumerate(labels) if l == cls_idx]
+        if cls_mask:
+            base_cls_acc = sum(1 for i in cls_mask if base_preds[i] == cls_idx) / len(cls_mask) * 100
+            ft_cls_acc = sum(1 for i in cls_mask if ft_preds[i] == cls_idx) / len(cls_mask) * 100
+        else:
+            base_cls_acc = 0
+            ft_cls_acc = 0
+        per_class_base_acc.append(base_cls_acc)
+        per_class_ft_acc.append(ft_cls_acc)
+
+    bar_chart = make_bar_chart(
+        labels=EMOTION_LABELS,
+        series={"Base": per_class_base_acc, "Fine-tuned": per_class_ft_acc},
+        title="Per-Class Accuracy — Base vs Fine-tuned",
+        colors=["#adb5bd", "#0f3460"],
+        y_max_cap=105.0,
+    )
+
+    # -- Example predictions --
+    improvement = ft_acc - base_acc
+    imp_badge = "badge-success" if improvement > 0 else "badge-danger" if improvement < 0 else "badge-info"
+
+    examples_html = ""
+    for i in range(min(10, len(texts))):
+        true_label = EMOTION_LABELS[labels[i]]
+        ft_label = EMOTION_LABELS[ft_preds[i]]
+        base_label = EMOTION_LABELS[base_preds[i]]
+        ft_correct = ft_preds[i] == labels[i]
+        base_correct = base_preds[i] == labels[i]
+        text_preview = texts[i][:200]
+
+        ft_badge = "badge-success" if ft_correct else "badge-danger"
+        base_badge = "badge-success" if base_correct else "badge-danger"
+
+        examples_html += f"""
+<div class="card">
+  <p style="font-size:0.95em;">"{text_preview}"</p>
+  <p>True: <b>{true_label}</b> |
+  Base: <span class="badge {base_badge}">{base_label}</span> |
+  Fine-tuned: <span class="badge {ft_badge}">{ft_label}</span></p>
+</div>"""
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Evaluation Results — Emotion Classification</h2>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{base_acc:.1f}%</div><div class="label">Base Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{ft_acc:.1f}%</div><div class="label">Fine-tuned Accuracy</div></div>'
+            f'  <div class="stat"><div class="value"><span class="badge {imp_badge}">{improvement:+.1f}pp</span></div><div class="label">Improvement</div></div>'
+            f'  <div class="stat"><div class="value">{ft_f1:.1f}%</div><div class="label">Fine-tuned F1</div></div>'
+            f'</div>'
+            f'<div class="chart-container">{bar_chart}</div>'
+            f'<div class="chart-container">{cm_svg}</div>'
+            f"<h3>Per-Class Metrics (Fine-tuned)</h3>"
+            f"{per_class_html}"
+            f"<h3>Example Predictions</h3>"
+            f"{examples_html}"
+        ),
+        do_flush=True,
+    )
+
+    return json.dumps({
+        "base_accuracy": round(base_acc, 1),
+        "base_f1": round(base_f1, 1),
+        "finetuned_accuracy": round(ft_acc, 1),
+        "finetuned_f1": round(ft_f1, 1),
+        "improvement": round(improvement, 1),
+        "num_examples": len(texts),
+        "confusion_matrix": cm_list,
+        "per_class": {k: report_dict[k] for k in EMOTION_LABELS if k in report_dict},
+    })
+
+
+# ------------------------------------------------------------------
+# Task 4: Explore inference
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def explore_inference(
+    finetuned_dir: flyte.io.Dir,
+    data_dir: flyte.io.Dir,
+    num_examples: int = 8,
+) -> str:
+    """Deep-dive into model behavior with attention and token importance.
+
+    For a set of examples, this task produces:
+    1. Predictions with full confidence distribution across all 6 emotions
+    2. Attention heatmaps — which tokens the model focuses on for classification
+       (CLS token attention from the last layer, averaged across heads)
+    3. Token importance via gradient-based attribution — which tokens most
+       influence the predicted class (gradient x embedding norm)
+    4. Misclassification analysis — confident wrong predictions with explanations
+    """
+    import numpy as np
+    import torch
+    from datasets import load_from_disk
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    log.info("Starting explore_inference...")
+    await flyte.report.replace.aio(
+        wrap_report(
+            "<h2>Explore Inference</h2>"
+            "<p>Loading model for attention and attribution analysis...</p>"
+        ),
+        do_flush=True,
+    )
+
+    # -- Load model (with eager attention for weight extraction) --
+    ft_path = await finetuned_dir.download()
+    tokenizer = AutoTokenizer.from_pretrained(ft_path)
+
+    # Need eager attention to extract attention weights (flash attention doesn't return them)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        ft_path,
+        output_attentions=True,
+        attn_implementation="eager",
+    )
+    model.eval()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = model.to(device)
+
+    # -- Load eval data --
+    data_path = await data_dir.download()
+    dataset = load_from_disk(data_path)
+    eval_ds = dataset["eval"]
+
+    # Pick a diverse set of examples — try to get some from each class
+    examples_per_class = max(1, num_examples // 6)
+    selected_indices = []
+    for cls_idx in range(6):
+        cls_indices = [i for i in range(len(eval_ds)) if eval_ds[i]["label"] == cls_idx]
+        selected_indices.extend(cls_indices[:examples_per_class])
+    # Fill remaining with random
+    remaining = num_examples - len(selected_indices)
+    if remaining > 0:
+        other_indices = [i for i in range(len(eval_ds)) if i not in selected_indices]
+        selected_indices.extend(other_indices[:remaining])
+    selected_indices = selected_indices[:num_examples]
+
+    # -- Analyze each example --
+    analyses = []
+    for idx_num, ds_idx in enumerate(selected_indices):
+        text = eval_ds[ds_idx]["text"]
+        true_label = eval_ds[ds_idx]["label"]
+
+        await flyte.report.replace.aio(
+            wrap_report(
+                f"<h2>Explore Inference</h2>"
+                f"<p>Analyzing example {idx_num + 1}/{len(selected_indices)}...</p>"
+                f'<div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">'
+                f'<div style="background:#0f3460;width:{(idx_num + 1) / len(selected_indices) * 100:.1f}%;height:100%;border-radius:4px;"></div>'
+                f'</div>'
+            ),
+            do_flush=True,
+        )
+
+        # Tokenize
+        inputs = tokenizer(text, return_tensors="pt", truncation=True, max_length=128)
+        inputs = {k: v.to(device) for k, v in inputs.items()}
+        token_ids = inputs["input_ids"][0]
+        tokens = tokenizer.convert_ids_to_tokens(token_ids)
+
+        # Forward pass with attention
+        with torch.no_grad():
+            outputs = model(**inputs)
+
+        logits = outputs.logits[0]
+        probs = torch.softmax(logits, dim=-1).cpu().tolist()
+        pred_idx = int(torch.argmax(logits).item())
+
+        # -- Attention: CLS token attention from last layer --
+        # attentions shape: (num_layers, batch, num_heads, seq_len, seq_len)
+        last_layer_attention = outputs.attentions[-1][0]  # (num_heads, seq_len, seq_len)
+        # Average across heads, take CLS row (index 0)
+        cls_attention = last_layer_attention.mean(dim=0)[0].cpu().numpy()  # (seq_len,)
+
+        # Remove [CLS] and [SEP] and padding from visualization
+        real_token_mask = []
+        clean_tokens = []
+        clean_attention = []
+        for i, tok in enumerate(tokens):
+            if tok in ("[CLS]", "[SEP]", "<s>", "</s>", "[PAD]", "<pad>"):
+                continue
+            if tok == tokenizer.pad_token:
+                continue
+            clean_tokens.append(tok)
+            clean_attention.append(float(cls_attention[i]))
+            real_token_mask.append(i)
+
+        # -- Token importance via gradient attribution --
+        # Re-run with gradients enabled on embeddings
+        embedding_layer = None
+        for name, module in model.named_modules():
+            if isinstance(module, torch.nn.Embedding) and "word" in name.lower():
+                embedding_layer = module
+                break
+        if embedding_layer is None:
+            # Fallback: find the first large embedding
+            for name, module in model.named_modules():
+                if isinstance(module, torch.nn.Embedding) and module.weight.shape[0] > 1000:
+                    embedding_layer = module
+                    break
+
+        importance_scores = [0.0] * len(clean_tokens)
+        if embedding_layer is not None:
+            inputs_grad = tokenizer(text, return_tensors="pt", truncation=True, max_length=128)
+            inputs_grad = {k: v.to(device) for k, v in inputs_grad.items()}
+
+            embeddings = embedding_layer(inputs_grad["input_ids"])
+            embeddings.retain_grad()
+
+            # Run model with embeddings instead of input_ids
+            # We need to hook into the model to replace the embedding output
+            embedding_output = [None]
+
+            def hook_fn(module, input, output):
+                embedding_output[0] = output
+                return embeddings.requires_grad_(True)
+
+            handle = embedding_layer.register_forward_hook(hook_fn)
+
+            outputs_grad = model(**inputs_grad)
+            handle.remove()
+
+            # Gradient of predicted class w.r.t. embeddings
+            pred_score = outputs_grad.logits[0, pred_idx]
+            pred_score.backward()
+
+            if embeddings.grad is not None:
+                # Token importance = L2 norm of (gradient * embedding) per token
+                token_importance = (embeddings.grad[0] * embeddings[0]).norm(dim=-1).detach().cpu().numpy()
+                for clean_idx, orig_idx in enumerate(real_token_mask):
+                    if orig_idx < len(token_importance):
+                        importance_scores[clean_idx] = float(token_importance[orig_idx])
+
+            model.zero_grad()
+
+        analyses.append({
+            "text": text,
+            "true_label": true_label,
+            "pred_idx": pred_idx,
+            "probs": probs,
+            "tokens": clean_tokens,
+            "attention": clean_attention,
+            "importance": importance_scores,
+            "correct": pred_idx == true_label,
+        })
+
+    # -- Build report --
+    log.info("Building explore_inference report...")
+
+    # Overall summary
+    correct = sum(1 for a in analyses if a["correct"])
+    total = len(analyses)
+
+    # Separate correct vs wrong
+    correct_analyses = [a for a in analyses if a["correct"]]
+    wrong_analyses = [a for a in analyses if not a["correct"]]
+
+    # -- Build example cards --
+    examples_html = ""
+    for a in analyses:
+        true_name = EMOTION_LABELS[a["true_label"]]
+        pred_name = EMOTION_LABELS[a["pred_idx"]]
+        status_badge = "badge-success" if a["correct"] else "badge-danger"
+        status_text = "Correct" if a["correct"] else "Wrong"
+
+        # Confidence bars
+        conf_bars = make_confidence_bars(
+            labels=EMOTION_LABELS,
+            probabilities=a["probs"],
+            predicted_idx=a["pred_idx"],
+            true_idx=a["true_label"],
+        )
+
+        # Attention heatmap
+        attention_viz = make_attention_text(
+            tokens=a["tokens"],
+            weights=a["attention"],
+            title="Attention (what the model looks at for its prediction — darker = more attention)",
+        )
+
+        # Token importance
+        importance_viz = make_token_importance_text(
+            tokens=a["tokens"],
+            importance=a["importance"],
+            title="Token importance (gradient attribution — green = supports prediction, red = opposes)",
+        )
+
+        text_preview = a["text"][:300]
+        examples_html += f"""
+<div class="card">
+  <p style="font-size:1em;"><b>"{text_preview}"</b></p>
+  <p>True: <b>{true_name}</b> | Predicted: <span class="badge {status_badge}">{pred_name} ({status_text})</span>
+     | Confidence: <b>{a['probs'][a['pred_idx']]:.1%}</b></p>
+  <div style="margin:12px 0;">{conf_bars}</div>
+  <div style="margin:12px 0;">{attention_viz}</div>
+  <div style="margin:12px 0;">{importance_viz}</div>
+</div>"""
+
+    # -- Misclassification spotlight --
+    misclass_html = ""
+    if wrong_analyses:
+        # Sort by confidence (most confident wrong first)
+        wrong_sorted = sorted(wrong_analyses, key=lambda a: a["probs"][a["pred_idx"]], reverse=True)
+
+        misclass_html = "<h3>Misclassification Spotlight</h3>"
+        misclass_html += '<div class="note">These are the model\'s most confident wrong predictions — cases where the model is sure but incorrect. These reveal the model\'s blind spots.</div>'
+
+        for a in wrong_sorted[:3]:
+            true_name = EMOTION_LABELS[a["true_label"]]
+            pred_name = EMOTION_LABELS[a["pred_idx"]]
+            conf = a["probs"][a["pred_idx"]]
+            true_conf = a["probs"][a["true_label"]]
+
+            misclass_html += f"""
+<div class="card" style="border-left:4px solid #e63946;">
+  <p><b>"{a['text'][:200]}"</b></p>
+  <p>Predicted <span class="badge badge-danger">{pred_name}</span> ({conf:.1%})
+     but true label is <span class="badge badge-info">{true_name}</span> ({true_conf:.1%})</p>
+  <p style="font-size:0.85em;color:#6c757d;">
+     The model assigned {conf:.1%} confidence to {pred_name} vs {true_conf:.1%} to {true_name}.
+     {"The model was very sure here — this is a genuine blind spot." if conf > 0.7 else "The model was uncertain — the true class was a close second."}
+  </p>
+</div>"""
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Explore Inference — Attention &amp; Attribution</h2>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{correct}/{total}</div><div class="label">Correct</div></div>'
+            f'  <div class="stat"><div class="value">{correct/total:.0%}</div><div class="label">Accuracy (sample)</div></div>'
+            f'  <div class="stat"><div class="value">{len(wrong_analyses)}</div><div class="label">Errors to Analyze</div></div>'
+            f'</div>'
+            f'<div class="note">'
+            f'<b>How to read the visualizations below:</b><br/>'
+            f'<b>Attention heatmap:</b> Shows which tokens the [CLS] token attends to in the final layer '
+            f'(averaged across all attention heads). Darker = more attention. This reveals what the model "looks at" when making its classification decision.<br/>'
+            f'<b>Token importance:</b> Gradient-based attribution showing which tokens most influence the prediction. '
+            f'Green = supports the prediction, Red = opposes it. Computed as gradient &times; embedding norm.'
+            f'</div>'
+            f"<h3>Example Analysis</h3>"
+            f"{examples_html}"
+            f"{misclass_html}"
+        ),
+        do_flush=True,
+    )
+
+    return json.dumps({
+        "num_examples": total,
+        "correct": correct,
+        "accuracy": round(correct / total * 100, 1),
+        "num_misclassifications": len(wrong_analyses),
+        "analyses": [
+            {
+                "text": a["text"][:200],
+                "true_label": EMOTION_LABELS[a["true_label"]],
+                "predicted": EMOTION_LABELS[a["pred_idx"]],
+                "confidence": round(a["probs"][a["pred_idx"]], 3),
+                "correct": a["correct"],
+            }
+            for a in analyses
+        ],
+    })
+
+
+# ------------------------------------------------------------------
+# Pipeline
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@cpu_env.task(report=True)
+async def pipeline(
+    model_name: str = "answerdotai/ModernBERT-base",
+    epochs: int = 3,
+    lr: float = 2e-5,
+    batch_size: int = 16,
+    warmup_steps: int = 100,
+    max_train_samples: int = 10000,
+    max_eval_samples: int = 2000,
+    num_eval_examples: int = 200,
+    num_explore_examples: int = 12,
+) -> flyte.io.Dir:
+    """
+    ModernBERT emotion classification pipeline.
+
+    Returns the fine-tuned model directory (used by serve.py for deployment).
+
+    1. Download emotion dataset (6 classes from Twitter text)
+    2. Fine-tune ModernBERT for sequence classification
+    3. Evaluate: base vs fine-tuned with confusion matrix
+    4. Explore inference: attention heatmaps + token importance
+
+    Args:
+        model_name: HuggingFace encoder model to fine-tune.
+        num_explore_examples: Number of examples for attention/attribution analysis.
+    """
+    log.info(f"Pipeline: {model_name} | emotion classification")
+    steps = ["Get Data", "Train", "Evaluate", "Explore Inference"]
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Emotion Classification Pipeline</h2>"
+            f"<h3>{model_name}</h3>"
+            f"{pipeline_step_indicator(0, steps)}"
+            f'<div class="card"><p>Downloading emotion dataset...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    # Step 1: Get data
+    data_dir = await get_data(max_train_samples, max_eval_samples)
+
+    # Step 2: Train
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Emotion Classification Pipeline</h2>"
+            f"<h3>{model_name}</h3>"
+            f"{pipeline_step_indicator(1, steps)}"
+            f'<div class="card"><p>Fine-tuning for emotion classification...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    finetuned_dir = await train(model_name, data_dir, epochs, lr, batch_size, warmup_steps)
+
+    # Step 3: Evaluate
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Emotion Classification Pipeline</h2>"
+            f"<h3>{model_name}</h3>"
+            f"{pipeline_step_indicator(2, steps)}"
+            f'<div class="card"><p>Evaluating base vs fine-tuned model...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    eval_result = await evaluate(model_name, finetuned_dir, data_dir, num_eval_examples)
+    eval_metrics = json.loads(eval_result)
+
+    # Step 4: Explore inference
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Emotion Classification Pipeline</h2>"
+            f"<h3>{model_name}</h3>"
+            f"{pipeline_step_indicator(3, steps)}"
+            f'<div class="card"><p>Analyzing attention patterns and token importance...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    explore_result = await explore_inference(finetuned_dir, data_dir, num_explore_examples)
+
+    # -- Final report --
+    improvement = eval_metrics["improvement"]
+    imp_badge = "badge-success" if improvement > 0 else "badge-danger" if improvement < 0 else "badge-info"
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Emotion Classification Pipeline Complete</h2>"
+            f"<h3>{model_name}</h3>"
+            f"{pipeline_step_indicator(4, steps)}"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{eval_metrics["base_accuracy"]}%</div><div class="label">Base Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{eval_metrics["finetuned_accuracy"]}%</div><div class="label">Fine-tuned Accuracy</div></div>'
+            f'  <div class="stat"><div class="value"><span class="badge {imp_badge}">{improvement:+.1f}pp</span></div><div class="label">Improvement</div></div>'
+            f'  <div class="stat"><div class="value">{eval_metrics["finetuned_f1"]}%</div><div class="label">Weighted F1</div></div>'
+            f'</div>'
+        ),
+        do_flush=True,
+    )
+
+    log.info(f"Pipeline complete. Accuracy improvement: {improvement:+.1f}pp")
+    return finetuned_dir
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py
+++ b/v2/tutorials/bert_fine_tuning_emotion/bert_fine_tuning_emotion.py
@@ -494,7 +494,10 @@ async def evaluate(
     cm_svg = make_confusion_matrix(cm_list, EMOTION_LABELS, title="Fine-tuned Model — Confusion Matrix")
 
     # -- Per-class metrics --
-    report_dict = classification_report(labels, ft_preds, target_names=EMOTION_LABELS, output_dict=True, zero_division=0)
+    report_dict = classification_report(
+        labels, ft_preds, labels=list(range(6)), target_names=EMOTION_LABELS,
+        output_dict=True, zero_division=0,
+    )
     per_class_html = "<table><tr><th>Emotion</th><th>Precision</th><th>Recall</th><th>F1</th><th>Support</th></tr>"
     for label_name in EMOTION_LABELS:
         if label_name in report_dict:

--- a/v2/tutorials/bert_fine_tuning_emotion/report_helpers.py
+++ b/v2/tutorials/bert_fine_tuning_emotion/report_helpers.py
@@ -1,0 +1,437 @@
+"""Flyte report helpers — CSS, SVG charts, attention heatmaps, and HTML wrappers."""
+
+import html as html_module
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .highlight { color: #0f3460; font-weight: 700; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d4edda; color: #155724; }
+  .report .badge-info { background: #d1ecf1; color: #0c5460; }
+  .report .badge-danger { background: #f8d7da; color: #721c24; }
+  .report .badge-warning { background: #fff3cd; color: #856404; }
+  .report .chart-container { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 16px 0; }
+  .report .attention-text { line-height: 2.2; font-size: 1.05em; margin: 8px 0; }
+  .report .attention-text span { padding: 2px 4px; border-radius: 3px; margin: 1px; }
+  .report .confidence-bar { display: flex; align-items: center; margin: 4px 0; }
+  .report .confidence-bar .bar-label { width: 80px; font-size: 0.85em; text-align: right; padding-right: 8px; }
+  .report .confidence-bar .bar-track { flex: 1; background: #e9ecef; height: 20px; border-radius: 4px; overflow: hidden; }
+  .report .confidence-bar .bar-fill { height: 100%; border-radius: 4px; transition: width 0.3s; }
+  .report .confidence-bar .bar-value { width: 50px; font-size: 0.85em; padding-left: 8px; }
+</style>
+"""
+
+
+def wrap_report(html: str) -> str:
+    """Wrap HTML content with report styling."""
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+# ------------------------------------------------------------------
+# Line chart (same as GRPO tutorial)
+# ------------------------------------------------------------------
+
+def make_line_chart(
+    data: list[dict],
+    x_key: str,
+    y_keys: list[str],
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+    y_display_names: dict[str, str] | None = None,
+) -> str:
+    """Generate an SVG line chart from a list of dicts."""
+    default_colors = ["#5a7db5", "#0f3460", "#06d6a0", "#ffc107", "#6c757d"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 50
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    x_vals = [d[x_key] for d in data] if data else []
+    if x_vals:
+        x_min, x_max = min(x_vals), max(x_vals)
+    else:
+        x_min, x_max = 0, 1
+    x_range = x_max - x_min or 1
+
+    all_y = []
+    for key in y_keys:
+        all_y.extend(d[key] for d in data if key in d)
+    y_min = min(all_y) if all_y else 0
+    y_max = max(all_y) if all_y else 1
+    y_pad = (y_max - y_min) * 0.1 or 0.1
+    y_min_plot = y_min - y_pad
+    y_max_plot = y_max + y_pad
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap)
+    y_range = y_max_plot - y_min_plot or 1
+
+    def sx(v):
+        return ml + (v - x_min) / x_range * cw
+
+    def sy(v):
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    for i in range(6):
+        y_tick = y_min_plot + y_range * i / 5
+        py = sy(y_tick)
+        lines.append(f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" stroke="#e9ecef" stroke-width="1"/>')
+        lines.append(f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" font-size="11" fill="#6c757d">{y_tick:.3f}</text>')
+
+    lines.append(f'<line x1="{ml}" y1="{mt}" x2="{ml}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+    lines.append(f'<line x1="{ml}" y1="{mt + ch}" x2="{ml + cw}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+
+    if x_vals:
+        n_x_ticks = min(len(data), 10)
+        step = max(1, len(data) // n_x_ticks)
+        for i in range(0, len(data), step):
+            px = sx(x_vals[i])
+            lines.append(f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" font-size="11" fill="#6c757d">{x_vals[i]:.1f}</text>')
+
+    if not data:
+        lines.append(f'<text x="{ml + cw / 2}" y="{mt + ch / 2}" text-anchor="middle" font-size="13" fill="#adb5bd" font-style="italic">Waiting for data...</text>')
+
+    for si, key in enumerate(y_keys):
+        color = colors[si % len(colors)]
+        points = [(sx(d[x_key]), sy(d[key])) for d in data if key in d]
+        if not points:
+            continue
+        if len(points) >= 2:
+            path_d = f"M {points[0][0]:.1f},{points[0][1]:.1f}"
+            for px, py in points[1:]:
+                path_d += f" L {px:.1f},{py:.1f}"
+            dash = ' stroke-dasharray="6,3"' if si % 2 == 1 else ""
+            lines.append(f'<path d="{path_d}" fill="none" stroke="{color}" stroke-width="2" stroke-linejoin="round"{dash}/>')
+        if len(points) <= 30:
+            for px, py in points:
+                lines.append(f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{color}"/>')
+
+    if title:
+        lines.append(f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+    if x_label:
+        lines.append(f'<text x="{ml + cw / 2}" y="{height - 6}" text-anchor="middle" font-size="12" fill="#6c757d">{x_label}</text>')
+    if y_label:
+        lines.append(f'<text x="14" y="{mt + ch / 2}" text-anchor="middle" font-size="12" fill="#6c757d" transform="rotate(-90, 14, {mt + ch / 2})">{y_label}</text>')
+
+    names = y_display_names or {}
+    if len(y_keys) > 1:
+        lx = ml + 10
+        for si, key in enumerate(y_keys):
+            color = colors[si % len(colors)]
+            ly = mt + 14 + si * 18
+            lines.append(f'<rect x="{lx}" y="{ly - 6}" width="12" height="12" rx="2" fill="{color}"/>')
+            label = names.get(key, key)
+            lines.append(f'<text x="{lx + 16}" y="{ly + 4}" font-size="11" fill="#1a1a2e">{label}</text>')
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+# ------------------------------------------------------------------
+# Bar chart
+# ------------------------------------------------------------------
+
+def make_bar_chart(
+    labels: list[str],
+    series: dict[str, list[float]],
+    title: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+) -> str:
+    """Generate an SVG grouped bar chart."""
+    if not labels:
+        return ""
+
+    default_colors = ["#adb5bd", "#0f3460", "#06d6a0", "#5a7db5"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 60
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    all_vals = [v for vals in series.values() for v in vals]
+    y_max = max(all_vals) if all_vals else 1
+    y_max_plot = y_max * 1.15 or 1
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap) or y_max_cap
+
+    n_groups = len(labels)
+    n_series = len(series)
+    group_width = cw / n_groups
+    bar_width = group_width * 0.7 / max(n_series, 1)
+    gap = group_width * 0.15
+
+    def sy(v):
+        return mt + ch - (v / y_max_plot) * ch
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    for i in range(6):
+        y_tick = y_max_plot * i / 5
+        py = sy(y_tick)
+        svg.append(f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" stroke="#e9ecef" stroke-width="1"/>')
+        svg.append(f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" font-size="11" fill="#6c757d">{y_tick:.1f}</text>')
+
+    for gi, label in enumerate(labels):
+        gx = ml + gi * group_width + gap
+        for si, (name, vals) in enumerate(series.items()):
+            color = colors[si % len(colors)]
+            bx = gx + si * bar_width
+            val = vals[gi]
+            by = sy(val)
+            bh = mt + ch - by
+            svg.append(f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_width - 1:.1f}" height="{bh:.1f}" fill="{color}" rx="2"/>')
+            svg.append(f'<text x="{bx + bar_width / 2:.1f}" y="{by - 4:.1f}" text-anchor="middle" font-size="10" fill="#1a1a2e">{val:.1f}%</text>')
+        svg.append(f'<text x="{gx + n_series * bar_width / 2:.1f}" y="{mt + ch + 18}" text-anchor="middle" font-size="11" fill="#6c757d">{label}</text>')
+
+    if title:
+        svg.append(f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    lx = ml + cw - len(series) * 100
+    for si, name in enumerate(series):
+        color = colors[si % len(colors)]
+        svg.append(f'<rect x="{lx + si * 100}" y="{mt + ch + 35}" width="12" height="12" rx="2" fill="{color}"/>')
+        svg.append(f'<text x="{lx + si * 100 + 16}" y="{mt + ch + 46}" font-size="11" fill="#1a1a2e">{name}</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+# ------------------------------------------------------------------
+# Confusion matrix heatmap (SVG)
+# ------------------------------------------------------------------
+
+def make_confusion_matrix(
+    matrix: list[list[int]],
+    labels: list[str],
+    title: str = "Confusion Matrix",
+    width: int = 500,
+    height: int = 500,
+) -> str:
+    """Generate an SVG confusion matrix heatmap."""
+    n = len(labels)
+    ml, mt = 90, 50
+    cell_size = min((width - ml - 20) / n, (height - mt - 40) / n)
+    grid_w = cell_size * n
+    grid_h = cell_size * n
+
+    max_val = max(max(row) for row in matrix) if matrix else 1
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {ml + grid_w + 30} {mt + grid_h + 50}" '
+        f'style="width:100%;max-width:{int(ml + grid_w + 30)}px;height:auto;">',
+        f'<rect width="{ml + grid_w + 30}" height="{mt + grid_h + 50}" fill="#fff" rx="6"/>',
+    ]
+
+    if title:
+        svg.append(f'<text x="{(ml + grid_w + 30) / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    # Axis labels
+    svg.append(f'<text x="{ml + grid_w / 2}" y="{mt + grid_h + 35}" text-anchor="middle" font-size="12" fill="#6c757d">Predicted</text>')
+    svg.append(f'<text x="12" y="{mt + grid_h / 2}" text-anchor="middle" font-size="12" fill="#6c757d" transform="rotate(-90, 12, {mt + grid_h / 2})">Actual</text>')
+
+    for i in range(n):
+        for j in range(n):
+            x = ml + j * cell_size
+            y = mt + i * cell_size
+            val = matrix[i][j]
+            intensity = val / max_val if max_val > 0 else 0
+
+            if i == j:
+                r = int(15 + (15 - 15) * (1 - intensity))
+                g = int(52 + (52 - 52) * (1 - intensity))
+                b = int(96 + (96 - 96) * (1 - intensity))
+                opacity = 0.15 + intensity * 0.85
+                color = f"rgba(15, 52, 96, {opacity:.2f})"
+            else:
+                opacity = 0.05 + intensity * 0.6
+                color = f"rgba(220, 53, 69, {opacity:.2f})"
+
+            text_color = "#fff" if intensity > 0.5 else "#1a1a2e"
+
+            svg.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{cell_size:.1f}" height="{cell_size:.1f}" fill="{color}" stroke="#dee2e6" stroke-width="1"/>')
+            svg.append(f'<text x="{x + cell_size / 2:.1f}" y="{y + cell_size / 2 + 5:.1f}" text-anchor="middle" font-size="12" font-weight="600" fill="{text_color}">{val}</text>')
+
+    # Row labels (actual)
+    for i, label in enumerate(labels):
+        y = mt + i * cell_size + cell_size / 2 + 4
+        svg.append(f'<text x="{ml - 6}" y="{y:.1f}" text-anchor="end" font-size="11" fill="#1a1a2e">{label}</text>')
+
+    # Column labels (predicted)
+    for j, label in enumerate(labels):
+        x = ml + j * cell_size + cell_size / 2
+        svg.append(f'<text x="{x:.1f}" y="{mt - 8}" text-anchor="middle" font-size="11" fill="#1a1a2e">{label}</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+# ------------------------------------------------------------------
+# Colored text for attention / token importance
+# ------------------------------------------------------------------
+
+EMOTION_COLORS = {
+    "sadness": "#4a6fa5",
+    "joy": "#f4a261",
+    "love": "#e76f51",
+    "anger": "#e63946",
+    "fear": "#6c567b",
+    "surprise": "#2a9d8f",
+}
+
+
+def make_attention_text(
+    tokens: list[str],
+    weights: list[float],
+    color: str = "#0f3460",
+    title: str = "",
+) -> str:
+    """Render tokens with background color intensity proportional to attention weight.
+
+    Args:
+        tokens: List of tokens (words/subwords).
+        weights: Attention weights per token (0-1 normalized).
+        color: Base color for highlighting (CSS color string).
+        title: Optional title above the text.
+    """
+    max_w = max(weights) if weights else 1
+    min_w = min(weights) if weights else 0
+    w_range = max_w - min_w or 1
+
+    spans = []
+    for token, w in zip(tokens, weights):
+        norm_w = (w - min_w) / w_range
+        opacity = 0.05 + norm_w * 0.85
+        text_color = "#fff" if norm_w > 0.6 else "#1a1a2e"
+        clean_token = token.replace("##", "").replace("Ġ", "").replace("▁", "")
+        safe_token = html_module.escape(clean_token)
+        if not safe_token.strip():
+            continue
+        spans.append(
+            f'<span style="background:rgba(15,52,96,{opacity:.2f});color:{text_color};'
+            f'padding:2px 4px;border-radius:3px;margin:1px;">{safe_token}</span>'
+        )
+
+    title_html = f"<p style='font-size:0.85em;color:#6c757d;margin:4px 0;'>{title}</p>" if title else ""
+    return f'{title_html}<div class="attention-text">{"".join(spans)}</div>'
+
+
+def make_token_importance_text(
+    tokens: list[str],
+    importance: list[float],
+    title: str = "",
+) -> str:
+    """Render tokens colored by gradient-based importance (green = positive, red = negative).
+
+    For classification, higher importance means the token had more influence on the prediction.
+    """
+    max_imp = max(abs(v) for v in importance) if importance else 1
+
+    spans = []
+    for token, imp in zip(tokens, importance):
+        norm = imp / max_imp if max_imp > 0 else 0
+        abs_norm = abs(norm)
+        opacity = 0.05 + abs_norm * 0.85
+
+        if norm >= 0:
+            bg = f"rgba(6, 214, 160, {opacity:.2f})"
+        else:
+            bg = f"rgba(230, 57, 70, {opacity:.2f})"
+
+        text_color = "#fff" if abs_norm > 0.6 else "#1a1a2e"
+        clean_token = token.replace("##", "").replace("Ġ", "").replace("▁", "")
+        safe_token = html_module.escape(clean_token)
+        if not safe_token.strip():
+            continue
+        spans.append(
+            f'<span style="background:{bg};color:{text_color};'
+            f'padding:2px 4px;border-radius:3px;margin:1px;">{safe_token}</span>'
+        )
+
+    title_html = f"<p style='font-size:0.85em;color:#6c757d;margin:4px 0;'>{title}</p>" if title else ""
+    return f'{title_html}<div class="attention-text">{"".join(spans)}</div>'
+
+
+# ------------------------------------------------------------------
+# Confidence bars (horizontal)
+# ------------------------------------------------------------------
+
+def make_confidence_bars(
+    labels: list[str],
+    probabilities: list[float],
+    predicted_idx: int = -1,
+    true_idx: int = -1,
+) -> str:
+    """Render horizontal confidence bars for each class."""
+    bars = []
+    for i, (label, prob) in enumerate(zip(labels, probabilities)):
+        pct = prob * 100
+        color = EMOTION_COLORS.get(label, "#0f3460")
+
+        label_suffix = ""
+        if i == predicted_idx and i == true_idx:
+            label_suffix = ' <span class="badge badge-success">correct</span>'
+        elif i == predicted_idx:
+            label_suffix = ' <span class="badge badge-danger">predicted</span>'
+        elif i == true_idx:
+            label_suffix = ' <span class="badge badge-info">true</span>'
+
+        bars.append(
+            f'<div class="confidence-bar">'
+            f'  <div class="bar-label">{label}{label_suffix}</div>'
+            f'  <div class="bar-track"><div class="bar-fill" style="width:{pct:.1f}%;background:{color};"></div></div>'
+            f'  <div class="bar-value">{pct:.1f}%</div>'
+            f'</div>'
+        )
+    return "\n".join(bars)
+
+
+# ------------------------------------------------------------------
+# Pipeline step indicator
+# ------------------------------------------------------------------
+
+def pipeline_step_indicator(current: int, steps: list[str]) -> str:
+    """Build a visual step indicator (checkmark/dot/circle)."""
+    html = '<div style="display:flex;gap:24px;margin:16px 0;">'
+    for i, label in enumerate(steps):
+        if i < current:
+            icon = '<span style="color:#155724;font-size:1.2em;">&#10003;</span>'
+            color = "#155724"
+        elif i == current:
+            icon = '<span style="color:#0f3460;font-size:1.2em;">&#9679;</span>'
+            color = "#0f3460"
+        else:
+            icon = '<span style="color:#adb5bd;font-size:1.2em;">&#9675;</span>'
+            color = "#adb5bd"
+        html += f'<div style="text-align:center;"><div>{icon}</div><div style="font-size:0.85em;color:{color};">{label}</div></div>'
+    html += '</div>'
+    return html

--- a/v2/tutorials/detr_object_detection/detr_object_detection.py
+++ b/v2/tutorials/detr_object_detection/detr_object_detection.py
@@ -1,0 +1,1469 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "torchvision>=0.24.0",
+#    "transformers>=4.49.0",
+#    "accelerate>=0.34.0",
+#    "huggingface_hub>=0.24.0",
+#    "datasets>=3.0.0",
+#    "pillow>=10.0.0",
+#    "albumentations>=1.4.0",
+#    "torchmetrics>=1.4.0",
+#    "pycocotools>=2.0.7",
+#    "numpy",
+# ]
+# main = "pipeline"
+# params = ""
+# ///
+import asyncio
+import base64
+import io
+import json
+import logging
+import os
+import random
+import shutil
+import tempfile
+
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+main_img = flyte.Image.from_uv_script(__file__, name="detr-object-detection", pre=True)
+
+gpu_env = flyte.TaskEnvironment(
+    name="detr-object-detection-gpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=1),
+)
+
+cpu_env = flyte.TaskEnvironment(
+    name="detr-object-detection-cpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="6Gi"),
+    depends_on=[gpu_env],
+)
+# {{/docs-fragment env}}
+
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+# ------------------------------------------------------------------
+# Report styling — shared CSS for all task reports
+# ------------------------------------------------------------------
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .highlight { color: #0f3460; font-weight: 700; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .img-pair { display: flex; gap: 12px; margin: 16px 0; flex-wrap: wrap; }
+  .report .img-pair > div { flex: 1; min-width: 300px; }
+  .report .img-pair img { width: 100%; border-radius: 6px; border: 1px solid #dee2e6; }
+  .report .img-pair .gt-label { color: #5a7db5; font-weight: 600; }
+  .report .img-pair .pred-label { color: #06d6a0; font-weight: 600; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d4edda; color: #155724; }
+  .report .badge-info { background: #d1ecf1; color: #0c5460; }
+  .report .chart-container { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 16px 0; }
+</style>
+"""
+
+
+def _wrap_report(html: str) -> str:
+    """Wrap HTML content with report styling."""
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+# ------------------------------------------------------------------
+# SVG chart helpers — lightweight charts without matplotlib
+# ------------------------------------------------------------------
+
+def _make_line_chart(
+    data: list[dict],
+    x_key: str,
+    y_keys: list[str],
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+    x_range_override: tuple[float, float] | None = None,
+    y_display_names: dict[str, str] | None = None,
+) -> str:
+    """Generate an SVG line chart from a list of dicts.
+
+    Args:
+        data: List of dicts, each with x_key and y_keys values.
+        x_key: Key for x-axis values.
+        y_keys: Keys for y-axis series to plot.
+        title: Chart title.
+        x_label: X-axis label.
+        y_label: Y-axis label.
+        colors: Colors for each series (defaults to a built-in palette).
+        width: SVG width in pixels.
+        height: SVG height in pixels.
+        y_max_cap: If set, cap the y-axis at this value (e.g. 1.0 for mAP).
+        x_range_override: If set, force the x-axis to this (min, max) range.
+
+    Returns:
+        SVG string.
+    """
+
+    default_colors = ["#5a7db5", "#0f3460", "#06d6a0", "#ffc107", "#6c757d"]
+    colors = colors or default_colors
+
+    # Chart area margins
+    ml, mr, mt, mb = 60, 20, 40, 50
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    x_vals = [d[x_key] for d in data] if data else []
+    if x_range_override:
+        x_min, x_max = x_range_override
+    elif x_vals:
+        x_min, x_max = min(x_vals), max(x_vals)
+    else:
+        x_min, x_max = 0, 1
+    x_range = x_max - x_min or 1
+
+    # Compute y range across all series
+    all_y = []
+    for key in y_keys:
+        all_y.extend(d[key] for d in data if key in d)
+    y_min = min(all_y) if all_y else 0
+    y_max = max(all_y) if all_y else 1
+    y_pad = (y_max - y_min) * 0.1 or 0.1
+    y_min_plot = max(0, y_min - y_pad)
+    y_max_plot = y_max + y_pad
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap)
+    y_range = y_max_plot - y_min_plot or 1
+
+    def sx(v):
+        return ml + (v - x_min) / x_range * cw
+
+    def sy(v):
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    # Build SVG
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        # Background
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Grid lines (5 horizontal)
+    for i in range(6):
+        y_tick = y_min_plot + y_range * i / 5
+        py = sy(y_tick)
+        lines.append(
+            f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" '
+            f'stroke="#e9ecef" stroke-width="1"/>'
+        )
+        lines.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6c757d">{y_tick:.3f}</text>'
+        )
+
+    # Axes
+    lines.append(
+        f'<line x1="{ml}" y1="{mt}" x2="{ml}" y2="{mt + ch}" '
+        f'stroke="#adb5bd" stroke-width="1.5"/>'
+    )
+    lines.append(
+        f'<line x1="{ml}" y1="{mt + ch}" x2="{ml + cw}" y2="{mt + ch}" '
+        f'stroke="#adb5bd" stroke-width="1.5"/>'
+    )
+
+    # X-axis ticks
+    if x_vals:
+        n_x_ticks = min(len(data), 10)
+        step = max(1, len(data) // n_x_ticks)
+        for i in range(0, len(data), step):
+            px = sx(x_vals[i])
+            lines.append(
+                f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" '
+                f'font-size="11" fill="#6c757d">{x_vals[i]:.0f}</text>'
+            )
+    else:
+        # Empty chart — generate evenly spaced ticks from x range
+        for i in range(6):
+            x_tick = x_min + x_range * i / 5
+            px = sx(x_tick)
+            lines.append(
+                f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" '
+                f'font-size="11" fill="#6c757d">{x_tick:.0f}</text>'
+            )
+
+    # Plot each series
+    if not data:
+        # Empty chart placeholder
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{mt + ch / 2}" text-anchor="middle" '
+            f'font-size="13" fill="#adb5bd" font-style="italic">Waiting for data...</text>'
+        )
+    for si, key in enumerate(y_keys):
+        color = colors[si % len(colors)]
+        points = [(sx(d[x_key]), sy(d[key])) for d in data if key in d]
+        if not points:
+            continue
+        # Draw line if we have 2+ points (dash odd series for visibility)
+        if len(points) >= 2:
+            path_d = f"M {points[0][0]:.1f},{points[0][1]:.1f}"
+            for px, py in points[1:]:
+                path_d += f" L {px:.1f},{py:.1f}"
+            dash = ' stroke-dasharray="6,3"' if si % 2 == 1 else ""
+            lines.append(
+                f'<path d="{path_d}" fill="none" stroke="{color}" '
+                f'stroke-width="2" stroke-linejoin="round"{dash}/>'
+            )
+        # Always show dots for sparse data (including single points)
+        if len(points) <= 30:
+            for px, py in points:
+                lines.append(
+                    f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{color}"/>'
+                )
+
+    # Title
+    if title:
+        lines.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    # Axis labels
+    if x_label:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{height - 6}" text-anchor="middle" '
+            f'font-size="12" fill="#6c757d">{x_label}</text>'
+        )
+    if y_label:
+        lines.append(
+            f'<text x="14" y="{mt + ch / 2}" text-anchor="middle" '
+            f'font-size="12" fill="#6c757d" '
+            f'transform="rotate(-90, 14, {mt + ch / 2})">{y_label}</text>'
+        )
+
+    # Legend
+    names = y_display_names or {}
+    if len(y_keys) > 1:
+        lx = ml + 10
+        for si, key in enumerate(y_keys):
+            color = colors[si % len(colors)]
+            ly = mt + 14 + si * 18
+            lines.append(
+                f'<rect x="{lx}" y="{ly - 6}" width="12" height="12" '
+                f'rx="2" fill="{color}"/>'
+            )
+            label = names.get(key, key)
+            lines.append(
+                f'<text x="{lx + 16}" y="{ly + 4}" font-size="11" '
+                f'fill="#1a1a2e">{label}</text>'
+            )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def _make_bar_chart(
+    labels: list[str],
+    series: dict[str, list[float]],
+    title: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+) -> str:
+    """Generate an SVG grouped bar chart.
+
+    Args:
+        labels: Category labels for x-axis.
+        series: Dict mapping series name to list of values (same length as labels).
+        title: Chart title.
+        colors: Colors for each series.
+        width: SVG width.
+        height: SVG height.
+        y_max_cap: If set, cap the y-axis at this value (e.g. 1.0 for mAP).
+
+    Returns:
+        SVG string.
+    """
+    if not labels:
+        return ""
+
+    default_colors = ["#adb5bd", "#0f3460", "#06d6a0", "#5a7db5"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 60
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    all_vals = [v for vals in series.values() for v in vals]
+    y_max = max(all_vals) if all_vals else 1
+    y_max_plot = y_max * 1.15 or 1
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap) or y_max_cap
+
+    n_groups = len(labels)
+    n_series = len(series)
+    group_width = cw / n_groups
+    bar_width = group_width * 0.7 / max(n_series, 1)
+    gap = group_width * 0.15
+
+    def sy(v):
+        return mt + ch - (v / y_max_plot) * ch
+
+    lines_svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Grid lines
+    for i in range(6):
+        y_tick = y_max_plot * i / 5
+        py = sy(y_tick)
+        lines_svg.append(
+            f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" '
+            f'stroke="#e9ecef" stroke-width="1"/>'
+        )
+        lines_svg.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6c757d">{y_tick:.3f}</text>'
+        )
+
+    # Bars
+    for gi, label in enumerate(labels):
+        gx = ml + gi * group_width + gap
+        for si, (name, vals) in enumerate(series.items()):
+            color = colors[si % len(colors)]
+            bx = gx + si * bar_width
+            val = vals[gi]
+            by = sy(val)
+            bh = mt + ch - by
+            lines_svg.append(
+                f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_width - 1:.1f}" '
+                f'height="{bh:.1f}" fill="{color}" rx="2"/>'
+            )
+            # Value label on top of bar
+            lines_svg.append(
+                f'<text x="{bx + bar_width / 2:.1f}" y="{by - 4:.1f}" '
+                f'text-anchor="middle" font-size="10" fill="#1a1a2e">'
+                f'{val:.3f}</text>'
+            )
+        # Group label
+        lines_svg.append(
+            f'<text x="{gx + n_series * bar_width / 2:.1f}" y="{mt + ch + 18}" '
+            f'text-anchor="middle" font-size="11" fill="#6c757d">{label}</text>'
+        )
+
+    # Title
+    if title:
+        lines_svg.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    # Legend
+    lx = ml + cw - len(series) * 100
+    for si, name in enumerate(series):
+        color = colors[si % len(colors)]
+        lines_svg.append(
+            f'<rect x="{lx + si * 100}" y="{mt + ch + 35}" width="12" '
+            f'height="12" rx="2" fill="{color}"/>'
+        )
+        lines_svg.append(
+            f'<text x="{lx + si * 100 + 16}" y="{mt + ch + 46}" font-size="11" '
+            f'fill="#1a1a2e">{name}</text>'
+        )
+
+    lines_svg.append("</svg>")
+    return "\n".join(lines_svg)
+
+
+# ------------------------------------------------------------------
+# Task 1: Prepare dataset — download COCO JSON + images, split train/val
+# ------------------------------------------------------------------
+
+@cpu_env.task(cache="auto")
+async def prepare_data(
+    dataset_repo: str = "sagecodes/union_flyte_swag_object_detection",
+    annotations_path: str = "swag/train.json",
+    images_subdir: str = "swag/images",
+    val_fraction: float = 0.2,
+    seed: int = 42,
+) -> flyte.io.Dir:
+    """Download a COCO-format dataset from HF and split into train/val."""
+    from huggingface_hub import snapshot_download
+
+    log.info(f"Downloading dataset: {dataset_repo}")
+    local_repo = snapshot_download(
+        repo_id=dataset_repo,
+        repo_type="dataset",
+    )
+
+    ann_file = os.path.join(local_repo, annotations_path)
+    img_root = os.path.join(local_repo, images_subdir)
+
+    with open(ann_file) as f:
+        coco = json.load(f)
+
+    images = coco["images"]
+    annotations = coco["annotations"]
+    categories = coco["categories"]
+
+    log.info(
+        f"Loaded {len(images)} images, {len(annotations)} annotations, "
+        f"{len(categories)} categories"
+    )
+    log.info(f"Raw category ids: {sorted({c['id'] for c in categories})}")
+    log.info(
+        f"Raw annotation category_ids (unique): "
+        f"{sorted({a['category_id'] for a in annotations})}"
+    )
+
+    # Remap category ids to contiguous 0..N-1 — required because HF object
+    # detection models size their classifier head to len(id2label) and treat
+    # class labels as direct indices into that head. Any gap or 1-indexed id
+    # causes an IndexKernel OOB inside the focal-loss scatter.
+    #
+    # Build the remap from the UNION of ids declared in `categories` and ids
+    # actually used in `annotations` — some datasets have orphaned annotations
+    # referencing categories that aren't declared (this one does).
+    declared_ids = {c["id"] for c in categories}
+    used_ids = {a["category_id"] for a in annotations}
+    orphans = used_ids - declared_ids
+    if orphans:
+        log.warning(
+            f"Annotations reference undeclared category ids {sorted(orphans)} — "
+            f"adding stub categories."
+        )
+
+    all_cat_ids = sorted(declared_ids | used_ids)
+    id_remap = {old: new for new, old in enumerate(all_cat_ids)}
+    existing_names = {c["id"]: c["name"] for c in categories}
+    categories = [
+        {"id": id_remap[old], "name": existing_names.get(old, f"category_{old}")}
+        for old in all_cat_ids
+    ]
+    annotations = [
+        {**a, "category_id": id_remap[a["category_id"]]} for a in annotations
+    ]
+    log.info(f"Remapped category ids: {id_remap}")
+    log.info(f"Final categories: {categories}")
+
+    # Split by image id
+    rng = random.Random(seed)
+    img_ids = [im["id"] for im in images]
+    rng.shuffle(img_ids)
+    n_val = max(1, int(len(img_ids) * val_fraction))
+    val_ids = set(img_ids[:n_val])
+    train_ids = set(img_ids[n_val:])
+
+    def filter_coco(keep_ids: set) -> dict:
+        return {
+            "info": coco.get("info", {}),
+            "categories": categories,
+            "images": [im for im in images if im["id"] in keep_ids],
+            "annotations": [a for a in annotations if a["image_id"] in keep_ids],
+        }
+
+    train_coco = filter_coco(train_ids)
+    val_coco = filter_coco(val_ids)
+
+    log.info(
+        f"Split: {len(train_coco['images'])} train / {len(val_coco['images'])} val images"
+    )
+
+    # Pack output dir: images/ + train.json + val.json
+    out_dir = tempfile.mkdtemp(prefix="coco_split_")
+    out_img = os.path.join(out_dir, "images")
+    shutil.copytree(img_root, out_img)
+
+    with open(os.path.join(out_dir, "train.json"), "w") as f:
+        json.dump(train_coco, f)
+    with open(os.path.join(out_dir, "val.json"), "w") as f:
+        json.dump(val_coco, f)
+
+    return await flyte.io.Dir.from_local(out_dir)
+
+
+# ------------------------------------------------------------------
+# Helpers — torch Dataset wrapping COCO JSON
+# ------------------------------------------------------------------
+
+def _build_torch_dataset(coco_path: str, images_root: str, augment: bool):
+    """Build a torch Dataset that yields {image, target} for the HF image processor."""
+    import albumentations as A
+    import numpy as np
+    from PIL import Image
+    from torch.utils.data import Dataset
+
+    with open(coco_path) as f:
+        coco = json.load(f)
+
+    images_by_id = {im["id"]: im for im in coco["images"]}
+    anns_by_image: dict[int, list] = {}
+    for a in coco["annotations"]:
+        anns_by_image.setdefault(a["image_id"], []).append(a)
+
+    image_ids = list(images_by_id.keys())
+
+    # NOTE: we deliberately don't resize here — the HF image processor handles
+    # resize+pad. Augmentation only.
+    if augment:
+        transform = A.Compose(
+            [
+                A.HorizontalFlip(p=0.5),
+                A.VerticalFlip(p=0.1),
+                A.RandomBrightnessContrast(brightness_limit=0.3, contrast_limit=0.3, p=0.5),
+                A.HueSaturationValue(hue_shift_limit=10, sat_shift_limit=30, val_shift_limit=20, p=0.4),
+                A.Rotate(limit=15, border_mode=0, p=0.4),
+                A.RandomScale(scale_limit=0.2, p=0.4),
+                A.GaussianBlur(blur_limit=(3, 5), p=0.2),
+                A.GaussNoise(p=0.2),
+            ],
+            bbox_params=A.BboxParams(
+                format="coco",
+                label_fields=["category"],
+                min_area=4,
+                min_visibility=0.1,
+                clip=True,
+            ),
+        )
+    else:
+        transform = A.Compose(
+            [A.NoOp()],
+            bbox_params=A.BboxParams(format="coco", label_fields=["category"], clip=True),
+        )
+
+    class CocoDataset(Dataset):
+        def __len__(self) -> int:
+            return len(image_ids)
+
+        def __getitem__(self, idx: int):
+            img_id = image_ids[idx]
+            meta = images_by_id[img_id]
+            img_path = os.path.join(images_root, os.path.basename(meta["file_name"]))
+            if not os.path.exists(img_path):
+                img_path = os.path.join(images_root, meta["file_name"])
+            image = np.array(Image.open(img_path).convert("RGB"))
+
+            anns = anns_by_image.get(img_id, [])
+            bboxes = [a["bbox"] for a in anns]
+            categories = [a["category_id"] for a in anns]
+
+            out = transform(image=image, bboxes=bboxes, category=categories)
+            image_t = out["image"]
+            bboxes_t = out["bboxes"]
+            categories_t = out["category"]
+
+            target_anns = []
+            for bb, cat in zip(bboxes_t, categories_t):
+                x, y, w, h = bb
+                target_anns.append(
+                    {
+                        "image_id": img_id,
+                        "category_id": int(cat),
+                        "bbox": [float(x), float(y), float(w), float(h)],
+                        "area": float(w * h),
+                        "iscrowd": 0,
+                    }
+                )
+
+            return {
+                "image": image_t,
+                "target": {"image_id": img_id, "annotations": target_anns},
+            }
+
+    return CocoDataset(), coco["categories"]
+
+
+# ------------------------------------------------------------------
+# Task 2: Train
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def train(
+    model_name: str,
+    data_dir: flyte.io.Dir,
+    epochs: int = 30,
+    lr: float = 5e-5,
+    batch_size: int = 4,
+    weight_decay: float = 1e-4,
+    eval_every_n_epochs: int | None = None,
+) -> flyte.io.Dir:
+    """Fine-tune RT-DETR (or any HuggingFace object-detection model) on COCO data."""
+    import torch
+    from transformers import (
+        AutoImageProcessor,
+        AutoModelForObjectDetection,
+        Trainer,
+        TrainerCallback,
+        TrainingArguments,
+    )
+
+    log.info(f"Training: model={model_name}")
+    await flyte.report.replace.aio(_wrap_report(
+        f"<h2>Loading model...</h2><p>{model_name}</p>"
+        f"<p>Preparing dataset and initializing weights...</p>"
+    ), do_flush=True)
+
+    # -- Load data --
+    data_path = await data_dir.download()
+    images_root = os.path.join(data_path, "images")
+    train_json = os.path.join(data_path, "train.json")
+
+    with open(train_json) as f:
+        categories = json.load(f)["categories"]
+    id2label = {c["id"]: c["name"] for c in categories}
+    label2id = {v: k for k, v in id2label.items()}
+
+    train_ds, _ = _build_torch_dataset(train_json, images_root, augment=True)
+    log.info(f"Train examples: {len(train_ds)} | Categories: {id2label}")
+
+    # -- Optionally load val set for periodic mAP evaluation --
+    val_json = os.path.join(data_path, "val.json")
+    val_images = None
+    val_targets = None
+    if eval_every_n_epochs and os.path.exists(val_json):
+        import torch as _torch
+        from PIL import Image
+
+        with open(val_json) as f:
+            val_coco = json.load(f)
+        images_by_id = {im["id"]: im for im in val_coco["images"]}
+        anns_by_image: dict[int, list] = {}
+        for a in val_coco["annotations"]:
+            anns_by_image.setdefault(a["image_id"], []).append(a)
+        val_images = []
+        val_targets = []
+        for img_id, meta in images_by_id.items():
+            path = os.path.join(images_root, os.path.basename(meta["file_name"]))
+            if not os.path.exists(path):
+                path = os.path.join(images_root, meta["file_name"])
+            val_images.append(Image.open(path).convert("RGB"))
+            boxes_xyxy = []
+            labels = []
+            for a in anns_by_image.get(img_id, []):
+                x, y, w, h = a["bbox"]
+                boxes_xyxy.append([x, y, x + w, y + h])
+                labels.append(a["category_id"])
+            val_targets.append({
+                "boxes": _torch.tensor(boxes_xyxy, dtype=_torch.float32).reshape(-1, 4),
+                "labels": _torch.tensor(labels, dtype=_torch.long),
+            })
+        log.info(f"Val examples for periodic eval: {len(val_images)}")
+
+    # -- Processor + model --
+    processor = AutoImageProcessor.from_pretrained(model_name)
+    model = AutoModelForObjectDetection.from_pretrained(
+        model_name,
+        num_labels=len(id2label),
+        id2label=id2label,
+        label2id=label2id,
+        ignore_mismatched_sizes=True,
+    )
+
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    log.info(
+        f"Parameters: {trainable_params:,} / {total_params:,} "
+        f"({trainable_params / total_params * 100:.1f}%)"
+    )
+
+    # -- Collator — runs the image processor on each batch --
+    def collate_fn(batch):
+        images = [b["image"] for b in batch]
+        targets = [b["target"] for b in batch]
+        enc = processor(images=images, annotations=targets, return_tensors="pt")
+        return {"pixel_values": enc["pixel_values"], "labels": enc["labels"]}
+
+    # -- Sanity check: peek at one batch and verify class_labels fit --
+    sample = collate_fn([train_ds[i] for i in range(min(2, len(train_ds)))])
+    all_labels = []
+    for lbl in sample["labels"]:
+        all_labels.extend(lbl["class_labels"].tolist())
+    log.info(
+        f"Sanity check — class_labels in first batch: {sorted(set(all_labels))} | "
+        f"model num_labels: {model.config.num_labels} | "
+        f"id2label: {model.config.id2label}"
+    )
+    if all_labels and max(all_labels) >= model.config.num_labels:
+        raise ValueError(
+            f"class_label {max(all_labels)} out of range for num_labels="
+            f"{model.config.num_labels}. Check category id remapping in prepare_data."
+        )
+
+    # -- Collect training metrics and update the report chart live.
+    # trainer.train() runs in a background thread (via asyncio.to_thread),
+    # so the asyncio event loop stays free. We use run_coroutine_threadsafe
+    # to push report updates from the callback thread onto that loop.
+    training_log: list[dict] = []
+    eval_log: list[dict] = []  # periodic mAP checkpoints (epoch, map, map_50)
+    loop = asyncio.get_running_loop()
+
+    cat_badges = " ".join(
+        f'<span class="badge badge-info">{name}</span>'
+        for name in id2label.values()
+    )
+
+    def _build_training_report(max_steps: int) -> str:
+        """Build the live training report HTML from current training_log."""
+        stats_html = f"""
+        <h2>Training in Progress...</h2>
+        <h3>{model_name}</h3>
+        <div class="stat-grid">
+          <div class="stat"><div class="value">{len(train_ds)}</div><div class="label">Train Examples</div></div>
+          <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>
+          <div class="stat"><div class="value">{lr}</div><div class="label">Learning Rate</div></div>
+          <div class="stat"><div class="value">{batch_size}</div><div class="label">Batch Size</div></div>
+          <div class="stat"><div class="value">{total_params:,}</div><div class="label">Total Params</div></div>
+          <div class="stat"><div class="value">{trainable_params / total_params * 100:.1f}%</div><div class="label">Trainable</div></div>
+        </div>
+        <p>Categories: {cat_badges}</p>
+        """
+
+        charts_html = ""
+        if training_log:
+            current = training_log[-1]
+            progress_pct = current["step"] / max_steps * 100 if max_steps else 0
+            charts_html += f"""
+            <div class="card">
+              <b>Step {current['step']}/{max_steps}</b>
+              ({progress_pct:.0f}%) |
+              Epoch {current['epoch']:.2f}/{epochs} |
+              Loss: <span class="highlight">{current['loss']:.4f}</span>
+              <div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">
+                <div style="background:#0f3460;width:{progress_pct:.1f}%;height:100%;border-radius:4px;"></div>
+              </div>
+            </div>
+            """
+
+            loss_chart = _make_line_chart(
+                data=training_log,
+                x_key="epoch",
+                y_keys=["loss"],
+                title="Training Loss",
+                x_label="Epoch",
+                y_label="Loss",
+                colors=["#5a7db5"],
+            )
+            charts_html += f'<div class="chart-container">{loss_chart}</div>'
+
+            if eval_every_n_epochs:
+                # Match x-axis to the loss chart: start at 0, end at current epoch
+                current_max_epoch = current["epoch"]
+                map_chart = _make_line_chart(
+                    data=eval_log,
+                    x_key="epoch",
+                    y_keys=["map", "map_50"],
+                    title="Validation mAP (periodic)",
+                    x_label="Epoch",
+                    y_label="mAP",
+                    colors=["#0f3460", "#06d6a0"],
+                    y_max_cap=1.0,
+                    y_display_names={"map": "mAP (0.50:0.95)", "map_50": "mAP@50"},
+                    x_range_override=(0, current_max_epoch),
+                )
+                charts_html += f'<div class="chart-container">{map_chart}</div>'
+
+            if "lr" in training_log[0]:
+                lr_chart = _make_line_chart(
+                    data=training_log,
+                    x_key="epoch",
+                    y_keys=["lr"],
+                    title="Learning Rate Schedule",
+                    x_label="Epoch",
+                    y_label="LR",
+                    colors=["#0f3460"],
+                )
+                charts_html += f'<div class="chart-container">{lr_chart}</div>'
+
+        return _wrap_report(stats_html + charts_html)
+
+    class MetricsCallback(TrainerCallback):
+        def __init__(self):
+            self._last_eval_epoch = 0
+
+        def on_log(self, args, state, control, logs=None, **kwargs):
+            if not logs or "loss" not in logs:
+                return
+            entry = {
+                "step": state.global_step,
+                "epoch": round(logs.get("epoch", 0), 2),
+                "loss": round(logs["loss"], 4),
+            }
+            if "learning_rate" in logs:
+                entry["lr"] = logs["learning_rate"]
+            if "grad_norm" in logs:
+                entry["grad_norm"] = round(float(logs["grad_norm"]), 4)
+            training_log.append(entry)
+            log.info(
+                f"step={state.global_step}/{state.max_steps} "
+                f"epoch={entry['epoch']:.2f} "
+                f"loss={entry['loss']:.4f}"
+            )
+
+            # Push a live report update onto the asyncio event loop.
+            # do_flush=True dispatches the update to the UI immediately.
+            asyncio.run_coroutine_threadsafe(
+                flyte.report.replace.aio(
+                    _build_training_report(state.max_steps),
+                    do_flush=True,
+                ),
+                loop,
+            )
+
+        def on_epoch_end(self, args, state, control, model=None, **kwargs):
+            if not eval_every_n_epochs or val_images is None:
+                return
+            current_epoch = round(state.epoch)
+            if current_epoch % eval_every_n_epochs != 0:
+                return
+            if current_epoch == self._last_eval_epoch:
+                return
+            self._last_eval_epoch = current_epoch
+
+            log.info(f"Running periodic mAP eval at epoch {current_epoch}...")
+            from torchmetrics.detection.mean_ap import MeanAveragePrecision
+
+            device = next(model.parameters()).device
+            # _run_inference sets model.eval(); restore train mode after.
+            preds = _run_inference(model, processor, val_images, device, threshold=0.3)
+            model.train()
+
+            formatted = [
+                {"boxes": p["boxes"], "scores": p["scores"], "labels": p["labels"]}
+                for p in preds
+            ]
+            metric = MeanAveragePrecision(box_format="xyxy", iou_type="bbox")
+            metric.update(formatted, val_targets)
+            result = metric.compute()
+            map_val = round(result["map"].item(), 4)
+            map_50 = round(result["map_50"].item(), 4)
+
+            eval_log.append({
+                "epoch": current_epoch,
+                "map": map_val,
+                "map_50": map_50,
+            })
+            log.info(f"Epoch {current_epoch} — mAP: {map_val:.4f}, mAP@50: {map_50:.4f}")
+
+            asyncio.run_coroutine_threadsafe(
+                flyte.report.replace.aio(
+                    _build_training_report(state.max_steps),
+                    do_flush=True,
+                ),
+                loop,
+            )
+
+    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    output_dir = os.path.join(tempfile.mkdtemp(), "checkpoints")
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
+        learning_rate=lr,
+        weight_decay=weight_decay,
+        logging_steps=5,
+        save_strategy="no",
+        bf16=use_bf16,
+        fp16=not use_bf16 and torch.cuda.is_available(),
+        warmup_ratio=0.1,
+        remove_unused_columns=False,
+        dataloader_num_workers=2,
+        report_to="none",
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        data_collator=collate_fn,
+        callbacks=[MetricsCallback()],
+    )
+
+    log.info("Starting training...")
+    # Run the sync HF training loop in a thread so the asyncio event loop
+    # stays free for Flyte's syncify bridge.
+    await asyncio.to_thread(trainer.train)
+    log.info("Training complete.")
+
+    save_dir = os.path.join(tempfile.mkdtemp(), "finetuned_model")
+    trainer.save_model(save_dir)
+    processor.save_pretrained(save_dir)
+    log.info(f"Model saved to {save_dir}")
+
+    # -- Build final training report --
+    stats_html = f"""
+    <h2>Training Complete</h2>
+    <h3>{model_name}</h3>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{len(train_ds)}</div><div class="label">Train Examples</div></div>
+      <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>
+      <div class="stat"><div class="value">{lr}</div><div class="label">Learning Rate</div></div>
+      <div class="stat"><div class="value">{batch_size}</div><div class="label">Batch Size</div></div>
+      <div class="stat"><div class="value">{total_params:,}</div><div class="label">Total Params</div></div>
+      <div class="stat"><div class="value">{trainable_params / total_params * 100:.1f}%</div><div class="label">Trainable</div></div>
+    </div>
+    <p>Categories: {cat_badges}</p>
+    """
+
+    charts_html = ""
+    if training_log:
+        final_loss = training_log[-1]["loss"]
+        min_loss = min(d["loss"] for d in training_log)
+        initial_loss = training_log[0]["loss"]
+        total_steps = training_log[-1]["step"]
+
+        charts_html += f"""
+        <div class="card">
+          <b>Training Summary:</b>
+          Initial loss: {initial_loss:.4f} |
+          Final loss: <span class="highlight">{final_loss:.4f}</span> |
+          Min loss: {min_loss:.4f} |
+          Total steps: {total_steps}
+        </div>
+        """
+
+        epoch_range = (0, epochs)
+
+        loss_chart = _make_line_chart(
+            data=training_log,
+            x_key="epoch",
+            y_keys=["loss"],
+            title="Training Loss",
+            x_label="Epoch",
+            y_label="Loss",
+            colors=["#5a7db5"],
+            x_range_override=epoch_range,
+        )
+        charts_html += f'<div class="chart-container">{loss_chart}</div>'
+
+    if eval_log:
+        map_chart = _make_line_chart(
+            data=eval_log,
+            x_key="epoch",
+            y_keys=["map", "map_50"],
+            title="Validation mAP (periodic)",
+            x_label="Epoch",
+            y_label="mAP",
+            colors=["#0f3460", "#06d6a0"],
+            y_max_cap=1.0,
+            x_range_override=(0, epochs),
+            y_display_names={"map": "mAP (0.50:0.95)", "map_50": "mAP@50"},
+        )
+        charts_html += f'<div class="chart-container">{map_chart}</div>'
+
+    if training_log and "lr" in training_log[0]:
+        lr_chart = _make_line_chart(
+            data=training_log,
+            x_key="epoch",
+            y_keys=["lr"],
+            title="Learning Rate Schedule",
+            x_label="Epoch",
+            y_label="LR",
+            colors=["#0f3460"],
+            x_range_override=(0, epochs),
+        )
+        charts_html += f'<div class="chart-container">{lr_chart}</div>'
+
+    await flyte.report.replace.aio(_wrap_report(stats_html + charts_html), do_flush=True)
+
+    return await flyte.io.Dir.from_local(save_dir)
+
+
+# ------------------------------------------------------------------
+# Inference helpers
+# ------------------------------------------------------------------
+
+def _run_inference(model, processor, images, device, threshold: float = 0.3):
+    """Run object detection on a list of PIL images. Returns list of dicts."""
+    import torch
+
+    results = []
+    model.eval()
+    for img in images:
+        inputs = processor(images=img, return_tensors="pt").to(device)
+        with torch.no_grad():
+            outputs = model(**inputs)
+        target_size = torch.tensor([img.size[::-1]], device=device)  # (h, w)
+        post = processor.post_process_object_detection(
+            outputs, target_sizes=target_size, threshold=threshold
+        )[0]
+        results.append(
+            {
+                "scores": post["scores"].cpu(),
+                "labels": post["labels"].cpu(),
+                "boxes": post["boxes"].cpu(),  # xyxy in original image coords
+            }
+        )
+    return results
+
+
+def _draw_boxes(image, boxes, labels, scores, id2label, color: str = "lime"):
+    """Draw bounding boxes on a PIL image. Returns a new PIL image."""
+    from PIL import ImageDraw, ImageFont
+
+    img = image.copy()
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.truetype("DejaVuSans-Bold.ttf", size=max(14, img.width // 60))
+    except Exception:
+        font = ImageFont.load_default()
+
+    for box, label, score in zip(boxes.tolist(), labels.tolist(), scores.tolist()):
+        x0, y0, x1, y1 = box
+        width = max(2, img.width // 400)
+        draw.rectangle([x0, y0, x1, y1], outline=color, width=width)
+        name = id2label.get(int(label), str(int(label)))
+        caption = f"{name} {score:.2f}"
+        text_bg = draw.textbbox((x0, y0), caption, font=font)
+        draw.rectangle(text_bg, fill=color)
+        draw.text((x0, y0), caption, fill="black", font=font)
+    return img
+
+
+def _img_to_data_uri(img, max_dim: int = 800) -> str:
+    """PIL image → base64 data URI, downscaled for the report."""
+    w, h = img.size
+    if max(w, h) > max_dim:
+        scale = max_dim / max(w, h)
+        img = img.resize((int(w * scale), int(h * scale)))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=85)
+    return "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+# ------------------------------------------------------------------
+# Task 3: Evaluate — COCO mAP on fine-tuned model
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def evaluate(
+    finetuned_dir: flyte.io.Dir,
+    data_dir: flyte.io.Dir,
+    threshold: float = 0.5,
+) -> str:
+    """Compute COCO mAP for the fine-tuned model on the val split."""
+    import torch
+    from PIL import Image
+    from torchmetrics.detection.mean_ap import MeanAveragePrecision
+    from transformers import AutoImageProcessor, AutoModelForObjectDetection
+
+    log.info("Starting evaluation...")
+    await flyte.report.replace.aio(_wrap_report(
+        "<h2>Evaluation</h2><p>Loading val split and scoring model...</p>"
+    ), do_flush=True)
+
+    data_path = await data_dir.download()
+    images_root = os.path.join(data_path, "images")
+    val_json = os.path.join(data_path, "val.json")
+
+    with open(val_json) as f:
+        val_coco = json.load(f)
+
+    images_by_id = {im["id"]: im for im in val_coco["images"]}
+    anns_by_image: dict[int, list] = {}
+    for a in val_coco["annotations"]:
+        anns_by_image.setdefault(a["image_id"], []).append(a)
+
+    pil_images = []
+    targets = []
+    for img_id, meta in images_by_id.items():
+        path = os.path.join(images_root, os.path.basename(meta["file_name"]))
+        if not os.path.exists(path):
+            path = os.path.join(images_root, meta["file_name"])
+        pil_images.append(Image.open(path).convert("RGB"))
+        boxes_xyxy = []
+        labels = []
+        for a in anns_by_image.get(img_id, []):
+            x, y, w, h = a["bbox"]
+            boxes_xyxy.append([x, y, x + w, y + h])
+            labels.append(a["category_id"])
+        targets.append(
+            {
+                "boxes": torch.tensor(boxes_xyxy, dtype=torch.float32).reshape(-1, 4),
+                "labels": torch.tensor(labels, dtype=torch.long),
+            }
+        )
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    ft_path = await finetuned_dir.download()
+    log.info(f"Scoring fine-tuned model: {ft_path}")
+    processor = AutoImageProcessor.from_pretrained(ft_path)
+    model = AutoModelForObjectDetection.from_pretrained(ft_path).to(device)
+    preds = _run_inference(model, processor, pil_images, device, threshold=threshold)
+
+    formatted_preds = [
+        {"boxes": p["boxes"], "scores": p["scores"], "labels": p["labels"]}
+        for p in preds
+    ]
+
+    metric = MeanAveragePrecision(box_format="xyxy", iou_type="bbox")
+    metric.update(formatted_preds, targets)
+
+    def to_python(v):
+        if hasattr(v, "numel"):
+            return v.item() if v.numel() == 1 else v.tolist()
+        return v
+
+    ft_metrics = {k: to_python(v) for k, v in metric.compute().items()}
+    del model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    log.info(f"Fine-tuned mAP: {ft_metrics.get('map', 0):.3f}")
+
+    metric_keys = ["map", "map_50", "map_75", "mar_10"]
+    metric_display = {
+        "map": "mAP",
+        "map_50": "mAP@50",
+        "map_75": "mAP@75",
+        "mar_10": "mAR@10",
+    }
+
+    rows = []
+    for key in metric_keys:
+        ft_val = ft_metrics.get(key, 0)
+        rows.append(
+            f"<tr><td><b>{metric_display.get(key, key)}</b></td>"
+            f"<td class='highlight'>{ft_val:.3f}</td></tr>"
+        )
+    table = (
+        "<table><tr><th>Metric</th><th>Score</th></tr>"
+        + "".join(rows)
+        + "</table>"
+    )
+
+    bar_chart = _make_bar_chart(
+        labels=[metric_display.get(k, k) for k in metric_keys],
+        series={"Fine-tuned": [ft_metrics.get(k, 0) for k in metric_keys]},
+        title="COCO Evaluation Metrics",
+        colors=["#0f3460"],
+        y_max_cap=1.0,
+    )
+
+    ft_map = ft_metrics.get("map", 0)
+    ft_map50 = ft_metrics.get("map_50", 0)
+
+    eval_html = f"""
+    <h2>Evaluation — COCO mAP</h2>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{len(pil_images)}</div><div class="label">Val Images</div></div>
+      <div class="stat"><div class="value">{threshold}</div><div class="label">Threshold</div></div>
+      <div class="stat"><div class="value highlight">{ft_map:.3f}</div><div class="label">mAP</div></div>
+      <div class="stat"><div class="value highlight">{ft_map50:.3f}</div><div class="label">mAP@50</div></div>
+    </div>
+    <div class="chart-container">{bar_chart}</div>
+    {table}
+    <div class="note">
+      <b>mAP</b> (mean Average Precision) measures how accurately the model
+      detects objects — balancing whether predictions are correct (precision)
+      and whether all objects are found (recall). The @50 and @75 variants
+      require IoU overlaps of 50% and 75% between predicted and ground-truth
+      boxes. <b>mAR</b> (mean Average Recall) measures how many ground-truth
+      objects the model finds, with @1 and @10 limiting detections to 1 or 10
+      per image.
+    </div>
+    """
+
+    await flyte.report.replace.aio(_wrap_report(eval_html), do_flush=True)
+
+    return json.dumps(
+        {
+            "finetuned": {k: round(v, 4) for k, v in ft_metrics.items() if isinstance(v, (int, float))},
+            "num_val_images": len(pil_images),
+        }
+    )
+
+
+# ------------------------------------------------------------------
+# Task 4: Inference demo — render bboxes on val images
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def inference_demo(
+    finetuned_dir: flyte.io.Dir,
+    data_dir: flyte.io.Dir,
+    threshold: float = 0.5,
+    max_images: int = 8,
+    metrics_json: str = "{}",
+) -> str:
+    """Run the fine-tuned model on val images, render bboxes, embed in the report."""
+    import torch
+    from PIL import Image
+    from torchmetrics.detection.mean_ap import MeanAveragePrecision
+    from transformers import AutoImageProcessor, AutoModelForObjectDetection
+
+    data_path = await data_dir.download()
+    images_root = os.path.join(data_path, "images")
+    val_json = os.path.join(data_path, "val.json")
+
+    with open(val_json) as f:
+        val_coco = json.load(f)
+
+    id2label = {c["id"]: c["name"] for c in val_coco["categories"]}
+    metas = val_coco["images"][:max_images]
+    anns_by_image: dict[int, list] = {}
+    for a in val_coco["annotations"]:
+        anns_by_image.setdefault(a["image_id"], []).append(a)
+
+    pil_images = []
+    gt_per_image = []
+    for meta in metas:
+        path = os.path.join(images_root, os.path.basename(meta["file_name"]))
+        if not os.path.exists(path):
+            path = os.path.join(images_root, meta["file_name"])
+        pil_images.append(Image.open(path).convert("RGB"))
+
+        boxes_xyxy = []
+        labels = []
+        for a in anns_by_image.get(meta["id"], []):
+            x, y, w, h = a["bbox"]
+            boxes_xyxy.append([x, y, x + w, y + h])
+            labels.append(a["category_id"])
+        gt_per_image.append(
+            {
+                "boxes": torch.tensor(boxes_xyxy, dtype=torch.float32).reshape(-1, 4),
+                "labels": torch.tensor(labels, dtype=torch.long),
+                "scores": torch.ones(len(labels)),
+            }
+        )
+
+    ft_path = await finetuned_dir.download()
+    processor = AutoImageProcessor.from_pretrained(ft_path)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = AutoModelForObjectDetection.from_pretrained(ft_path).to(device)
+
+    preds = _run_inference(model, processor, pil_images, device, threshold=threshold)
+
+    html_blocks = []
+    total_gt = 0
+    total_pred = 0
+    for i, (img, pred, gt) in enumerate(zip(pil_images, preds, gt_per_image)):
+        n_gt = len(gt["labels"])
+        n_pred = len(pred["labels"])
+        total_gt += n_gt
+        total_pred += n_pred
+
+        # Per-image mAP
+        metric = MeanAveragePrecision(box_format="xyxy", iou_type="bbox")
+        metric.update(
+            [{"boxes": pred["boxes"], "scores": pred["scores"], "labels": pred["labels"]}],
+            [{"boxes": gt["boxes"], "labels": gt["labels"]}],
+        )
+        img_metrics = metric.compute()
+        img_map = img_metrics["map"].item()
+        img_map_badge = (
+            f'<span class="badge badge-success">mAP {img_map:.2f}</span>'
+            if img_map >= 0.5
+            else f'<span class="badge badge-info">mAP {img_map:.2f}</span>'
+        )
+
+        pred_img = _draw_boxes(
+            img, pred["boxes"], pred["labels"], pred["scores"],
+            id2label, color="lime",
+        )
+        gt_img = _draw_boxes(
+            img, gt["boxes"], gt["labels"], gt["scores"],
+            id2label, color="dodgerblue",
+        )
+        html_blocks.append(f"""
+        <div class="card">
+          <b>Image {i + 1}</b> {img_map_badge}
+          <div class="img-pair">
+            <div>
+              <p><span class="gt-label">Ground Truth</span>
+                 <span class="badge badge-info">{n_gt} boxes</span></p>
+              <img src="{_img_to_data_uri(gt_img)}" />
+            </div>
+            <div>
+              <p><span class="pred-label">Predictions</span>
+                 <span class="badge badge-success">{n_pred} boxes</span>
+                 (threshold={threshold})</p>
+              <img src="{_img_to_data_uri(pred_img)}" />
+            </div>
+          </div>
+        </div>""")
+
+    # Parse metrics if provided (from evaluate task)
+    metrics = json.loads(metrics_json)
+    ft_metrics = metrics.get("finetuned", {})
+    ft_map = ft_metrics.get("map", None)
+    ft_map50 = ft_metrics.get("map_50", None)
+
+    metrics_stats = ""
+    if ft_map is not None:
+        metrics_stats = f"""
+        <div class="stat"><div class="value highlight">{ft_map:.3f}</div><div class="label">mAP</div></div>
+        <div class="stat"><div class="value highlight">{ft_map50:.3f}</div><div class="label">mAP@50</div></div>
+        """
+
+    demo_html = f"""
+    <h2>Inference Demo</h2>
+    <h3>Fine-tuned RT-DETR on validation images</h3>
+    <div class="stat-grid">
+      {metrics_stats}
+      <div class="stat"><div class="value">{len(pil_images)}</div><div class="label">Images Shown</div></div>
+      <div class="stat"><div class="value">{total_gt}</div><div class="label">Ground Truth Boxes</div></div>
+      <div class="stat"><div class="value">{total_pred}</div><div class="label">Predicted Boxes</div></div>
+      <div class="stat"><div class="value">{threshold}</div><div class="label">Confidence Threshold</div></div>
+    </div>
+    <p><span class="gt-label">Blue = ground truth</span> |
+       <span class="pred-label">Green = predictions</span></p>
+    {"".join(html_blocks)}
+    """
+
+    await flyte.report.replace.aio(_wrap_report(demo_html), do_flush=True)
+
+    return json.dumps(
+        {
+            "num_images": len(pil_images),
+            "predictions_per_image": [len(p["labels"]) for p in preds],
+        }
+    )
+
+
+# ------------------------------------------------------------------
+# Pipeline
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@cpu_env.task(report=True)
+async def pipeline(
+    model_name: str = "PekingU/rtdetr_v2_r18vd",
+    dataset_repo: str = "sagecodes/union_flyte_swag_object_detection",
+    annotations_path: str = "swag/train.json",
+    images_subdir: str = "swag/images",
+    epochs: int = 30,
+    lr: float = 5e-5,
+    batch_size: int = 4,
+    val_fraction: float = 0.2,
+    threshold: float = 0.5,
+    demo_images: int = 8,
+    eval_every_n_epochs: int | None = None,
+) -> tuple[flyte.io.Dir, str]:
+    """
+    End-to-end RT-DETRv2 fine-tuning pipeline.
+
+    Returns the fine-tuned model directory and a JSON summary.
+
+    1. Download COCO dataset from HuggingFace and split train/val
+    2. Fine-tune RT-DETRv2 on the train split
+    3. Evaluate: COCO mAP comparison (base vs fine-tuned)
+    4. Inference demo: render bounding boxes on val images
+    """
+    log.info(f"Pipeline: {model_name} | dataset={dataset_repo}")
+
+    def _pipeline_progress(step: int, label: str) -> str:
+        steps = ["Preparing Data", "Fine-tuning", "Evaluating", "Inference Demo"]
+        dots = ""
+        for i, s in enumerate(steps):
+            if i + 1 < step:
+                icon = '<span style="color:#06d6a0;">&#10003;</span>'
+            elif i + 1 == step:
+                icon = '<span style="color:#e94560;">&#9679;</span>'
+            else:
+                icon = '<span style="color:#adb5bd;">&#9675;</span>'
+            dots += f"<span style='margin:0 8px;'>{icon} {s}</span>"
+        return f"""
+        <h2>RT-DETRv2 Object Detection Pipeline</h2>
+        <p><b>Model:</b> {model_name} | <b>Dataset:</b> {dataset_repo}</p>
+        <div class="card" style="text-align:center;">{dots}</div>
+        <p>{label}</p>
+        """
+
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(1, "Downloading and splitting dataset...")),
+        do_flush=True,
+    )
+
+    data_dir = await prepare_data(
+        dataset_repo=dataset_repo,
+        annotations_path=annotations_path,
+        images_subdir=images_subdir,
+        val_fraction=val_fraction,
+    )
+
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(2, "Fine-tuning model...")),
+        do_flush=True,
+    )
+
+    finetuned_dir = await train(
+        model_name, data_dir, epochs, lr, batch_size,
+        eval_every_n_epochs=eval_every_n_epochs,
+    )
+
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(3, "Running COCO mAP evaluation...")),
+        do_flush=True,
+    )
+
+    metrics_json = await evaluate(finetuned_dir, data_dir, threshold)
+    metrics = json.loads(metrics_json)
+
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(4, "Rendering bounding box demo...")),
+        do_flush=True,
+    )
+
+    demo_json = await inference_demo(
+        finetuned_dir, data_dir, threshold, demo_images,
+        metrics_json=metrics_json,
+    )
+
+    ft_map = metrics["finetuned"].get("map", 0)
+    ft_map50 = metrics["finetuned"].get("map_50", 0)
+
+    final_html = f"""
+    <h2>Pipeline Complete</h2>
+    <h3>{model_name}</h3>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{metrics['num_val_images']}</div><div class="label">Val Images</div></div>
+      <div class="stat"><div class="value highlight">{ft_map:.3f}</div><div class="label">mAP</div></div>
+      <div class="stat"><div class="value highlight">{ft_map50:.3f}</div><div class="label">mAP@50</div></div>
+    </div>
+    <div class="card">
+      <b>Configuration:</b> {epochs} epochs | LR {lr} | Batch size {batch_size} |
+      Val fraction {val_fraction} | Threshold {threshold}
+    </div>
+    """
+
+    await flyte.report.replace.aio(_wrap_report(final_html), do_flush=True)
+
+    log.info(f"Pipeline complete. Fine-tuned mAP: {ft_map:.3f}")
+    return finetuned_dir, json.dumps({"metrics": metrics, "demo": json.loads(demo_json)})
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/fraud_detection_feast/fraud_detection_feast.py
+++ b/v2/tutorials/fraud_detection_feast/fraud_detection_feast.py
@@ -1,0 +1,562 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "feast==0.63.0",
+#    "scikit-learn==1.8.0",
+#    "xgboost==3.2.0",
+#    "joblib",
+#    "pandas",
+#    "pyarrow",
+#    "kagglehub==0.3.12",
+# ]
+# main = "fraud_detection_pipeline"
+# params = ""
+# ///
+import json
+import logging
+import math
+import os
+import shutil
+import tempfile
+from datetime import datetime, timedelta, timezone
+
+import joblib
+import numpy as np
+import pandas as pd
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+main_img = flyte.Image.from_uv_script(__file__, name="fraud-detection-feast", pre=True)
+
+env = flyte.TaskEnvironment(
+    name="fraud-detection-feast",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="4Gi"),
+)
+# {{/docs-fragment env}}
+
+
+import report_helpers as rh
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+
+# ------------------------------------------------------------------
+# Feature definitions
+#
+# Transaction features: known at scoring time (from the request)
+# User features: pre-computed aggregates stored in Feast
+# Derived features: computed at both training and scoring time by
+#                   comparing the transaction to the user's profile
+# ------------------------------------------------------------------
+
+TXN_FEATURE_COLS = ["amt", "amt_log", "category_encoded", "merch_lat", "merch_long"]
+
+USER_FEATURE_COLS = [
+    "txn_count", "mean_amt", "std_amt", "max_amt",
+    "home_lat", "home_long", "age",
+]
+
+DERIVED_FEATURE_COLS = [
+    "amt_zscore", "amt_ratio", "distance_from_home", "hour", "day_of_week",
+]
+
+ALL_FEATURE_COLS = TXN_FEATURE_COLS + USER_FEATURE_COLS + DERIVED_FEATURE_COLS
+
+
+def haversine(lat1, lon1, lat2, lon2):
+    """Compute distance in miles between two (lat, lon) points."""
+    R = 3959  # Earth radius in miles
+    lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
+    return 2 * R * np.arcsin(np.sqrt(a))
+
+
+# ------------------------------------------------------------------
+# Task 1: Download dataset and engineer features
+# ------------------------------------------------------------------
+
+@env.task(report=True, cache="auto")
+async def prepare_data() -> flyte.io.Dir:
+    """Download the Sparkov credit card fraud dataset and prepare parquets."""
+    import kagglehub
+
+    log.info("Downloading dataset...")
+    dataset_path = kagglehub.dataset_download("kartik2112/fraud-detection")
+    csv_path = os.path.join(dataset_path, "fraudTrain.csv")
+    df = pd.read_csv(csv_path)
+    log.info(f"Loaded {len(df):,} transactions ({int(df['is_fraud'].sum()):,} fraudulent)")
+
+    # Sample for workshop speed (stratified to preserve fraud ratio)
+    if len(df) > 500_000:
+        from sklearn.model_selection import train_test_split
+        df, _ = train_test_split(df, train_size=500_000, stratify=df["is_fraud"], random_state=42)
+        log.info(f"Sampled to {len(df):,} transactions")
+
+    # ------------------------------------------------------------------
+    # Parse timestamps
+    # ------------------------------------------------------------------
+    df["event_timestamp"] = pd.to_datetime(df["trans_date_trans_time"])
+    df["event_timestamp"] = df["event_timestamp"].dt.tz_localize("UTC")
+    df["hour"] = df["event_timestamp"].dt.hour
+    df["day_of_week"] = df["event_timestamp"].dt.dayofweek
+
+    # ------------------------------------------------------------------
+    # Map cc_num → sequential user_id for clean API
+    # ------------------------------------------------------------------
+    cc_nums = df["cc_num"].unique()
+    cc_to_user = {cc: i for i, cc in enumerate(sorted(cc_nums))}
+    df["user_id"] = df["cc_num"].map(cc_to_user)
+
+    # ------------------------------------------------------------------
+    # Feature engineering
+    # ------------------------------------------------------------------
+    df["amt_log"] = np.log1p(df["amt"])
+
+    # Label-encode merchant category
+    categories = sorted(df["category"].unique())
+    cat_to_int = {cat: i for i, cat in enumerate(categories)}
+    df["category_encoded"] = df["category"].map(cat_to_int)
+
+    # Compute age from dob
+    df["dob"] = pd.to_datetime(df["dob"]).dt.tz_localize("UTC")
+    ref_date = df["event_timestamp"].max()
+    df["age"] = ((ref_date - df["dob"]).dt.days / 365.25).astype(int)
+
+    # Distance between buyer and merchant
+    df["distance"] = haversine(df["lat"], df["long"], df["merch_lat"], df["merch_long"])
+
+    # ------------------------------------------------------------------
+    # Build user aggregates
+    # ------------------------------------------------------------------
+    user_stats = df.groupby("user_id").agg(
+        txn_count=("amt", "count"),
+        mean_amt=("amt", "mean"),
+        std_amt=("amt", "std"),
+        max_amt=("amt", "max"),
+        home_lat=("lat", "median"),
+        home_long=("long", "median"),
+        age=("age", "first"),
+    ).reset_index()
+    user_stats["std_amt"] = user_stats["std_amt"].fillna(0)
+    # Use earliest timestamp so Feast point-in-time joins work for all transactions
+    earliest_ts = df.groupby("user_id")["event_timestamp"].min().reset_index()
+    user_stats = user_stats.merge(earliest_ts, on="user_id")
+
+    # ------------------------------------------------------------------
+    # Save to temp directory
+    # ------------------------------------------------------------------
+    data_dir = tempfile.mkdtemp()
+
+    txn_cols = [
+        "user_id", "event_timestamp",
+        "amt", "amt_log", "category_encoded", "merch_lat", "merch_long",
+        "hour", "day_of_week", "lat", "long", "distance",
+        "is_fraud",
+    ]
+    df[txn_cols].to_parquet(os.path.join(data_dir, "transactions.parquet"), index=False)
+    user_stats.to_parquet(os.path.join(data_dir, "user_features.parquet"), index=False)
+
+    # Save category mapping + cc_num mapping for the app
+    with open(os.path.join(data_dir, "category_mapping.json"), "w") as f:
+        json.dump(cat_to_int, f)
+    with open(os.path.join(data_dir, "user_mapping.json"), "w") as f:
+        json.dump({str(k): v for k, v in cc_to_user.items()}, f)
+
+    n_fraud = int(df["is_fraud"].sum())
+    n_legit = len(df) - n_fraud
+    fraud_pct = df["is_fraud"].mean() * 100
+    html = (
+        '<h2>Data Prepared</h2>'
+        + rh.stat_grid([
+            (f"{len(df):,}", "Transactions"),
+            (f"{n_fraud:,}", "Fraudulent"),
+            (f"{fraud_pct:.2f}%", "Fraud Rate"),
+            (f"{user_stats['user_id'].nunique():,}", "Users"),
+            (f"{len(categories)}", "Categories"),
+        ])
+        + rh.class_distribution_bar(n_legit, n_fraud)
+    )
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    return await flyte.io.Dir.from_local(data_dir)
+
+
+# ------------------------------------------------------------------
+# Task 2: Set up Feast and materialize user profiles to online store
+# ------------------------------------------------------------------
+
+@env.task(report=True)
+async def materialize_features(data_dir: flyte.io.Dir) -> flyte.io.Dir:
+    """Apply Feast definitions and materialize user profiles to SQLite online store."""
+    from feast import Entity, FeatureStore, FeatureView, Field, FileSource
+    from feast.types import Float64, Int64
+
+    data_path = await data_dir.download()
+
+    # Create a self-contained Feast repo in a temp directory
+    feast_dir = tempfile.mkdtemp()
+
+    # Copy parquet into feast dir so the repo is fully self-contained
+    shutil.copy2(
+        os.path.join(data_path, "user_features.parquet"),
+        os.path.join(feast_dir, "user_features.parquet"),
+    )
+
+    # Write feature_store.yaml
+    yaml_content = (
+        "project: fraud_detection\n"
+        f"registry: {feast_dir}/registry.db\n"
+        "provider: local\n"
+        "online_store:\n"
+        "  type: sqlite\n"
+        f"  path: {feast_dir}/online_store.db\n"
+        "offline_store:\n"
+        "  type: file\n"
+        "entity_key_serialization_version: 3\n"
+    )
+    yaml_path = os.path.join(feast_dir, "feature_store.yaml")
+    with open(yaml_path, "w") as f:
+        f.write(yaml_content)
+
+    store = FeatureStore(repo_path=feast_dir)
+
+    # Define entity and feature view
+    user = Entity(name="user", join_keys=["user_id"], description="Credit card holder")
+
+    user_source = FileSource(
+        path=os.path.join(feast_dir, "user_features.parquet"),
+        timestamp_field="event_timestamp",
+    )
+
+    user_stats = FeatureView(
+        name="user_stats",
+        entities=[user],
+        ttl=timedelta(days=0),  # No expiry — workshop data has old timestamps
+        schema=[
+            Field(name="txn_count", dtype=Int64),
+            Field(name="mean_amt", dtype=Float64),
+            Field(name="std_amt", dtype=Float64),
+            Field(name="max_amt", dtype=Float64),
+            Field(name="home_lat", dtype=Float64),
+            Field(name="home_long", dtype=Float64),
+            Field(name="age", dtype=Int64),
+        ],
+        online=True,
+        source=user_source,
+    )
+
+    # Apply and materialize
+    log.info("Applying Feast definitions...")
+    store.apply([user, user_stats])
+
+    log.info("Materializing user profiles to online store...")
+    store.materialize(
+        start_date=datetime(2018, 1, 1, tzinfo=timezone.utc),
+        end_date=datetime.now(timezone.utc),
+    )
+
+    # Re-apply with relative paths so the registry is portable across workers
+    portable_yaml = (
+        "project: fraud_detection\n"
+        "registry: registry.db\n"
+        "provider: local\n"
+        "online_store:\n"
+        "  type: sqlite\n"
+        "  path: online_store.db\n"
+        "offline_store:\n"
+        "  type: file\n"
+        "entity_key_serialization_version: 3\n"
+    )
+    with open(yaml_path, "w") as f:
+        f.write(portable_yaml)
+
+    # Re-apply with relative source path so get_historical_features works on other workers
+    store = FeatureStore(repo_path=feast_dir)
+    user_source = FileSource(
+        path="user_features.parquet",
+        timestamp_field="event_timestamp",
+    )
+    user_stats = FeatureView(
+        name="user_stats",
+        entities=[user],
+        ttl=timedelta(days=0),
+        schema=[
+            Field(name="txn_count", dtype=Int64),
+            Field(name="mean_amt", dtype=Float64),
+            Field(name="std_amt", dtype=Float64),
+            Field(name="max_amt", dtype=Float64),
+            Field(name="home_lat", dtype=Float64),
+            Field(name="home_long", dtype=Float64),
+            Field(name="age", dtype=Int64),
+        ],
+        online=True,
+        source=user_source,
+    )
+    store.apply([user, user_stats])
+
+    features = ["txn_count", "mean_amt", "std_amt", "max_amt", "home_lat", "home_long", "age"]
+    html = (
+        '<h2>Feature Store Materialized</h2>'
+        + rh.stat_grid([
+            ("user_stats", "Feature View"),
+            (str(len(features)), "Features"),
+            ("SQLite", "Online Store"),
+        ])
+        + '<h3>Materialized Features</h3>'
+        '<table>'
+        '<tr><th>Feature</th><th>Type</th><th>Description</th></tr>'
+        '<tr><td>txn_count</td><td><span class="badge badge-info">Int64</span></td><td>Total transactions</td></tr>'
+        '<tr><td>mean_amt</td><td><span class="badge badge-info">Float64</span></td><td>Average transaction amount</td></tr>'
+        '<tr><td>std_amt</td><td><span class="badge badge-info">Float64</span></td><td>Std dev of amounts</td></tr>'
+        '<tr><td>max_amt</td><td><span class="badge badge-info">Float64</span></td><td>Max transaction amount</td></tr>'
+        '<tr><td>home_lat</td><td><span class="badge badge-info">Float64</span></td><td>Home latitude (median)</td></tr>'
+        '<tr><td>home_long</td><td><span class="badge badge-info">Float64</span></td><td>Home longitude (median)</td></tr>'
+        '<tr><td>age</td><td><span class="badge badge-info">Int64</span></td><td>User age</td></tr>'
+        '</table>'
+        '<div class="note">User profiles are ready for real-time serving via the scoring app.</div>'
+    )
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    return await flyte.io.Dir.from_local(feast_dir)
+
+# ------------------------------------------------------------------
+# Task 3: Train XGBoost model
+# ------------------------------------------------------------------
+
+@env.task(report=True)
+async def train_model(
+    data_dir: flyte.io.Dir,
+    feast_dir: flyte.io.Dir,
+    n_estimators: int = 300,
+    max_depth: int = 6,
+    learning_rate: float = 0.1,
+    min_child_weight: int = 5,
+    gamma: float = 1.0,
+) -> flyte.io.File:
+    """Train an XGBoost classifier using Feast for feature retrieval."""
+    from feast import FeatureStore
+    from sklearn.model_selection import train_test_split
+    from sklearn.metrics import classification_report, roc_auc_score, confusion_matrix
+    from xgboost import XGBClassifier
+
+    data_path = await data_dir.download()
+    feast_path = await feast_dir.download()
+    txn_df = pd.read_parquet(os.path.join(data_path, "transactions.parquet"))
+
+    with open(os.path.join(data_path, "category_mapping.json")) as f:
+        category_mapping = json.load(f)
+
+    # Fetch user features from Feast (same path as serving)
+    store = FeatureStore(repo_path=feast_path)
+    entity_df = txn_df[["user_id", "event_timestamp"]].copy()
+
+    log.info("Fetching user features from Feast (get_historical_features)...")
+    training_data = store.get_historical_features(
+        entity_df=entity_df,
+        features=[
+            "user_stats:txn_count",
+            "user_stats:mean_amt",
+            "user_stats:std_amt",
+            "user_stats:max_amt",
+            "user_stats:home_lat",
+            "user_stats:home_long",
+            "user_stats:age",
+        ],
+    ).to_df()
+
+    # Merge back transaction features (Feast only returns user profile)
+    training_data = training_data.merge(
+        txn_df[["user_id", "event_timestamp", "amt", "amt_log", "category_encoded",
+                "merch_lat", "merch_long", "hour", "day_of_week", "is_fraud"]],
+        on=["user_id", "event_timestamp"],
+        how="inner",
+    )
+
+    # Derived features: compare this transaction to the user's profile
+    training_data["amt_zscore"] = (
+        (training_data["amt"] - training_data["mean_amt"])
+        / training_data["std_amt"].replace(0, 1)
+    )
+    training_data["amt_ratio"] = (
+        training_data["amt"] / training_data["mean_amt"].replace(0, 1)
+    )
+    training_data["distance_from_home"] = haversine(
+        training_data["home_lat"], training_data["home_long"],
+        training_data["merch_lat"], training_data["merch_long"],
+    )
+
+    training_data = training_data.dropna(subset=ALL_FEATURE_COLS)
+    X = training_data[ALL_FEATURE_COLS].values
+    y = training_data["is_fraud"].values
+    log.info(f"Training on {len(X):,} rows, {int(y.sum()):,} fraud")
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y,
+    )
+
+    n_legit = int((y_train == 0).sum())
+    n_fraud = int((y_train == 1).sum())
+    scale_pos_weight = n_legit / max(n_fraud, 1)
+
+    model = XGBClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        learning_rate=learning_rate,
+        scale_pos_weight=scale_pos_weight,
+        min_child_weight=min_child_weight,
+        gamma=gamma,
+        random_state=42,
+        eval_metric="logloss",
+    )
+    model.fit(X_train, y_train)
+
+    # Evaluate
+    y_pred = model.predict(X_test)
+    y_proba = model.predict_proba(X_test)[:, 1]
+    auc = roc_auc_score(y_test, y_proba)
+    cm = confusion_matrix(y_test, y_pred)
+    report = classification_report(y_test, y_pred, target_names=["Legit", "Fraud"])
+
+    log.info(f"AUC-ROC: {auc:.4f}")
+    log.info(f"\n{report}")
+
+    # Report
+    precision_fraud = cm[1][1] / max(cm[1][1] + cm[0][1], 1) * 100
+    recall_fraud = cm[1][1] / max(cm[1][1] + cm[1][0], 1) * 100
+
+    html = (
+        '<h2>Model Performance</h2>'
+        + rh.stat_grid([
+            (f"{auc:.4f}", "AUC-ROC"),
+            (f"{len(X_train):,}", "Training Samples"),
+            (f"{len(X_test):,}", "Test Samples"),
+            (f"{precision_fraud:.1f}%", "Fraud Precision"),
+            (f"{recall_fraud:.1f}%", "Fraud Recall"),
+        ])
+        + rh.confusion_matrix_html(cm)
+    )
+
+    # Feature importance bar chart
+    importance = model.feature_importances_
+    top_idx = np.argsort(importance)[::-1]
+    top_labels = [ALL_FEATURE_COLS[i] for i in top_idx]
+    top_values = [float(importance[i]) for i in top_idx]
+    html += '<h3>Feature Importance</h3>'
+    html += f'<div class="card">{rh.horizontal_bar_chart(top_labels, top_values)}</div>'
+
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    # Save model + metadata
+    model_path = os.path.join(tempfile.mkdtemp(), "model.joblib")
+    joblib.dump({
+        "model": model,
+        "auc_roc": auc,
+        "feature_cols": ALL_FEATURE_COLS,
+        "category_mapping": category_mapping,
+    }, model_path)
+
+    return await flyte.io.File.from_local(model_path)
+
+
+
+
+
+# ------------------------------------------------------------------
+# Orchestrator: prepare → materialize → train
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@env.task(report=True)
+async def fraud_detection_pipeline(
+    n_estimators: int = 300,
+    max_depth: int = 6,
+    learning_rate: float = 0.1,
+    min_child_weight: int = 5,
+    gamma: float = 1.0,
+) -> tuple[flyte.io.File, flyte.io.Dir]:
+    """
+    Full fraud detection pipeline:
+    1. Download and prepare data
+    2. Materialize user profiles to Feast
+    3. Train model using Feast for feature retrieval
+    Returns model file and Feast artifacts for serving.
+    """
+    log.info("Starting fraud detection pipeline")
+    steps = ["Prepare Data", "Materialize Features", "Train Model", "Done"]
+
+    html = '<h2>Fraud Detection Pipeline</h2>' + rh.pipeline_step_indicator(0, steps)
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    data_dir = await prepare_data()
+
+    html = '<h2>Fraud Detection Pipeline</h2>' + rh.pipeline_step_indicator(1, steps)
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    # Materialize features first so training can use Feast
+    feast_dir = await materialize_features(data_dir)
+
+    html = '<h2>Fraud Detection Pipeline</h2>' + rh.pipeline_step_indicator(2, steps)
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    # Train model using Feast for user feature retrieval
+    model_file = await train_model(
+        data_dir,
+        feast_dir,
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        learning_rate=learning_rate,
+        min_child_weight=min_child_weight,
+        gamma=gamma,
+    )
+
+    # Save copies to working directory for local app testing
+    model_local = await model_file.download()
+    feast_local = await feast_dir.download()
+    shutil.copy2(model_local, "model.joblib")
+    if os.path.exists("feast_artifacts"):
+        shutil.rmtree("feast_artifacts")
+    shutil.copytree(feast_local, "feast_artifacts")
+    log.info("Saved local copies: model.joblib, feast_artifacts/")
+
+    html = (
+        '<h2>Fraud Detection Pipeline</h2>'
+        + rh.pipeline_step_indicator(4, steps)
+        + '<div class="card">'
+        '<div style="font-weight:600;color:#155724;font-size:1.1em;margin-bottom:8px;">Pipeline Complete</div>'
+        '<p>Model and feature store artifacts are ready for serving.</p>'
+        '<table>'
+        '<tr><th>Next Step</th><th>Command</th></tr>'
+        '<tr><td>Run locally</td><td><code>python app.py</code></td></tr>'
+        '<tr><td>Deploy scoring app</td><td><code>flyte deploy app.py serving_env</code></td></tr>'
+        '<tr><td>Deploy dashboard</td><td><code>flyte deploy dashboard.py dashboard_env</code></td></tr>'
+        '</table></div>'
+    )
+    await flyte.report.replace.aio(rh.wrap(html))
+    await flyte.report.flush.aio()
+
+    log.info("Pipeline complete")
+    return model_file, feast_dir
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(fraud_detection_pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/fraud_detection_feast/report_helpers.py
+++ b/v2/tutorials/fraud_detection_feast/report_helpers.py
@@ -1,0 +1,155 @@
+"""Report helpers — styled HTML components for Flyte task reports."""
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .highlight { color: #0f3460; font-weight: 700; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d4edda; color: #155724; }
+  .report .badge-info { background: #d1ecf1; color: #0c5460; }
+  .report .badge-warning { background: #fff3cd; color: #856404; }
+  .report .badge-danger { background: #f8d7da; color: #721c24; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+</style>
+"""
+
+
+def wrap(html: str) -> str:
+    """Wrap HTML content with report styling."""
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+def stat_grid(stats: list[tuple[str, str]]) -> str:
+    """Render a grid of KPI stat cards. Each stat is (value, label)."""
+    cards = ""
+    for value, label in stats:
+        cards += f'<div class="stat"><div class="value">{value}</div><div class="label">{label}</div></div>'
+    return f'<div class="stat-grid">{cards}</div>'
+
+
+def confusion_matrix_html(cm, labels: list[str] = ("Legit", "Fraud")) -> str:
+    """Render a styled confusion matrix table."""
+    tn, fp, fn, tp = cm[0][0], cm[0][1], cm[1][0], cm[1][1]
+    total = tn + fp + fn + tp
+    accuracy = (tn + tp) / total * 100
+    precision = tp / max(tp + fp, 1) * 100
+    recall = tp / max(tp + fn, 1) * 100
+
+    return (
+        '<h3>Confusion Matrix</h3>'
+        '<table>'
+        f'<tr><th></th><th>Predicted {labels[0]}</th><th>Predicted {labels[1]}</th><th></th></tr>'
+        f'<tr><td><b>Actual {labels[0]}</b></td>'
+        f'<td style="background:#d4edda;color:#155724;font-weight:600;text-align:center;">{tn:,}</td>'
+        f'<td style="background:#f8d7da;color:#721c24;text-align:center;">{fp:,}</td>'
+        f'<td style="font-size:0.85em;color:#6c757d;">FP rate: {fp / max(tn + fp, 1) * 100:.2f}%</td></tr>'
+        f'<tr><td><b>Actual {labels[1]}</b></td>'
+        f'<td style="background:#f8d7da;color:#721c24;text-align:center;">{fn:,}</td>'
+        f'<td style="background:#d4edda;color:#155724;font-weight:600;text-align:center;">{tp:,}</td>'
+        f'<td style="font-size:0.85em;color:#6c757d;">Recall: {recall:.1f}%</td></tr>'
+        f'<tr><td></td><td colspan="2" style="font-size:0.85em;color:#6c757d;text-align:center;">'
+        f'Accuracy: {accuracy:.1f}% | Precision: {precision:.1f}%</td><td></td></tr>'
+        '</table>'
+    )
+
+
+def horizontal_bar_chart(
+    labels: list[str],
+    values: list[float],
+    title: str = "",
+    color: str = "#0f3460",
+    width: int = 700,
+    value_fmt: str = ".4f",
+) -> str:
+    """Generate an SVG horizontal bar chart."""
+    n = len(labels)
+    row_height = max(22, min(32, 300 // max(n, 1)))
+    ml = 160  # left margin for labels
+    mr = 60
+    mt = 30
+    cw = width - ml - mr
+    actual_height = mt + n * row_height + 20
+    bar_h = row_height - 6
+
+    v_max = max(values) if values else 1
+
+    svg = [f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {actual_height}" '
+           f'style="width:100%;max-width:{width}px;">']
+
+    if title:
+        svg.append(f'<text x="{width // 2}" y="18" text-anchor="middle" '
+                   f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    for i, (label, val) in enumerate(zip(labels, values)):
+        y = mt + i * row_height
+        bw = (val / v_max) * cw if v_max else 0
+        # Truncate long labels
+        display_label = label if len(label) <= 20 else label[:18] + "..."
+        svg.append(f'<text x="{ml - 8}" y="{y + bar_h / 2 + 4:.1f}" text-anchor="end" '
+                   f'font-size="11" fill="#1a1a2e">{display_label}</text>')
+        svg.append(f'<rect x="{ml}" y="{y:.1f}" width="{bw:.1f}" height="{bar_h:.1f}" '
+                   f'fill="{color}" rx="3" opacity="0.85"/>')
+        svg.append(f'<text x="{ml + bw + 6:.1f}" y="{y + bar_h / 2 + 4:.1f}" '
+                   f'font-size="11" fill="#0f3460" font-weight="600">{val:{value_fmt}}</text>')
+
+    svg.append('</svg>')
+    return '\n'.join(svg)
+
+
+def pipeline_step_indicator(current: int, steps: list[str]) -> str:
+    """Build a visual step indicator showing progress through pipeline stages."""
+    html = '<div style="display:flex;gap:24px;margin:16px 0;justify-content:center;">'
+    for i, label in enumerate(steps):
+        if i < current:
+            icon = '<span style="color:#155724;font-size:1.3em;">&#10003;</span>'
+            color = "#155724"
+            bg = "#d4edda"
+        elif i == current:
+            icon = '<span style="color:#0f3460;font-size:1.3em;">&#9679;</span>'
+            color = "#0f3460"
+            bg = "#d1ecf1"
+        else:
+            icon = '<span style="color:#adb5bd;font-size:1.3em;">&#9675;</span>'
+            color = "#adb5bd"
+            bg = "#f8f9fa"
+        html += (
+            f'<div style="text-align:center;background:{bg};border-radius:8px;padding:8px 16px;">'
+            f'<div>{icon}</div>'
+            f'<div style="font-size:0.85em;color:{color};font-weight:600;">{label}</div>'
+            f'</div>'
+        )
+    html += '</div>'
+    return html
+
+
+def class_distribution_bar(n_legit: int, n_fraud: int) -> str:
+    """Render a stacked bar showing class imbalance."""
+    total = n_legit + n_fraud
+    fraud_pct = n_fraud / total * 100
+    legit_pct = n_legit / total * 100
+    return (
+        '<div class="card">'
+        '<div style="font-weight:600;margin-bottom:8px;">Class Distribution</div>'
+        f'<div style="display:flex;border-radius:6px;overflow:hidden;height:28px;">'
+        f'<div style="background:#0f3460;width:{legit_pct:.1f}%;display:flex;align-items:center;'
+        f'justify-content:center;color:#fff;font-size:0.8em;font-weight:600;">'
+        f'Legit {legit_pct:.1f}%</div>'
+        f'<div style="background:#e74c3c;width:{fraud_pct:.1f}%;display:flex;align-items:center;'
+        f'justify-content:center;color:#fff;font-size:0.8em;font-weight:600;">'
+        f'Fraud {fraud_pct:.1f}%</div>'
+        f'</div>'
+        f'<div style="display:flex;justify-content:space-between;font-size:0.8em;color:#6c757d;margin-top:4px;">'
+        f'<span>{n_legit:,} transactions</span><span>{n_fraud:,} transactions</span></div>'
+        '</div>'
+    )

--- a/v2/tutorials/genomic_gene_comparison/genomic_gene_comparison.py
+++ b/v2/tutorials/genomic_gene_comparison/genomic_gene_comparison.py
@@ -1,0 +1,1283 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "transformers>=4.49.0",
+#    "accelerate>=0.34.0",
+#    "numpy",
+# ]
+# main = "pipeline"
+# params = ""
+# ///
+import json
+import logging
+import math
+import os
+import tempfile
+
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+main_img = flyte.Image.from_uv_script(__file__, name="genomic-gene-comparison", pre=True)
+
+gpu_env = flyte.TaskEnvironment(
+    name="genomic-gene-comparison-gpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=4, memory="32Gi", gpu=1),
+)
+
+cpu_env = flyte.TaskEnvironment(
+    name="genomic-gene-comparison-cpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="8Gi"),
+    depends_on=[gpu_env],
+)
+# {{/docs-fragment env}}
+
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+# ------------------------------------------------------------------
+# Homologous gene sets - same gene across species
+# ------------------------------------------------------------------
+# Full-length coding sequences from NCBI RefSeq (stop codon excluded).
+
+GENE_SETS = {
+    "insulin": {
+        "gene_name": "Insulin",
+        "description": "Insulin regulates blood sugar in all vertebrates. Highly conserved across 500M+ years of evolution - even fish insulin can lower blood sugar in humans. Comparing across species reveals which regions are functionally essential (conserved) vs free to drift.",
+        "sequences": {
+            "Human": {
+                "dna": "ATGGCCCTGTGGATGCGCCTCCTGCCCCTGCTGGCGCTGCTGGCCCTCTGGGGACCTGACCCAGCCGCAGCCTTTGTGAACCAACACCTGTGCGGCTCACACCTGGTGGAAGCTCTCTACCTAGTGTGCGGGGAACGAGGCTTCTTCTACACACCCAAGACCCGCCGGGAGGCAGAGGACCTGCAGGTGGGGCAGGTGGAGCTGGGCGGGGGCCCTGGTGCAGGCAGCCTGCAGCCCTTGGCCCTGGAGGGGTCCCTGCAGAAGCGTGGCATTGTGGAACAATGCTGTACCAGCATCTGCTCCCTCTACCAGCTGGAGAACTACTGCAAC",
+                "common_name": "Homo sapiens",
+            },
+            "Mouse": {
+                "dna": "ATGGCCCTGTGGATGCGCTTCCTGCCCCTGCTGGCCCTGCTCTTCCTCTGGGAGTCCCACCCCACCCAGGCTTTTGTCAAGCAGCACCTTTGTGGTTCCCACCTGGTGGAGGCTCTCTACCTGGTGTGTGGGGAGCGTGGCTTCTTCTACACACCCATGTCCCGCCGTGAAGTGGAGGACCCACAAGTGGCACAACTGGAGCTGGGTGGAGGCCCGGGAGCAGGTGACCTTCAGACCTTGGCACTGGAGGTGGCCCAGCAGAAGCGTGGCATTGTAGATCAGTGCTGCACCAGCATCTGCTCCCTCTACCAGCTGGAGAACTACTGCAAC",
+                "common_name": "Mus musculus",
+            },
+            "Chicken": {
+                "dna": "ATGGCTCTCTGGATCCGATCACTGCCTCTTCTGGCTCTCCTTGTCTTTTCTGGCCCTGGAACCAGCTATGCAGCTGCCAACCAGCACCTCTGTGGCTCCCACTTGGTGGAGGCTCTCTACCTGGTGTGTGGAGAGCGTGGCTTCTTCTACTCCCCCAAAGCCCGACGGGATGTCGAGCAGCCCCTAGTGAGCAGTCCCTTGCGTGGCGAGGCAGGAGTGCTGCCTTTCCAGCAGGAGGAATACGAGAAAGTCAAGCGAGGGATTGTTGAGCAATGCTGCCATAACACGTGTTCCCTCTACCAACTGGAGAACTACTGCAAC",
+                "common_name": "Gallus gallus",
+            },
+            "Zebrafish": {
+                "dna": "ATGGCAGTGTGGCTTCAGGCTGGTGCTCTGTTGGTCCTGTTGGTCGTGTCCAGTGTAAGCACTAACCCAGGCACACCGCAGCACCTGTGTGGATCTCATCTGGTCGATGCCCTTTATCTGGTCTGTGGCCCAACAGGCTTCTTCTACAACCCCAAGAGAGACGTTGAGCCCCTTCTGGGTTTCCTTCCTCCTAAATCTGCCCAGGAAACTGAGGTGGCTGACTTTGCATTTAAAGATCATGCCGAGCTGATAAGGAAGAGAGGCATTGTAGAGCAGTGCTGCCACAAACCCTGCAGCATCTTTGAGCTGCAGAACTACTGTAAC",
+                "common_name": "Danio rerio",
+            },
+            "Frog": {
+                "dna": "ATGGCTCTATGGATGCAGTGTCTGCCCCTGGTTCTTGTCCTCTTTTTCTCTACACCCAACACCGAAGCTCTAGTTAACCAGCACTTGTGTGGGTCTCACCTGGTAGAAGCCCTGTACTTAGTATGTGGGGATCGAGGCTTCTTCTACTACCCTAAGGTCAAACGGGACATGGAACAAGCACTTGTCAGTGGACCCCAGGATAATGAGTTGGATGGAATGCAGCTCCAGCCTCAGGAGTATCAGAAAATGAAGAGGGGGATTGTGGAGCAATGTTGCCACAGCACATGTTCTCTCTTCCAGCTGGAGAGTTACTGCAAC",
+                "common_name": "Xenopus laevis",
+            },
+            "Cow": {
+                "dna": "ATGGCCCTGTGGACACGCCTGGCGCCCCTGCTGGCCCTGCTGGCGCTCTGGGCCCCCGCCCCGGCCCGCGCCTTCGTCAACCAGCATCTGTGTGGCTCCCACCTGGTGGAGGCGCTGTACCTGGTGTGCGGAGAGCGCGGCTTCTTCTACACGCCCAAGGCCCGCCGGGAGGTGGAGGGCCCCCAGGTGGGGGCGCTGGAGCTGGCCGGAGGCCCGGGCGCGGGCGGCCTGGAGGGGCCCCCGCAGAAGCGTGGCATCGTGGAGCAGTGCTGTGCCAGCGTCTGCTCGCTCTACCAGCTGGAGAACTACTGTAAC",
+                "common_name": "Bos taurus",
+            },
+        },
+    },
+    "hemoglobin": {
+        "gene_name": "Hemoglobin Beta",
+        "description": "Beta-globin carries oxygen from lungs to tissues. The most studied gene in molecular evolution - sequence differences power the 'molecular clock' hypothesis. Sickle cell mutation (E6V) in humans shows how a single base change creates devastating disease.",
+        "sequences": {
+            "Human": {
+                "dna": "ATGGTGCATCTGACTCCTGAGGAGAAGTCTGCCGTTACTGCCCTGTGGGGCAAGGTGAACGTGGATGAAGTTGGTGGTGAGGCCCTGGGCAGGCTGCTGGTGGTCTACCCTTGGACCCAGAGGTTCTTTGAGTCCTTTGGGGATCTGTCCACTCCTGATGCTGTTATGGGCAACCCTAAGGTGAAGGCTCATGGCAAGAAAGTGCTCGGTGCCTTTAGTGATGGCCTGGCTCACCTGGACAACCTCAAGGGCACCTTTGCCACACTGAGTGAGCTGCACTGTGACAAGCTGCACGTGGATCCTGAGAACTTCAGGCTCCTGGGCAACGTGCTGGTCTGTGTGCTGGCCCATCACTTTGGCAAAGAATTCACCCCACCAGTGCAGGCTGCCTATCAGAAAGTGGTGGCTGGTGTGGCTAATGCCCTGGCCCACAAGTATCAC",
+                "common_name": "Homo sapiens",
+            },
+            "Mouse": {
+                "dna": "ATGGTGCACCTGACTGATGCTGAGAAGGCTGCTGTCTCTGGCCTGTGGGGAAAGGTGAACGCCGATGAAGTTGGTGGTGAGGCCCTGGGCAGGCTGCTGGTTGTCTACCCTTGGACCCAGCGGTACTTTGATAGCTTTGGAGACCTATCCTCTGCCTCTGCTATCATGGGTAATGCCAAAGTGAAGGCCCATGGCAAGAAAGTGATAACTGCCTTTAACGATGGCCTGAATCACTTGGACAGCCTCAAGGGCACCTTTGCCAGCCTCAGTGAGCTCCACTGTGACAAGCTGCATGTGGATCCTGAGAACTTCAGGCTCCTGGGCAATATGATCGTGATTGTGCTGGGCCACCACCTGGGCAAGGATTTCACCCCCGCTGCACAGGCTGCCTTCCAGAAGGTGGTGGCTGGAGTGGCTGCTGCCCTGGCTCACAAGTACCAC",
+                "common_name": "Mus musculus",
+            },
+            "Chicken": {
+                "dna": "ATGGTGCACTGGACTGCTGAGGAGAAGCAGCTCATCACCGGCCTCTGGGGCAAGGTCAATGTGGCCGAATGTGGGGCTGAAGCCCTGGCCAGGCTGCTGATCGTCTACCCCTGGACCCAGAGGTTCTTTGCGTCCTTTGGGAACCTCTCCAGCCCCACTGCCATCCTTGGCAACCCCATGGTCCGCGCCCATGGCAAGAAAGTGCTCACCTCCTTTGGGGATGCTGTGAAGAACCTGGACAACATCAAGAACACCTTCTCCCAACTGTCCGAACTGCATTGTGACAAGCTGCATGTGGACCCCGAGAACTTCAGGCTCCTGGGTGACATCCTCATCATTGTCCTGGCCGCCCACTTCAGCAAGGACTTCACTCCTGAATGCCAGGCTGCCTGGCAGAAGCTGGTCCGCGTGGTGGCCCATGCCCTGGCTCGCAAGTACCAC",
+                "common_name": "Gallus gallus",
+            },
+            "Zebrafish": {
+                "dna": "ATGGTTGAGTGGACAGATGCCGAGCGCACAGCCATCCTTGGCCTGTGGGGAAAGCTCAATATCGATGAAATCGGACCTCAGGCCCTATCCAGATGTCTGATCGTGTATCCCTGGACTCAGAGATATTTCGCCACATTCGGCAACCTGTCAAGCCCCGCTGCGATCATGGGTAACCCCAAAGTGGCAGCTCATGGGAGGACTGTGATGGGAGGTCTTGAGAGAGCCATCAAGAACATGGACAACGTCAAGAACACCTATGCCGCCCTCAGTGTGATGCACTCTGAGAAACTGCATGTGGATCCCGACAACTTCAGGCTTCTCGCTGATTGCATCACCGTTTGCGCTGCCATGAAGTTCGGCCAAGCTGGTTTCAATGCTGATGTCCAGGAGGCCTGGCAGAAGTTTCTGGCTGTGGTCGTTTCTGCTCTGTGCAGACAGTACCAC",
+                "common_name": "Danio rerio",
+            },
+            "Frog": {
+                "dna": "ATGGTTCATTGGACAGCTGAAGAGAAGGCCGCCATCACCTCTGTGTGGCAGGAGGTCAACCAGGAGCAAGATGGCCATGATGCACTCACAAGGCTGCTGGTTGTGTACCCCTGGACCCAGAGATACTTCAGCAGTTTTGGAAATCTCGGTAATGCCACAGCTATTGCTGGAAATGTCAAGGTGCGTGCCCATGGCAAGAAGGTTCTTTCAGCTGTTGGTGATGCCATCGCCCATCTTGACAACGTGAAGGGAACTCTCCATGACCTCAGTGTGGTCCACGCCTTCAAGCTCTATGTGGATCCTGAGAACTTCAAGCGTCTTGGTGAAGTTCTGGTCATTGTCTTGGCTTCCAAACTGGGATCAGCCTTTACTCCTCAAGTCCAGGGAGCCTGGGAGAAATTTGTTGCTGTTCTGGTTGATGCCCTCAGCCAAGGATACAAC",
+                "common_name": "Xenopus laevis",
+            },
+            "Cow": {
+                "dna": "ATGCTGACTGCTGAGGAGAAGGCTGCCGTCACCGCCTTTTGGGGCAAGGTGAAAGTGGATGAAGTTGGTGGTGAGGCCCTGGGCAGGCTGCTGGTTGTCTACCCCTGGACTCAGAGGTTCTTTGAGTCCTTTGGGGACTTGTCCACTGCTGATGCTGTTATGAACAACCCTAAGGTGAAGGCCCATGGCAAGAAGGTGCTAGATTCCTTTAGTAATGGCATGAAGCATCTCGATGACCTCAAGGGCACCTTTGCTGCGCTGAGTGAGCTGCACTGTGATAAGCTGCATGTGGATCCTGAGAACTTCAAGCTCCTGGGCAACGTGCTAGTGGTTGTGCTGGCTCGCAATTTTGGCAAGGAATTCACCCCGGTGCTGCAGGCTGACTTTCAGAAGGTGGTGGCTGGTGTGGCCAATGCCCTGGCCCACAGATATCAT",
+                "common_name": "Bos taurus",
+            },
+        },
+    },
+    "p53": {
+        "gene_name": "p53 (TP53)",
+        "description": "The 'guardian of the genome' - p53 detects DNA damage and triggers repair or cell death. Mutated in >50% of human cancers. Elephants have 20 copies of p53 (humans have 1), which may explain their extremely low cancer rates despite their size (Peto's paradox).",
+        "sequences": {
+            "Human": {
+                "dna": "ATGGAGGAGCCGCAGTCAGATCCTAGCGTCGAGCCCCCTCTGAGTCAGGAAACATTTTCAGACCTATGGAAACTACTTCCTGAAAACAACGTTCTGTCCCCCTTGCCGTCCCAAGCAATGGATGATTTGATGCTGTCCCCGGACGATATTGAACAATGGTTCACTGAAGACCCAGGTCCAGATGAAGCTCCCAGAATGCCAGAGGCTGCTCCCCCCGTGGCCCCTGCACCAGCAGCTCCTACACCGGCGGCCCCTGCACCAGCCCCCTCCTGGCCCCTGTCATCTTCTGTCCCTTCCCAGAAAACCTACCAGGGCAGCTACGGTTTCCGTCTGGGCTTCTTGCATTCTGGGACAGCCAAGTCTGTGACTTGCACGTACTCCCCTGCCCTCAACAAGATGTTTTGCCAACTGGCCAAGACCTGCCCTGTGCAGCTGTGGGTTGATTCCACACCCCCGCCCGGCACCCGCGTCCGCGCCATGGCCATCTACAAGCAGTCACAGCACATGACGGAGGTTGTGAGGCGCTGCCCCCACCATGAGCGCTGCTCAGATAGCGATGGTCTGGCCCCTCCTCAGCATCTTATCCGAGTGGAAGGAAATTTGCGTGTGGAGTATTTGGATGACAGAAACACTTTTCGACATAGTGTGGTGGTGCCCTATGAGCCGCCTGAGGTTGGCTCTGACTGTACCACCATCCACTACAACTACATGTGTAACAGTTCCTGCATGGGCGGCATGAACCGGAGGCCCATCCTCACCATCATCACACTGGAAGACTCCAGTGGTAATCTACTGGGACGGAACAGCTTTGAGGTGCGTGTTTGTGCCTGTCCTGGGAGAGACCGGCGCACAGAGGAAGAGAATCTCCGCAAGAAAGGGGAGCCTCACCACGAGCTGCCCCCAGGGAGCACTAAGCGAGCACTGCCCAACAACACCAGCTCCTCTCCCCAGCCAAAGAAGAAACCACTGGATGGAGAATATTTCACCCTTCAGATCCGTGGGCGTGAGCGCTTCGAGATGTTCCGAGAGCTGAATGAGGCCTTGGAACTCAAGGATGCCCAGGCTGGGAAGGAGCCAGGGGGGAGCAGGGCTCACTCCAGCCACCTGAAGTCCAAAAAGGGTCAGTCTACCTCCCGCCATAAAAAACTCATGTTCAAGACAGAAGGGCCTGACTCAGAC",
+                "common_name": "Homo sapiens",
+            },
+            "Mouse": {
+                "dna": "ATGACTGCCATGGAGGAGTCACAGTCGGATATCAGCCTCGAGCTCCCTCTGAGCCAGGAGACATTTTCAGGCTTATGGAAACTACTTCCTCCAGAAGATATCCTGCCATCACCTCACTGCATGGACGATCTGTTGCTGCCCCAGGATGTTGAGGAGTTTTTTGAAGGCCCAAGTGAAGCCCTCCGAGTGTCAGGAGCTCCTGCAGCACAGGACCCTGTCACCGAGACCCCTGGGCCAGTGGCCCCTGCCCCAGCCACTCCATGGCCCCTGTCATCTTTTGTCCCTTCTCAAAAAACTTACCAGGGCAACTATGGCTTCCACCTGGGCTTCCTGCAGTCTGGGACAGCCAAGTCTGTTATGTGCACGTACTCTCCTCCCCTCAATAAGCTATTCTGCCAGCTGGCGAAGACGTGCCCTGTGCAGTTGTGGGTCAGCGCCACACCTCCAGCTGGGAGCCGTGTCCGCGCCATGGCCATCTACAAGAAGTCACAGCACATGACGGAGGTCGTGAGACGCTGCCCCCACCATGAGCGCTGCTCCGATGGTGATGGCCTGGCTCCTCCCCAGCATCTTATCCGGGTGGAAGGAAATTTGTATCCCGAGTATCTGGAAGACAGGCAGACTTTTCGCCACAGCGTGGTGGTACCTTATGAGCCACCCGAGGCCGGCTCTGAGTATACCACCATCCACTACAAGTACATGTGTAATAGCTCCTGCATGGGGGGCATGAACCGCCGACCTATCCTTACCATCATCACACTGGAAGACTCCAGTGGGAACCTTCTGGGACGGGACAGCTTTGAGGTTCGTGTTTGTGCCTGCCCTGGGAGAGACCGCCGTACAGAAGAAGAAAATTTCCGCAAAAAGGAAGTCCTTTGCCCTGAACTGCCCCCAGGGAGCGCAAAGAGAGCGCTGCCCACCTGCACAAGCGCCTCTCCCCCGCAAAAGAAAAAACCACTTGATGGAGAGTATTTCACCCTCAAGATCCGCGGGCGTAAACGCTTCGAGATGTTCCGGGAGCTGAATGAGGCCTTAGAGTTAAAGGATGCCCATGCTACAGAGGAGTCTGGAGACAGCAGGGCTCACTCCAGCTACCTGAAGACCAAGAAGGGCCAGTCTACTTCCCGCCATAAAAAAACAATGGTCAAGAAAGTGGGGCCTGACTCAGAC",
+                "common_name": "Mus musculus",
+            },
+            "Chicken": {
+                "dna": "ATGGCGGAGGAGATGGAACCATTGCTGGAACCCACTGAGGTCTTCATGGACCTCTGGAGCATGCTCCCCTATAGCATGCAACAGCTGCCCCTCCCTGAGGATCACAGCAACTGGCAGGAGCTGAGCCCCCTGGAACCCAGCGACCCCCCCCCACCACCGCCACCACCACCTCTGCCATTGGCCGCCGCCGCCCCCCCCCCATTAAACCCCCCCACCCCCCCCCGCGCTGCCCCCTCCCCGGTGGTCCCATCCACGGAGGATTATGGGGGGGACTTCGACTTCCGGGTGGGGTTCGTGGAGGCGGGCACAGCCAAATCGGTCACCTGCACTTACTCCCCGGTGCTGAATAAGGTCTATTGCCGCCTGGCCAAGCCGTGCCCGGTGCAGGTGAGGGTGGGGGTGGCGCCCCCCCCCGGTTCCTCCCTCCGCGCCGTGGCCGTCTATAAGAAATCAGAGCACGTGGCCGAAGTGGTGCGGCGCTGCCCCCACCACGAGCGCTGCGGGGGGGGCACCGACGGCCTGGCCCCCGCACAGCACCTCATCCGGGTGGAGGGGAACCCCCAGGCGCGTTACCACGACGACGAGACCACCAAACGGCACAGCGTCGTCGTCCCCTATGAGCCCCCCGAGGTGGGCTCTGACTGTACCACGGTGCTGTACAACTTCATGTGCAACAGTTCCTGCATGGGGGGGATGAACCGCCGCCCCATCCTCACCATCCTTACACTGGAGGGGCCGGGGGGGCAGCTGTTGGGGCGGCGCTGCTTCGAGGTGCGCGTGTGCGCATGTCCGGGGAGGGACCGCAAGATCGAGGAGGAGAACTTCCGCAAGAGGGGCGGGGCCGGGGGCGTGGCTAAGCGAGCCATGTCGCCCCCAACCGAAGCCCCCGAGCCCCCCAAGAAGCGCGTGCTGAACCCCGACAATGAGATATTCTACCTGCAGGTGCGCGGGCGCCGCCGCTATGAGATGCTGAAGGAGATCAATGAGGCGCTGCAGCTCGCCGAGGGGGGGTCCGCACCGCGGCCTTCCAAAGGCCGCCGTGTGAAGGTGGAGGGACCCCAACCCAGCTGCGGGAAGAAACTGCTGCAAAAAGGCTCGGAC",
+                "common_name": "Gallus gallus",
+            },
+            "Zebrafish": {
+                "dna": "ATGGCGCAAAACGACAGCCAAGAGTTCGCGGAGCTCTGGGAGAAGAATTTGATTATTCAGCCCCCAGGTGGTGGCTCTTGCTGGGACATCATTAATGATGAGGAGTACTTGCCGGGATCGTTTGACCCCAATTTTTTTGAAAATGTGCTTGAAGAACAGCCTCAGCCATCCACTCTCCCACCAACATCCACTGTTCCGGAGACAAGCGACTATCCCGGCGATCATGGATTTAGGCTCAGGTTCCCGCAGTCTGGCACAGCAAAATCTGTAACTTGCACTTATTCACCGGACCTGAATAAACTCTTCTGTCAGCTGGCAAAAACTTGCCCCGTTCAAATGGTGGTGGACGTTGCCCCTCCACAGGGCTCCGTGGTTCGAGCCACTGCCATCTATAAGAAGTCCGAGCATGTGGCTGAAGTGGTCCGCAGATGCCCCCATCATGAGCGAACCCCGGATGGAGATAACTTGGCGCCTGCTGGTCATTTGATAAGAGTGGAGGGCAATCAGCGAGCAAATTACAGGGAAGATAACATCACTTTAAGGCATAGTGTTTTTGTCCCATATGAAGCACCACAGCTTGGTGCTGAATGGACAACTGTGCTACTAAACTACATGTGCAATAGCAGCTGCATGGGGGGGATGAACCGCAGGCCCATCCTCACAATCATCACTCTGGAGACTCAGGAAGGTCAGTTGCTGGGCCGGAGGTCTTTTGAGGTGCGTGTGTGTGCATGTCCAGGCAGAGACAGGAAAACTGAGGAGAGCAACTTCAAGAAAGACCAAGAGACCAAAACCATGGCCAAAACCACCACTGGGACCAAACGTAGTTTGGTGAAAGAATCTTCTTCAGCTACATTACGACCTGAGGGGAGCAAAAAGGCCAAGGGCTCCAGCAGCGATGAGGAGATCTTTACCCTGCAGGTGAGGGGCAGGGAGCGTTATGAAATTTTAAAGAAATTGAACGACAGTCTGGAGTTAAGTGATGTGGTGCCTGCCTCAGATGCTGAAAAGTATCGTCAGAAATTCATGACAAAAAACAAAAAAGAGAATCGTGAATCATCTGAGCCCAAACAGGGAAAGAAGCTGATGGTGAAGGACGAAGGAAGAAGCGACTCTGAT",
+                "common_name": "Danio rerio",
+            },
+            "Elephant": {
+                "dna": "ATGGAGGAGCCCCAGTCAGATCTCAGCACCGAGCTCCCTCTGAGTCAAGAGACGTTTTCATACTTATGGGAACTCCTTCCTGAGAATCCGGTTCTGTCCCCCACACTACCCCCGGCAGTGGAGGTCATGGACGATCTGCTACTCTCAGAAGACACTGCAAACTGGCTAGAAAGCCAAGTTGAGGCTCAGGGAATGTCCACAACCCCTGCACCAGCCACCCCTACACCGGTGGCCCCCGCACCAGCCACCTCCTGGACCCTGTCATCTTCCGTCCCTTCCCAAAAGACCTACCCTGGCACCTATGGTTTCCGTCTGGGCTTCCTACATTCTGGGACAGCCAAGTCCGTCACCTGCACGTACTCCCCTGACCTTAACAAGCTGTTTTGCCAGCTGGCAAAAACCTGCCCAGTGCAGCTGTGGGTCGCCTCACCACCCCCGCCCGGCACCCGTGTTCGCACCATGGCCATCTACAAGAAGTCAGAGCATATGACGGAGGTCGTCAAGCGCTGCCCCCACCATGAGCGCTGCTCTGACTCTAGCGATGGCCTGGCCCCTCCTCAGCACCTCATCCGGGTGGAAGGAAACCTGCGTGCTGAGTATCTGGAGGACAGCATCACTCTCCGACACAGTGTGGTGGTGCCCTACGAGCCGCCCGAGGTTGGGTCTGACTGTACCACCATCCACTTCAACTTCATGTGTAACAGCTCCTGCATGGGGGGCATGAACCGGCGGCCCATCCTCACCATCATCACACTGGAAGACTCCAGTGGTAATCTGCTGGGACGTAACAGCTTTGAGGTGCGCATTTGTGCCTGTCCTGGAAGAGACAGACGTACAGAAGAAGAAAATTTCCACAAGAAGGGAGAGCCTTGCCCAGAGCCGCCACCCCCTGGGAGGAGCACTAAGCGAGCACTGCCCACCAACACCAGCTCCTCTACCCAGCCAAAGAAGAAGCCACTGGATGAAGAATATTTCACCCTTCAGATCCGTGGGCGTGAACGCTTCAAGATGTTCCTAGAGCTAAATGAGGCCTTGGAGCTGAAGGATGCCCAGGCTGGGAAGGAGCCAGAGGGGAGCCGGGCTCACTCCAGCCCTTCGAAGTCTAAGAAGGGACAGTCTACCTCCCGCCATAAAAAACCAATGTTCAAGAGAGAGGGACCTGACTCAGAC",
+                "common_name": "Loxodonta africana",
+            },
+            "Dog": {
+                "dna": "ATGGAGGAGTCGCAGTCAGAGCTCAATATCGACCCCCCTCTGAGCCAGGAGACATTTTCAGAATTGTGGAACCTGCTTCCTGAAAACAATGTTCTGTCTTCGGAGCTGTGCCCAGCAGTGGATGAGCTGCTGCTCCCAGAGAGCGTCGTGAACTGGCTAGACGAAGACTCAGATGATGCTCCCAGGATGCCAGCCACTTCTGCCCCCACAGCCCCTGGACCGGCCCCCTCGTGGCCCCTATCATCCTCTGTCCCTTCCCCGAAGACCTACCCTGGCACCTATGGGTTCCGTTTGGGGTTCCTGCATTCCGGGACAGCCAAGTCTGTTACTTGGACGTACTCCCCTCTCCTCAACAAGTTGTTTTGCCAGCTGGCGAAGACCTGCCCCGTGCAGCTGTGGGTCAGCTCCCCACCCCCACCCAATACCTGCGTCCGCGCTATGGCCATCTATAAGAAGTCGGAGTTCGTGACCGAGGTTGTGCGGCGCTGCCCCCACCATGAACGCTGCTCTGACAGTAGTGACGGTCTTGCCCCTCCTCAGCATCTCATCCGAGTGGAAGGAAATTTGCGGGCCAAGTACCTGGACGACAGAAACACTTTTCGACACAGTGTGGTGGTGCCTTATGAGCCACCCGAGGTTGGCTCTGACTATACCACCATCCACTACAACTACATGTGTAACAGTTCCTGCATGGGAGGCATGAACCGGCGGCCCATCCTCACTATCATCACCCTGGAAGACTCCAGTGGAAACGTGCTGGGACGCAACAGCTTTGAGGTACGCGTTTGTGCCTGTCCCGGGAGAGACCGCCGGACTGAGGAGGAGAATTTCCACAAGAAGGGGGAGCCTTGTCCTGAGCCACCCCCCGGGAGTACCAAGCGAGCACTGCCTCCCAGCACCAGCTCCTCTCCCCCGCAAAAGAAGAAGCCACTAGATGGAGAATATTTCACCCTTCAGATCCGTGGGCGTGAACGCTATGAGATGTTCAGGAATCTGAATGAAGCCTTGGAGCTGAAGGATGCCCAGAGTGGAAAGGAGCCAGGGGGAAGCAGGGCTCACTCCAGCCACCTGAAGGCAAAGAAGGGGCAATCTACCTCTCGCCATAAAAAACTGATGTTCAAGAGAGAAGGGCTTGACTCAGAC",
+                "common_name": "Canis lupus familiaris",
+            },
+        },
+    },
+}
+
+# Standard genetic code
+CODON_TABLE = {
+    "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L", "CTT": "L", "CTC": "L",
+    "CTA": "L", "CTG": "L", "ATT": "I", "ATC": "I", "ATA": "I", "ATG": "M",
+    "GTT": "V", "GTC": "V", "GTA": "V", "GTG": "V", "TCT": "S", "TCC": "S",
+    "TCA": "S", "TCG": "S", "CCT": "P", "CCC": "P", "CCA": "P", "CCG": "P",
+    "ACT": "T", "ACC": "T", "ACA": "T", "ACG": "T", "GCT": "A", "GCC": "A",
+    "GCA": "A", "GCG": "A", "TAT": "Y", "TAC": "Y", "TAA": "*", "TAG": "*",
+    "CAT": "H", "CAC": "H", "CAA": "Q", "CAG": "Q", "AAT": "N", "AAC": "N",
+    "AAA": "K", "AAG": "K", "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
+    "TGT": "C", "TGC": "C", "TGA": "*", "TGG": "W", "CGT": "R", "CGC": "R",
+    "CGA": "R", "CGG": "R", "AGT": "S", "AGC": "S", "AGA": "R", "AGG": "R",
+    "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G",
+}
+
+BASE_COLORS = {"A": "#2ecc71", "T": "#e74c3c", "G": "#f39c12", "C": "#3498db"}
+
+
+def _translate(dna: str) -> str:
+    """Translate DNA to protein in reading frame 0."""
+    dna = dna.upper()
+    protein = []
+    for i in range(0, len(dna) - 2, 3):
+        codon = dna[i:i + 3]
+        aa = CODON_TABLE.get(codon, "X")
+        if aa == "*":
+            break
+        protein.append(aa)
+    return "".join(protein)
+
+
+def _gc_content(seq: str) -> float:
+    if not seq:
+        return 0.0
+    return sum(1 for b in seq.upper() if b in "GC") / len(seq)
+
+
+def _sequence_identity(seq1: str, seq2: str, match: int = 2, mismatch: int = -1, gap: int = -2) -> float:
+    """Percent identity via Needleman-Wunsch global alignment."""
+    if not seq1 or not seq2:
+        return 0.0
+    n, m = len(seq1), len(seq2)
+
+    # Build score matrix
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(1, n + 1):
+        dp[i][0] = dp[i - 1][0] + gap
+    for j in range(1, m + 1):
+        dp[0][j] = dp[0][j - 1] + gap
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            s = match if seq1[i - 1] == seq2[j - 1] else mismatch
+            dp[i][j] = max(dp[i - 1][j - 1] + s, dp[i - 1][j] + gap, dp[i][j - 1] + gap)
+
+    # Traceback to count matches and alignment length
+    i, j = n, m
+    matches = 0
+    aligned = 0
+    while i > 0 or j > 0:
+        if i > 0 and j > 0:
+            s = match if seq1[i - 1] == seq2[j - 1] else mismatch
+            if dp[i][j] == dp[i - 1][j - 1] + s:
+                if seq1[i - 1] == seq2[j - 1]:
+                    matches += 1
+                aligned += 1
+                i -= 1
+                j -= 1
+                continue
+        if i > 0 and dp[i][j] == dp[i - 1][j] + gap:
+            aligned += 1
+            i -= 1
+        else:
+            aligned += 1
+            j -= 1
+
+    return matches / aligned if aligned else 0.0
+
+
+# ------------------------------------------------------------------
+# Report styling
+# ------------------------------------------------------------------
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #1e3a5f; border-bottom: 2px solid #2563eb; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #1e40af; margin-top: 20px; }
+  .report .card { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #dbeafe; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #1e3a5f; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #1e3a5f; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dbeafe; }
+  .report tr:nth-child(even) { background: #eff6ff; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d1fae5; color: #065f46; }
+  .report .badge-warning { background: #fef3c7; color: #92400e; }
+  .report .badge-danger { background: #fee2e2; color: #991b1b; }
+  .report .badge-info { background: #dbeafe; color: #1e40af; }
+  .report .chart-container { background: #fff; border: 1px solid #dbeafe; border-radius: 8px; padding: 16px; margin: 16px 0; }
+  .report .note { background: #eff6ff; border-left: 4px solid #2563eb; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .structure-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; margin: 12px 0; }
+</style>
+"""
+
+
+def _wrap_report(html: str) -> str:
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+# ------------------------------------------------------------------
+# SVG chart helpers
+# ------------------------------------------------------------------
+
+def _make_heatmap(
+    matrix: list[list[float]],
+    row_labels: list[str],
+    col_labels: list[str],
+    title: str = "",
+    width: int = 600,
+    height: int = 500,
+    value_format: str = ".1f",
+    color_scale: str = "blue",
+) -> str:
+    """Generate an SVG heatmap."""
+    n_rows = len(matrix)
+    n_cols = len(matrix[0]) if matrix else 0
+    if not n_rows or not n_cols:
+        return ""
+
+    show_values = n_rows <= 10 and n_cols <= 10
+    flat = [v for row in matrix for v in row]
+    v_min = min(flat)
+    v_max = max(flat)
+    v_range = v_max - v_min or 1
+
+    if color_scale == "blue":
+        def get_color(v):
+            t = (v - v_min) / v_range
+            r = int(255 - t * (255 - 30))
+            g = int(255 - t * (255 - 58))
+            b = int(255 - t * (255 - 95))
+            return f"rgb({r},{g},{b})"
+    else:  # green
+        def get_color(v):
+            t = (v - v_min) / v_range
+            r = int(255 - t * (255 - 6))
+            g = int(255 - t * (255 - 95))
+            b = int(255 - t * (255 - 70))
+            return f"rgb({r},{g},{b})"
+
+    ml = max(80, max(len(l) for l in row_labels) * 7 + 10) if row_labels else 80
+    mr = 20
+    mt = 80
+    mb = 20
+    cw = width - ml - mr
+    ch = height - mt - mb
+    cell_w = cw / n_cols
+    cell_h = ch / n_rows
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    if title:
+        svg.append(f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    for j, label in enumerate(col_labels):
+        cx = ml + j * cell_w + cell_w / 2
+        svg.append(f'<text x="{cx:.1f}" y="{mt - 8}" text-anchor="start" font-size="10" fill="#374151" transform="rotate(-45, {cx:.1f}, {mt - 8})">{label}</text>')
+
+    for i, row_label in enumerate(row_labels):
+        ry = mt + i * cell_h + cell_h / 2
+        svg.append(f'<text x="{ml - 8}" y="{ry + 4:.1f}" text-anchor="end" font-size="10" fill="#374151">{row_label}</text>')
+        for j in range(n_cols):
+            val = matrix[i][j]
+            color = get_color(val)
+            cx = ml + j * cell_w
+            cy = mt + i * cell_h
+            svg.append(f'<rect x="{cx:.1f}" y="{cy:.1f}" width="{cell_w:.1f}" height="{cell_h:.1f}" fill="{color}" stroke="#fff" stroke-width="1"/>')
+            if show_values:
+                t = (val - v_min) / v_range
+                text_color = "#fff" if t > 0.55 else "#1a1a2e"
+                fs = min(10, int(cell_w / 4), int(cell_h / 2.5))
+                fs = max(7, fs)
+                svg.append(f'<text x="{cx + cell_w / 2:.1f}" y="{cy + cell_h / 2 + 3:.1f}" text-anchor="middle" font-size="{fs}" fill="{text_color}">{val:{value_format}}</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_dendrogram(
+    names: list[str],
+    matrix: list[list[float]],
+    title: str = "",
+    width: int = 700,
+    height: int = 350,
+    color: str = "#2563eb",
+) -> str:
+    """Generate an SVG dendrogram from a similarity matrix using UPGMA."""
+    n = len(names)
+    if n < 2:
+        return ""
+
+    dist = [[1.0 - matrix[i][j] for j in range(n)] for i in range(n)]
+
+    clusters = [{"members": [i], "height": 0.0, "left": None, "right": None} for i in range(n)]
+    active = list(range(n))
+
+    while len(active) > 1:
+        best_d = float("inf")
+        bi, bj = 0, 1
+        for ii in range(len(active)):
+            for jj in range(ii + 1, len(active)):
+                ci, cj = active[ii], active[jj]
+                d = 0
+                count = 0
+                for mi in clusters[ci]["members"]:
+                    for mj in clusters[cj]["members"]:
+                        d += dist[mi][mj]
+                        count += 1
+                avg_d = d / count if count else 0
+                if avg_d < best_d:
+                    best_d = avg_d
+                    bi, bj = ii, jj
+
+        ci, cj = active[bi], active[bj]
+        new_cluster = {
+            "members": clusters[ci]["members"] + clusters[cj]["members"],
+            "height": best_d,
+            "left": clusters[ci],
+            "right": clusters[cj],
+        }
+        clusters.append(new_cluster)
+        new_idx = len(clusters) - 1
+        active.pop(bj)
+        active.pop(bi)
+        active.append(new_idx)
+
+    root = clusters[active[0]]
+
+    max_label_len = max((len(n) for n in names), default=0)
+    ml, mr, mt, mb = max(50, max_label_len * 5 + 10), 30, 40, 80
+    cw = width - ml - mr
+    ch = height - mt - mb
+    max_h = root["height"] or 1
+
+    leaf_positions = {}
+    leaf_counter = [0]
+
+    def assign_leaves(node):
+        if node["left"] is None and node["right"] is None:
+            leaf_positions[node["members"][0]] = leaf_counter[0]
+            leaf_counter[0] += 1
+        else:
+            if node["left"]:
+                assign_leaves(node["left"])
+            if node["right"]:
+                assign_leaves(node["right"])
+
+    assign_leaves(root)
+    n_leaves = len(leaf_positions)
+    leaf_spacing = cw / max(n_leaves - 1, 1)
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    if title:
+        svg.append(f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="13" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    def get_x(node):
+        if node["left"] is None and node["right"] is None:
+            return ml + leaf_positions[node["members"][0]] * leaf_spacing
+        return (get_x(node["left"]) + get_x(node["right"])) / 2
+
+    def get_y(h):
+        return mt + ch - (h / max_h) * ch
+
+    def draw_node(node):
+        if node["left"] is None and node["right"] is None:
+            return
+        lx = get_x(node["left"])
+        rx = get_x(node["right"])
+        ly = get_y(node["left"]["height"])
+        ry = get_y(node["right"]["height"])
+        my = get_y(node["height"])
+
+        svg.append(f'<line x1="{lx:.1f}" y1="{ly:.1f}" x2="{lx:.1f}" y2="{my:.1f}" stroke="{color}" stroke-width="2"/>')
+        svg.append(f'<line x1="{rx:.1f}" y1="{ry:.1f}" x2="{rx:.1f}" y2="{my:.1f}" stroke="{color}" stroke-width="2"/>')
+        svg.append(f'<line x1="{lx:.1f}" y1="{my:.1f}" x2="{rx:.1f}" y2="{my:.1f}" stroke="{color}" stroke-width="2"/>')
+
+        if node["left"]:
+            draw_node(node["left"])
+        if node["right"]:
+            draw_node(node["right"])
+
+    draw_node(root)
+
+    for idx, pos in leaf_positions.items():
+        x = ml + pos * leaf_spacing
+        svg.append(
+            f'<text x="{x:.1f}" y="{mt + ch + 14}" text-anchor="start" font-size="10" fill="#374151" '
+            f'transform="rotate(40, {x:.1f}, {mt + ch + 14})">{names[idx]}</text>'
+        )
+
+    for i in range(5):
+        d = max_h * i / 4
+        y = get_y(d)
+        svg.append(f'<text x="{ml - 4}" y="{y + 3:.1f}" text-anchor="end" font-size="9" fill="#9ca3af">{d:.3f}</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_bar_chart(
+    labels: list[str],
+    series: dict[str, list[float]],
+    title: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    value_format: str = ".1f",
+) -> str:
+    """Generate an SVG grouped bar chart."""
+    if not labels:
+        return ""
+
+    default_colors = ["#2563eb", "#059669", "#f59e0b", "#dc2626", "#7c3aed"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 80
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    all_vals = [v for vals in series.values() for v in vals]
+    y_min = min(all_vals) if all_vals else 0
+    y_max = max(all_vals) if all_vals else 1
+    if y_min >= 0:
+        y_min_plot = 0
+        y_max_plot = y_max * 1.15 or 1
+    else:
+        y_range = y_max - y_min or 1
+        y_min_plot = y_min - y_range * 0.05
+        y_max_plot = y_max + y_range * 0.15
+
+    n_groups = len(labels)
+    n_series = len(series)
+    group_width = cw / n_groups
+    bar_width = group_width * 0.7 / max(n_series, 1)
+    gap = group_width * 0.15
+
+    def sy(v):
+        return mt + ch - ((v - y_min_plot) / (y_max_plot - y_min_plot)) * ch
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    for i in range(6):
+        y_tick = y_min_plot + (y_max_plot - y_min_plot) * i / 5
+        py = sy(y_tick)
+        svg.append(f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" stroke="#e9ecef" stroke-width="1"/>')
+        svg.append(f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" font-size="11" fill="#6c757d">{y_tick:{value_format}}</text>')
+
+    for gi, label in enumerate(labels):
+        gx = ml + gi * group_width + gap
+        for si, (name, vals) in enumerate(series.items()):
+            color = colors[si % len(colors)]
+            bx = gx + si * bar_width
+            val = vals[gi]
+            by = sy(val)
+            bh = mt + ch - by
+            svg.append(f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_width - 1:.1f}" height="{max(0, bh):.1f}" fill="{color}" rx="2"/>')
+            svg.append(f'<text x="{bx + bar_width / 2:.1f}" y="{by - 4:.1f}" text-anchor="middle" font-size="9" fill="#1a1a2e">{val:{value_format}}</text>')
+        lx = gx + n_series * bar_width / 2
+        svg.append(f'<text x="{lx:.1f}" y="{mt + ch + 14}" text-anchor="start" font-size="10" fill="#6c757d" transform="rotate(35, {lx:.1f}, {mt + ch + 14})">{label}</text>')
+
+    if title:
+        svg.append(f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>')
+
+    if n_series > 1:
+        lx = ml + cw - len(series) * 110
+        for si, name in enumerate(series):
+            color = colors[si % len(colors)]
+            svg.append(f'<rect x="{lx + si * 110}" y="{mt + ch + 55}" width="12" height="12" rx="2" fill="{color}"/>')
+            svg.append(f'<text x="{lx + si * 110 + 16}" y="{mt + ch + 66}" font-size="11" fill="#1a1a2e">{name}</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_plddt_sparkline(values: list[float], width: int = 400, height: int = 50) -> str:
+    """pLDDT sparkline with AlphaFold-style coloring."""
+    if not values or len(values) < 2:
+        return ""
+
+    pad = 4
+    cw = width - 2 * pad
+    ch = height - 2 * pad
+    seg_w = cw / len(values)
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+    ]
+
+    for i, v in enumerate(values):
+        x = pad + i * seg_w
+        bar_h = (v / 100) * ch
+        y = pad + ch - bar_h
+
+        if v >= 90:
+            color = "#0053d6"
+        elif v >= 70:
+            color = "#65cbf3"
+        elif v >= 50:
+            color = "#ffdb13"
+        else:
+            color = "#ff7d45"
+
+        svg.append(f'<rect x="{x:.1f}" y="{y:.1f}" width="{max(seg_w, 1):.1f}" height="{bar_h:.1f}" fill="{color}"/>')
+
+    ref_y = pad + ch - (70 / 100) * ch
+    svg.append(f'<line x1="{pad}" y1="{ref_y:.1f}" x2="{pad + cw}" y2="{ref_y:.1f}" stroke="#adb5bd" stroke-width="0.5" stroke-dasharray="3,2"/>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _outputs_to_pdb(outputs, sequence: str) -> str:
+    """Convert ESMFold outputs to PDB format string."""
+    import numpy as np
+
+    pos = outputs.positions[0]
+    if pos.dim() == 4:
+        pos = pos[-1]
+    positions = pos.cpu().numpy()
+    atom_names = ["N", "CA", "C", "O"]
+    aa_3letter = {
+        "A": "ALA", "R": "ARG", "N": "ASN", "D": "ASP", "C": "CYS",
+        "Q": "GLN", "E": "GLU", "G": "GLY", "H": "HIS", "I": "ILE",
+        "L": "LEU", "K": "LYS", "M": "MET", "F": "PHE", "P": "PRO",
+        "S": "SER", "T": "THR", "W": "TRP", "Y": "TYR", "V": "VAL",
+    }
+
+    pdb_lines = []
+    atom_idx = 1
+    for res_idx, aa in enumerate(sequence):
+        res_name = aa_3letter.get(aa, "UNK")
+        for atom_i, atom_name in enumerate(atom_names):
+            if atom_i >= positions.shape[1]:
+                break
+            x, y, z = positions[res_idx, atom_i]
+            if any(math.isnan(c) for c in (x, y, z)):
+                continue
+            pdb_lines.append(
+                f"ATOM  {atom_idx:5d}  {atom_name:<3s} {res_name} A{res_idx + 1:4d}    "
+                f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00           {atom_name[0]:>2s}"
+            )
+            atom_idx += 1
+    pdb_lines.append("END")
+    return "\n".join(pdb_lines)
+
+
+# ------------------------------------------------------------------
+# Task 1: Load gene set
+# ------------------------------------------------------------------
+
+@cpu_env.task()
+async def load_genes(
+    gene_set: str = "insulin",
+    custom_json: str = "",
+) -> flyte.io.Dir:
+    """Load a set of homologous genes from different species."""
+    if custom_json:
+        data = json.loads(custom_json)
+    elif gene_set in GENE_SETS:
+        data = GENE_SETS[gene_set]
+    else:
+        available = ", ".join(GENE_SETS.keys())
+        raise ValueError(f"Unknown gene set '{gene_set}'. Available: {available}")
+
+    log.info(f"Loaded gene set: {data['gene_name']} - {len(data['sequences'])} species")
+
+    out_dir = tempfile.mkdtemp(prefix="gene_compare_")
+    with open(os.path.join(out_dir, "genes.json"), "w") as f:
+        json.dump(data, f)
+
+    return await flyte.io.Dir.from_local(out_dir)
+
+
+# ------------------------------------------------------------------
+# Task 2: Score sequences with Carbon
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def score_sequences(
+    genes_dir: flyte.io.Dir,
+    model_name: str = "HuggingFaceBio/Carbon-3B",
+) -> str:
+    """Score each species' gene with Carbon-3B genomic language model.
+
+    Returns per-species log-likelihood scores and sequence metadata.
+    """
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    log.info(f"Loading Carbon model: {model_name}")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, trust_remote_code=True,
+        dtype=torch.bfloat16 if device == "cuda" else torch.float32,
+    ).to(device)
+    model.eval()
+
+    genes_path = await genes_dir.download()
+    with open(os.path.join(genes_path, "genes.json")) as f:
+        data = json.load(f)
+
+    species_names = list(data["sequences"].keys())
+    n = len(species_names)
+
+    scores = {}
+    for i, species in enumerate(species_names):
+        await flyte.report.replace.aio(_wrap_report(
+            f"<h2>Carbon Scoring</h2>"
+            f"<p>Scoring {species} ({i + 1}/{n})...</p>"
+        ), do_flush=True)
+
+        dna = data["sequences"][species]["dna"]
+        prompt = f"<dna>{dna}"
+        inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).to(device)
+
+        with torch.no_grad():
+            output = model(**inputs, labels=inputs["input_ids"])
+            loss = output.loss.item()
+            ll = -loss * inputs["input_ids"].shape[1]
+
+        protein = _translate(dna)
+        scores[species] = {
+            "log_likelihood": round(ll, 4),
+            "loss": round(loss, 4),
+            "gc_content": round(_gc_content(dna), 4),
+            "length": len(dna),
+            "protein": protein,
+            "protein_length": len(protein),
+            "common_name": data["sequences"][species]["common_name"],
+        }
+        log.info(f"  {species} ({data['sequences'][species]['common_name']}): LL={ll:.2f}, GC={_gc_content(dna):.1%}")
+
+    # Report
+    html_parts = [
+        f"<h2>{data['gene_name']} - Carbon Scoring</h2>",
+        f'<div class="note">{data["description"]}</div>',
+        '<div class="stat-grid">',
+        f'<div class="stat"><div class="value">{n}</div><div class="label">Species</div></div>',
+        f'<div class="stat"><div class="value">{data["gene_name"]}</div><div class="label">Gene</div></div>',
+        f'<div class="stat"><div class="value">{model_name.split("/")[-1]}</div><div class="label">Model</div></div>',
+        "</div>",
+    ]
+
+    html_parts.append(
+        "<table><tr><th>Species</th><th>Scientific Name</th><th>DNA Length</th>"
+        "<th>GC%</th><th>Protein Length</th><th>Carbon LL</th></tr>"
+    )
+    for species in species_names:
+        s = scores[species]
+        html_parts.append(
+            f'<tr><td><b>{species}</b></td><td><i>{s["common_name"]}</i></td>'
+            f'<td>{s["length"]}bp</td><td>{s["gc_content"]:.1%}</td>'
+            f'<td>{s["protein_length"]}aa</td>'
+            f'<td>{s["log_likelihood"]:.2f}</td></tr>'
+        )
+    html_parts.append("</table>")
+
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_bar_chart(
+        species_names,
+        {"Log-Likelihood": [scores[s]["log_likelihood"] for s in species_names]},
+        title="Carbon Log-Likelihood per Species",
+        value_format=".1f",
+    ))
+    html_parts.append("</div>")
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+
+    result = {
+        "gene_name": data["gene_name"],
+        "description": data["description"],
+        "species": species_names,
+        "scores": scores,
+    }
+    return json.dumps(result)
+
+
+# ------------------------------------------------------------------
+# Task 3: Align sequences and compute similarity
+# ------------------------------------------------------------------
+
+@cpu_env.task(report=True)
+async def align_and_compare(
+    scores_json: str,
+    genes_dir: flyte.io.Dir,
+) -> str:
+    """Align sequences with Needleman-Wunsch and compute pairwise identity.
+
+    Translates DNA to protein, builds DNA and protein identity matrices,
+    and generates phylogenetic trees from sequence divergence.
+    """
+    scores_data = json.loads(scores_json)
+    species_names = scores_data["species"]
+    scores = scores_data["scores"]
+    gene_name = scores_data["gene_name"]
+    n = len(species_names)
+
+    genes_path = await genes_dir.download()
+    with open(os.path.join(genes_path, "genes.json")) as f:
+        data = json.load(f)
+
+    await flyte.report.replace.aio(_wrap_report(
+        f"<h2>{gene_name} - Sequence Alignment</h2>"
+        f"<p>Aligning {n} species with Needleman-Wunsch...</p>"
+    ), do_flush=True)
+
+    # Pairwise DNA identity matrix
+    identity_matrix = []
+    for sp1 in species_names:
+        row = []
+        for sp2 in species_names:
+            dna1 = data["sequences"][sp1]["dna"]
+            dna2 = data["sequences"][sp2]["dna"]
+            identity = _sequence_identity(dna1, dna2)
+            row.append(round(identity, 4))
+        identity_matrix.append(row)
+
+    # Pairwise protein identity matrix
+    protein_matrix = []
+    for sp1 in species_names:
+        row = []
+        for sp2 in species_names:
+            identity = _sequence_identity(scores[sp1]["protein"], scores[sp2]["protein"])
+            row.append(round(identity, 4))
+        protein_matrix.append(row)
+
+    # Average pairwise identities (exclude diagonal)
+    dna_pairs = [identity_matrix[i][j] for i in range(n) for j in range(i + 1, n)]
+    prot_pairs = [protein_matrix[i][j] for i in range(n) for j in range(i + 1, n)]
+    avg_dna = sum(dna_pairs) / len(dna_pairs) if dna_pairs else 0
+    avg_prot = sum(prot_pairs) / len(prot_pairs) if prot_pairs else 0
+
+    # Most/least similar pair
+    best_pair = max(range(len(dna_pairs)), key=lambda k: dna_pairs[k])
+    worst_pair = min(range(len(dna_pairs)), key=lambda k: dna_pairs[k])
+    pair_indices = [(i, j) for i in range(n) for j in range(i + 1, n)]
+    best_sp = f"{species_names[pair_indices[best_pair][0]]}-{species_names[pair_indices[best_pair][1]]}"
+    worst_sp = f"{species_names[pair_indices[worst_pair][0]]}-{species_names[pair_indices[worst_pair][1]]}"
+
+    # Report
+    html_parts = [
+        f"<h2>{gene_name} - Sequence Alignment</h2>",
+        f'<div class="note">Pairwise alignment using Needleman-Wunsch (match=2, mismatch=-1, gap=-2). '
+        f"Identity is computed as matches / aligned length from the optimal global alignment.</div>",
+        '<div class="stat-grid">',
+        f'<div class="stat"><div class="value">{n}</div><div class="label">Species Aligned</div></div>',
+        f'<div class="stat"><div class="value">{n * (n - 1) // 2}</div><div class="label">Pairwise Alignments</div></div>',
+        f'<div class="stat"><div class="value">{avg_dna:.0%}</div><div class="label">Avg DNA Identity</div></div>',
+        f'<div class="stat"><div class="value">{avg_prot:.0%}</div><div class="label">Avg Protein Identity</div></div>',
+        f'<div class="stat"><div class="value">{best_sp}</div><div class="label">Most Similar</div></div>',
+        f'<div class="stat"><div class="value">{worst_sp}</div><div class="label">Most Divergent</div></div>',
+        "</div>",
+    ]
+
+    # DNA identity heatmap
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_heatmap(
+        identity_matrix, species_names, species_names,
+        title="Pairwise DNA Sequence Identity (%)",
+        value_format=".0%",
+    ))
+    html_parts.append("</div>")
+
+    # Protein identity heatmap
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_heatmap(
+        protein_matrix, species_names, species_names,
+        title="Pairwise Protein Sequence Identity (%)",
+        value_format=".0%",
+        color_scale="green",
+    ))
+    html_parts.append("</div>")
+
+    # DNA phylogenetic tree
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_dendrogram(
+        species_names, identity_matrix,
+        title=f"{gene_name} - Phylogenetic Tree (DNA Identity)",
+    ))
+    html_parts.append("</div>")
+
+    # Protein phylogenetic tree
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_dendrogram(
+        species_names, protein_matrix,
+        title=f"{gene_name} - Phylogenetic Tree (Protein Identity)",
+        color="#059669",
+    ))
+    html_parts.append("</div>")
+
+    # DNA vs Protein conservation comparison
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_bar_chart(
+        species_names,
+        {
+            "DNA vs Human": [identity_matrix[0][j] for j in range(n)],
+            "Protein vs Human": [protein_matrix[0][j] for j in range(n)],
+        },
+        title=f"Conservation vs {species_names[0]} (DNA and Protein)",
+        value_format=".0%",
+    ))
+    html_parts.append("</div>")
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+
+    result = {
+        "gene_name": gene_name,
+        "description": scores_data["description"],
+        "species": species_names,
+        "scores": scores,
+        "dna_identity_matrix": identity_matrix,
+        "protein_identity_matrix": protein_matrix,
+    }
+    return json.dumps(result)
+
+
+# ------------------------------------------------------------------
+# Task 4: Fold proteins with ESMFold
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def fold_proteins(
+    comparison_json: str,
+    max_length: int = 400,
+) -> str:
+    """Fold each species' translated protein with ESMFold for 3D comparison.
+
+    Returns PDB strings and pLDDT confidence scores for each species.
+    """
+    import torch
+    import numpy as np
+    from transformers import AutoTokenizer, EsmForProteinFolding
+
+    comparison = json.loads(comparison_json)
+    species_names = comparison["species"]
+    scores = comparison["scores"]
+
+    log.info("Loading ESMFold model...")
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    tokenizer = AutoTokenizer.from_pretrained("facebook/esmfold_v1")
+    model = EsmForProteinFolding.from_pretrained("facebook/esmfold_v1", low_cpu_mem_usage=True)
+    model = model.to(device)
+    model.eval()
+
+    structure_data = {}
+    n = len(species_names)
+
+    for idx, species in enumerate(species_names):
+        protein = scores[species]["protein"]
+
+        if len(protein) > max_length:
+            log.info(f"Skipping {species} ({len(protein)} aa > {max_length} max)")
+            continue
+
+        log.info(f"ESMFold [{idx + 1}/{n}]: {species} ({len(protein)} aa)")
+        await flyte.report.replace.aio(_wrap_report(
+            f"<h2>ESMFold - 3D Structure Prediction</h2>"
+            f"<p>Folding {species} ({idx + 1}/{n}): {len(protein)} residues...</p>"
+        ), do_flush=True)
+
+        inputs = tokenizer(protein, return_tensors="pt", add_special_tokens=False).to(device)
+
+        with torch.no_grad():
+            outputs = model(**inputs)
+
+        pdb_str = _outputs_to_pdb(outputs, protein)
+
+        plddt_raw = outputs.plddt[0].cpu().numpy()
+        if plddt_raw.ndim == 2:
+            plddt_raw = plddt_raw[-1]
+        plddt = plddt_raw.flatten()[:len(protein)]
+        if plddt.max() <= 1.0:
+            plddt = plddt * 100
+        plddt_mean = float(np.mean(plddt))
+
+        structure_data[species] = {
+            "pdb_str": pdb_str,
+            "plddt_mean": round(plddt_mean, 1),
+            "plddt_per_residue": [round(float(v), 1) for v in plddt[:len(protein)]],
+            "protein_length": len(protein),
+        }
+        log.info(f"  → mean pLDDT: {plddt_mean:.1f}")
+
+    # Report with 3D viewers
+    n_folded = len(structure_data)
+    avg_plddt = sum(d["plddt_mean"] for d in structure_data.values()) / n_folded if n_folded else 0
+
+    threeDmol_script = '<script src="https://3dmol.csb.pitt.edu/build/3Dmol-min.js"></script>'
+
+    stats_html = f"""
+    <h2>ESMFold - Cross-Species Structure Comparison</h2>
+    <div class="note">
+      <b>ESMFold</b> predicts 3D structure directly from amino acid sequence.
+      Comparing structures across species reveals which parts of the protein are
+      structurally conserved (functional core) vs divergent (surface loops, species-specific adaptations).
+    </div>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{n_folded}</div><div class="label">Structures</div></div>
+      <div class="stat"><div class="value">{avg_plddt:.1f}</div><div class="label">Avg pLDDT</div></div>
+      <div class="stat"><div class="value">{comparison['gene_name']}</div><div class="label">Gene</div></div>
+    </div>
+    """
+
+    viewers_html = '<div class="structure-grid">'
+    for species, sdata in structure_data.items():
+        plddt_val = sdata["plddt_mean"]
+        common = scores[species]["common_name"]
+
+        if plddt_val >= 90:
+            badge = '<span class="badge badge-success">Very High</span>'
+        elif plddt_val >= 70:
+            badge = '<span class="badge badge-info">Confident</span>'
+        elif plddt_val >= 50:
+            badge = '<span class="badge badge-warning">Low</span>'
+        else:
+            badge = '<span class="badge badge-danger">Disordered</span>'
+
+        plddt_sparkline = _make_plddt_sparkline(sdata["plddt_per_residue"], width=300)
+        pdb_escaped = sdata["pdb_str"].replace("\\", "\\\\").replace("`", "\\`").replace("$", "\\$")
+        viewer_id = f"viewer_{hash(species) & 0xFFFFFF:06x}"
+
+        viewers_html += f"""
+        <div class="card" style="margin:0;">
+          <h3 style="margin-top:0;">{species}
+            <span style="font-size:0.7em;color:#6c757d;">({sdata['protein_length']} aa)</span>
+            {badge}
+          </h3>
+          <p style="font-size:0.85em;color:#6c757d;margin:2px 0 8px;"><i>{common}</i></p>
+          <div id="{viewer_id}" style="width:100%;max-width:320px;height:280px;border:1px solid #dbeafe;border-radius:8px;position:relative;"></div>
+          <div style="margin-top:8px;">
+            <b>Mean pLDDT:</b> {plddt_val:.1f} / 100
+            <div style="margin-top:4px;">{plddt_sparkline}</div>
+            <div style="font-size:0.75em;color:#9ca3af;margin-top:2px;">
+              <span style="color:#0053d6;">&block; &gt;90</span>
+              <span style="color:#65cbf3;">&block; 70-90</span>
+              <span style="color:#ffdb13;">&block; 50-70</span>
+              <span style="color:#ff7d45;">&block; &lt;50</span>
+            </div>
+          </div>
+        </div>
+        <script>
+        (function() {{
+          var pdb = `{pdb_escaped}`;
+          function initViewer() {{
+            if (typeof $3Dmol === 'undefined') {{ setTimeout(initViewer, 200); return; }}
+            var viewer = $3Dmol.createViewer(document.getElementById("{viewer_id}"), {{backgroundColor: "white"}});
+            viewer.addModel(pdb, "pdb");
+            viewer.setStyle({{}}, {{cartoon: {{color: "spectrum"}}}});
+            viewer.zoomTo();
+            viewer.render();
+            viewer.spin("y", 1);
+          }}
+          initViewer();
+        }})();
+        </script>
+        """
+
+    viewers_html += "</div>"
+
+    # pLDDT comparison bar chart
+    plddt_chart = _make_bar_chart(
+        list(structure_data.keys()),
+        {"Mean pLDDT": [d["plddt_mean"] for d in structure_data.values()]},
+        title="Structure Confidence Comparison (pLDDT)",
+        value_format=".1f",
+        colors=["#0053d6"],
+    )
+
+    report_html = f"""
+    {threeDmol_script}
+    {stats_html}
+    {viewers_html}
+    <div class="chart-container">{plddt_chart}</div>
+    """
+
+    await flyte.report.replace.aio(_wrap_report(report_html), do_flush=True)
+
+    return json.dumps(structure_data)
+
+
+# ------------------------------------------------------------------
+# Task 5: Generate summary
+# ------------------------------------------------------------------
+
+@cpu_env.task(report=True)
+async def generate_summary(
+    comparison_json: str,
+    structures_json: str,
+) -> str:
+    """Generate comprehensive cross-species summary."""
+    comparison = json.loads(comparison_json)
+    structures = json.loads(structures_json)
+
+    species = comparison["species"]
+    scores = comparison["scores"]
+    gene_name = comparison["gene_name"]
+    dna_matrix = comparison["dna_identity_matrix"]
+    protein_matrix = comparison["protein_identity_matrix"]
+
+    html_parts = [
+        f"<h2>{gene_name} - Cross-Species Evolution Summary</h2>",
+        f'<div class="note">{comparison["description"]}</div>',
+    ]
+
+    # Key metrics
+    # Average pairwise identity (exclude diagonal)
+    n = len(species)
+    dna_pairs = [dna_matrix[i][j] for i in range(n) for j in range(i + 1, n)]
+    protein_pairs = [protein_matrix[i][j] for i in range(n) for j in range(i + 1, n)]
+    avg_dna_id = sum(dna_pairs) / len(dna_pairs) if dna_pairs else 0
+    avg_protein_id = sum(protein_pairs) / len(protein_pairs) if protein_pairs else 0
+    avg_plddt = sum(d["plddt_mean"] for d in structures.values()) / len(structures) if structures else 0
+
+    html_parts.append('<div class="stat-grid">')
+    html_parts.append(f'<div class="stat"><div class="value">{n}</div><div class="label">Species</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{avg_dna_id:.0%}</div><div class="label">Avg DNA Identity</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{avg_protein_id:.0%}</div><div class="label">Avg Protein Identity</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{avg_plddt:.1f}</div><div class="label">Avg pLDDT</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{len(structures)}</div><div class="label">Structures Folded</div></div>')
+    html_parts.append("</div>")
+
+    # Full comparison table
+    html_parts.append("<h3>Per-Species Detail</h3>")
+    html_parts.append(
+        "<table><tr><th>Species</th><th>Scientific Name</th><th>DNA (bp)</th>"
+        "<th>Protein (aa)</th><th>GC%</th><th>Carbon LL</th><th>pLDDT</th></tr>"
+    )
+    for sp in species:
+        s = scores[sp]
+        plddt = structures.get(sp, {}).get("plddt_mean", "N/A")
+        plddt_str = f"{plddt:.1f}" if isinstance(plddt, float) else plddt
+        html_parts.append(
+            f'<tr><td><b>{sp}</b></td><td><i>{s["common_name"]}</i></td>'
+            f'<td>{s["length"]}</td><td>{s["protein_length"]}</td>'
+            f'<td>{s["gc_content"]:.1%}</td><td>{s["log_likelihood"]:.2f}</td>'
+            f'<td>{plddt_str}</td></tr>'
+        )
+    html_parts.append("</table>")
+
+    # GC content comparison
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_bar_chart(
+        species,
+        {"GC Content": [scores[s]["gc_content"] for s in species]},
+        title="GC Content Across Species",
+        value_format=".2f",
+    ))
+    html_parts.append("</div>")
+
+    # DNA phylogenetic tree
+    html_parts.append("<h3>Phylogenetic Relationships</h3>")
+    html_parts.append(
+        '<div class="note">'
+        "Trees built from pairwise sequence identity using UPGMA clustering. "
+        "Species that diverged more recently cluster together. DNA and protein trees "
+        "may differ when synonymous mutations dominate."
+        "</div>"
+    )
+
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_dendrogram(
+        species, dna_matrix,
+        title=f"{gene_name} - DNA Phylogenetic Tree",
+    ))
+    html_parts.append("</div>")
+
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_dendrogram(
+        species, protein_matrix,
+        title=f"{gene_name} - Protein Phylogenetic Tree",
+        color="#059669",
+    ))
+    html_parts.append("</div>")
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+
+    summary = {
+        "gene_name": gene_name,
+        "n_species": n,
+        "avg_dna_identity": round(avg_dna_id, 4),
+        "avg_protein_identity": round(avg_protein_id, 4),
+        "avg_plddt": round(avg_plddt, 1),
+        "n_structures": len(structures),
+    }
+    return json.dumps(summary)
+
+
+# ------------------------------------------------------------------
+# Pipeline orchestrator
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@cpu_env.task(report=True)
+async def pipeline(
+    gene_set: str = "insulin",
+    model_name: str = "HuggingFaceBio/Carbon-3B",
+    custom_json: str = "",
+) -> tuple[str, str]:
+    """
+    End-to-end cross-species gene comparison pipeline.
+
+    Returns (comparison JSON, structures JSON).
+
+    1. Load homologous gene sequences across species
+    2. Score with Carbon genomic language model
+    3. Align sequences and compute pairwise similarity
+    4. Fold translated proteins with ESMFold
+    5. Generate comprehensive summary with phylogenetic trees
+    """
+    log.info(f"Starting cross-species gene comparison pipeline (gene_set={gene_set})...")
+
+    def _pipeline_progress(step: int, label: str) -> str:
+        steps = [
+            "Load Genes",
+            "Carbon Scoring",
+            "Sequence Alignment",
+            "ESMFold Structures",
+            "Generate Summary",
+        ]
+        dots = ""
+        for i, s in enumerate(steps):
+            if i + 1 < step:
+                icon = '<span style="color:#2563eb;">&#10003;</span>'
+            elif i + 1 == step:
+                icon = '<span style="color:#2563eb;">&#9679;</span>'
+            else:
+                icon = '<span style="color:#adb5bd;">&#9675;</span>'
+            dots += f"<span style='margin:0 8px;'>{icon} {s}</span>"
+        return f"""
+        <h2>Cross-Species Gene Comparison</h2>
+        <div class="card" style="text-align:center;">{dots}</div>
+        <p>{label}</p>
+        """
+
+    # Stage 1
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(1, "Loading homologous gene sequences...")),
+        do_flush=True,
+    )
+    genes_dir = await load_genes(gene_set=gene_set, custom_json=custom_json)
+
+    # Stage 2
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(2, "Scoring sequences with Carbon...")),
+        do_flush=True,
+    )
+    scores_json = await score_sequences(genes_dir=genes_dir, model_name=model_name)
+
+    # Stage 3
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(3, "Aligning sequences with Needleman-Wunsch...")),
+        do_flush=True,
+    )
+    comparison_json = await align_and_compare(scores_json=scores_json, genes_dir=genes_dir)
+
+    # Stage 4
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(4, "Folding proteins with ESMFold...")),
+        do_flush=True,
+    )
+    structures_json = await fold_proteins(comparison_json=comparison_json)
+
+    # Stage 5
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(5, "Generating summary report...")),
+        do_flush=True,
+    )
+    summary_json = await generate_summary(
+        comparison_json=comparison_json,
+        structures_json=structures_json,
+    )
+
+    # Final report
+    summary = json.loads(summary_json)
+    comparison = json.loads(comparison_json)
+
+    final_html = f"""
+    <h2>Pipeline Complete</h2>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{summary['gene_name']}</div><div class="label">Gene</div></div>
+      <div class="stat"><div class="value">{summary['n_species']}</div><div class="label">Species</div></div>
+      <div class="stat"><div class="value">{summary['avg_dna_identity']:.0%}</div><div class="label">Avg DNA Identity</div></div>
+      <div class="stat"><div class="value">{summary['avg_protein_identity']:.0%}</div><div class="label">Avg Protein Identity</div></div>
+      <div class="stat"><div class="value">{summary['avg_plddt']:.1f}</div><div class="label">Avg pLDDT</div></div>
+      <div class="stat"><div class="value">{summary['n_structures']}</div><div class="label">3D Structures</div></div>
+    </div>
+    <div class="card">
+      <b>Gene:</b> {summary['gene_name']} |
+      <b>Species:</b> {', '.join(comparison['species'])} |
+      <b>Model:</b> {model_name}
+    </div>
+    <div class="note">
+      All 4 pipeline stages completed. View individual task reports for DNA/protein
+      identity heatmaps, phylogenetic trees, interactive 3D protein structures with
+      pLDDT confidence, Carbon log-likelihood scores, and evolutionary analysis.
+    </div>
+    """
+
+    await flyte.report.replace.aio(_wrap_report(final_html), do_flush=True)
+    log.info("Pipeline complete.")
+    return comparison_json, structures_json
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/genomic_variant_effect/genomic_variant_effect.py
+++ b/v2/tutorials/genomic_variant_effect/genomic_variant_effect.py
@@ -1,0 +1,1304 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.9.0",
+#    "transformers>=4.49.0",
+#    "accelerate>=0.34.0",
+#    "numpy",
+# ]
+# main = "pipeline"
+# params = ""
+# ///
+import json
+import logging
+import math
+import os
+import tempfile
+
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+main_img = flyte.Image.from_uv_script(__file__, name="genomic-variant-effect", pre=True)
+
+gpu_env = flyte.TaskEnvironment(
+    name="genomic-variant-effect-gpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=1),
+)
+
+cpu_env = flyte.TaskEnvironment(
+    name="genomic-variant-effect-cpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="6Gi"),
+    depends_on=[gpu_env],
+)
+# {{/docs-fragment env}}
+
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+# ------------------------------------------------------------------
+# Default gene variants — clinically relevant mutations
+# ------------------------------------------------------------------
+# Each entry: gene name -> { "sequence": reference DNA, "variants": [{ "pos": 0-indexed, "ref": base, "alt": base, "name": "...", "known_effect": "..." }] }
+# Sequences are short windows (~120-200bp) around the variant site for tractable inference.
+
+DEFAULT_GENE_VARIANTS = {
+    "BRCA2 (Breast Cancer)": {
+        "description": "Tumor suppressor critical for DNA repair via homologous recombination. Mutations dramatically increase breast and ovarian cancer risk.",
+        "sequence": "ATGGCCTCGAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAGCAG",
+        "variants": [
+            {"pos": 12, "ref": "A", "alt": "T", "name": "c.37A>T", "known_effect": "pathogenic", "clinical": "Nonsense mutation — truncates protein early"},
+            {"pos": 18, "ref": "G", "alt": "A", "name": "c.55G>A", "known_effect": "benign", "clinical": "Synonymous — no amino acid change"},
+            {"pos": 30, "ref": "C", "alt": "T", "name": "c.91C>T", "known_effect": "pathogenic", "clinical": "Missense in DNA-binding domain"},
+            {"pos": 45, "ref": "G", "alt": "C", "name": "c.136G>C", "known_effect": "uncertain", "clinical": "Variant of uncertain significance (VUS)"},
+        ],
+    },
+    "TP53 (Tumor Suppressor)": {
+        "description": "Guardian of the genome. Activates DNA repair, cell cycle arrest, and apoptosis. Mutated in >50% of human cancers.",
+        "sequence": "ATGGAGGAGCCGCAGTCAGATCCTAGCGTGAGTTTGCACCCTTCAGAGACAGAAACCACTGGATTGGAGACTACTTCCTGAAACAACGTTCTGTCCCCCTTGCCGTCCCAAGCAATGGATGAT",
+        "variants": [
+            {"pos": 15, "ref": "C", "alt": "T", "name": "R175H", "known_effect": "pathogenic", "clinical": "Hotspot — gain-of-function, dominant negative. Most common TP53 mutation in cancer"},
+            {"pos": 36, "ref": "T", "alt": "C", "name": "P72R", "known_effect": "benign", "clinical": "Common polymorphism — subtle effect on apoptosis efficiency"},
+            {"pos": 54, "ref": "C", "alt": "A", "name": "G245S", "known_effect": "pathogenic", "clinical": "Contact mutant — disrupts DNA binding"},
+            {"pos": 72, "ref": "T", "alt": "G", "name": "R248W", "known_effect": "pathogenic", "clinical": "Structural mutant — destabilizes DNA-binding loop"},
+            {"pos": 90, "ref": "C", "alt": "T", "name": "R273H", "known_effect": "pathogenic", "clinical": "Contact mutant — directly contacts DNA bases"},
+        ],
+    },
+    "CFTR (Cystic Fibrosis)": {
+        "description": "Chloride channel protein. Mutations cause cystic fibrosis — the most common lethal genetic disease in people of European descent.",
+        "sequence": "ATGCAGAGGTCGCCTCTGGAAAAGGCCAGCGTTGTCTCCAAACTTTTTTTCAGCTGGACCAGACCAATTTTGAGGAAAGGATACAGACAGCGCCTGGAATTGTCAGACATATACCAAATCCCTTC",
+        "variants": [
+            {"pos": 9, "ref": "G", "alt": "A", "name": "G85E", "known_effect": "pathogenic", "clinical": "Disrupts chloride channel processing"},
+            {"pos": 24, "ref": "C", "alt": "T", "name": "R117H", "known_effect": "pathogenic", "clinical": "Reduces channel conductance — milder CF phenotype"},
+            {"pos": 48, "ref": "T", "alt": "C", "name": "I148T", "known_effect": "benign", "clinical": "Previously misclassified — now known benign polymorphism"},
+            {"pos": 66, "ref": "A", "alt": "G", "name": "R334W", "known_effect": "pathogenic", "clinical": "Gating mutation — channel opens less frequently"},
+        ],
+    },
+    "KRAS (Oncogene)": {
+        "description": "GTPase signal switch. KRAS mutations are the most common oncogenic driver — found in ~25% of all human cancers, especially pancreatic, colorectal, and lung.",
+        "sequence": "ATGACTGAATATAAACTTGTGGTAGTTGGAGCTGGTGGCGTAGGCAAGAGTGCCTTGACGATACAGCTAATTCAGAATCATTTTGTGGACGAATATGATCCAACAATAGAGGATTCCTACAGGAA",
+        "variants": [
+            {"pos": 34, "ref": "G", "alt": "T", "name": "G12V", "known_effect": "pathogenic", "clinical": "Locks KRAS in active state — constitutive proliferation signal"},
+            {"pos": 35, "ref": "G", "alt": "A", "name": "G12D", "known_effect": "pathogenic", "clinical": "Most common KRAS mutation in pancreatic cancer"},
+            {"pos": 37, "ref": "G", "alt": "T", "name": "G13D", "known_effect": "pathogenic", "clinical": "Constitutively active — common in colorectal cancer"},
+            {"pos": 60, "ref": "C", "alt": "A", "name": "Q61K", "known_effect": "pathogenic", "clinical": "Impairs GTP hydrolysis — locked ON state"},
+        ],
+    },
+    "HBB (Sickle Cell)": {
+        "description": "Beta-globin subunit of hemoglobin. The sickle cell mutation (E6V) is the most well-known single-base disease variant in humans.",
+        "sequence": "ATGGTGCATCTGACTCCTGAGGAGAAGTCTGCCGTTACTGCCCTGTGGGGCAAGGTGAACGTGGATGAAGTTGGTGGTGAGGCCCTGGGCAGGCTGCTGGTGGTCTACCCTTGGACCCAGAGG",
+        "variants": [
+            {"pos": 17, "ref": "A", "alt": "T", "name": "E6V (HbS)", "known_effect": "pathogenic", "clinical": "THE sickle cell mutation — causes hemoglobin polymerization under low O2"},
+            {"pos": 19, "ref": "G", "alt": "A", "name": "E6K (HbC)", "known_effect": "pathogenic", "clinical": "Hemoglobin C disease — milder than sickle cell but causes crystal formation"},
+            {"pos": 36, "ref": "G", "alt": "A", "name": "E26K", "known_effect": "benign", "clinical": "Hemoglobin E — most common Hb variant worldwide, mild effect"},
+            {"pos": 78, "ref": "C", "alt": "T", "name": "Q39X", "known_effect": "pathogenic", "clinical": "Nonsense — causes beta-thalassemia (no functional beta-globin)"},
+        ],
+    },
+}
+
+# DNA base colors (classic genomics color scheme)
+BASE_COLORS = {"A": "#2ecc71", "T": "#e74c3c", "G": "#f39c12", "C": "#3498db"}
+BASE_COMPLEMENT = {"A": "T", "T": "A", "G": "C", "C": "G"}
+
+# Pathogenicity color scheme
+EFFECT_COLORS = {
+    "pathogenic": "#dc2626",
+    "benign": "#059669",
+    "uncertain": "#f59e0b",
+}
+EFFECT_BADGES = {
+    "pathogenic": "badge-danger",
+    "benign": "badge-success",
+    "uncertain": "badge-warning",
+}
+
+
+# ------------------------------------------------------------------
+# Report styling — genomics-themed deep blues and teals
+# ------------------------------------------------------------------
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #1e3a5f; border-bottom: 2px solid #2563eb; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #1e40af; margin-top: 20px; }
+  .report .card { background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #dbeafe; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #1e3a5f; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #1e3a5f; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dbeafe; }
+  .report tr:nth-child(even) { background: #eff6ff; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d1fae5; color: #065f46; }
+  .report .badge-warning { background: #fef3c7; color: #92400e; }
+  .report .badge-danger { background: #fee2e2; color: #991b1b; }
+  .report .badge-info { background: #dbeafe; color: #1e40af; }
+  .report .chart-container { background: #fff; border: 1px solid #dbeafe; border-radius: 8px; padding: 16px; margin: 16px 0; }
+  .report .note { background: #eff6ff; border-left: 4px solid #2563eb; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .gene-card { background: #fff; border: 1px solid #dbeafe; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .dna-track { font-family: 'SF Mono', 'Fira Code', monospace; letter-spacing: 1px; }
+</style>
+"""
+
+
+def _wrap_report(html: str) -> str:
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+# ------------------------------------------------------------------
+# SVG chart helpers
+# ------------------------------------------------------------------
+
+def _make_bar_chart(
+    labels: list[str],
+    series: dict[str, list[float]],
+    title: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    value_format: str = ".2f",
+) -> str:
+    """Generate an SVG grouped bar chart."""
+    if not labels:
+        return ""
+
+    default_colors = ["#2563eb", "#1e3a5f", "#3b82f6", "#60a5fa", "#93c5fd"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 70, 20, 40, 80
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    all_vals = [v for vals in series.values() for v in vals]
+    y_max = max(abs(v) for v in all_vals) if all_vals else 1
+    y_min = min(all_vals) if all_vals else 0
+    # For VEP scores (negative = more damaging), we need to handle negative values
+    if y_min >= 0:
+        y_min_plot = 0
+        y_max_plot = y_max * 1.15 or 1
+    else:
+        y_max_plot = max(y_max * 1.15, 0.1)
+        y_min_plot = y_min * 1.15
+
+    y_range = y_max_plot - y_min_plot or 1
+
+    n_groups = len(labels)
+    n_series = len(series)
+    group_width = cw / n_groups
+    bar_width = group_width * 0.7 / max(n_series, 1)
+    gap = group_width * 0.15
+
+    def sy(v):
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Grid lines
+    for i in range(6):
+        y_tick = y_min_plot + y_range * i / 5
+        py = sy(y_tick)
+        svg.append(
+            f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" '
+            f'stroke="#e9ecef" stroke-width="1"/>'
+        )
+        svg.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6c757d">{y_tick:{value_format}}</text>'
+        )
+
+    # Zero line
+    if y_min_plot < 0 < y_max_plot:
+        zy = sy(0)
+        svg.append(
+            f'<line x1="{ml}" y1="{zy:.1f}" x2="{ml + cw}" y2="{zy:.1f}" '
+            f'stroke="#374151" stroke-width="1.5"/>'
+        )
+
+    # Bars
+    for gi, label in enumerate(labels):
+        gx = ml + gi * group_width + gap
+        for si, (name, vals) in enumerate(series.items()):
+            color = colors[si % len(colors)]
+            bx = gx + si * bar_width
+            val = vals[gi]
+            if val >= 0:
+                by = sy(val)
+                bh = sy(0) - by if y_min_plot < 0 else mt + ch - by
+            else:
+                by = sy(0) if y_min_plot < 0 else mt + ch
+                bh = sy(val) - by
+            svg.append(
+                f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_width - 1:.1f}" '
+                f'height="{max(0, bh):.1f}" fill="{color}" rx="2"/>'
+            )
+            text_y = by - 4 if val >= 0 else by + bh + 12
+            svg.append(
+                f'<text x="{bx + bar_width / 2:.1f}" y="{text_y:.1f}" '
+                f'text-anchor="middle" font-size="9" fill="#1a1a2e">'
+                f'{val:{value_format}}</text>'
+            )
+        # Rotated group label
+        lx = gx + n_series * bar_width / 2
+        svg.append(
+            f'<text x="{lx:.1f}" y="{mt + ch + 14}" '
+            f'text-anchor="end" font-size="10" fill="#6c757d" '
+            f'transform="rotate(-35, {lx:.1f}, {mt + ch + 14})">{label}</text>'
+        )
+
+    # Title
+    if title:
+        svg.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    # Legend
+    if n_series > 1:
+        lx = ml + cw - len(series) * 110
+        for si, name in enumerate(series):
+            color = colors[si % len(colors)]
+            svg.append(
+                f'<rect x="{lx + si * 110}" y="{mt + ch + 55}" width="12" '
+                f'height="12" rx="2" fill="{color}"/>'
+            )
+            svg.append(
+                f'<text x="{lx + si * 110 + 16}" y="{mt + ch + 66}" font-size="11" '
+                f'fill="#1a1a2e">{name}</text>'
+            )
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_heatmap(
+    matrix: list[list[float]],
+    row_labels: list[str],
+    col_labels: list[str],
+    title: str = "",
+    width: int = 700,
+    height: int = 500,
+    value_format: str = ".2f",
+    diverging: bool = False,
+) -> str:
+    """Generate an SVG heatmap. If diverging=True, uses red-white-blue scale centered at 0."""
+    n_rows = len(matrix)
+    n_cols = len(matrix[0]) if matrix else 0
+    if not n_rows or not n_cols:
+        return ""
+
+    show_values = n_rows <= 10 and n_cols <= 12
+
+    flat = [v for row in matrix for v in row]
+    v_min = min(flat)
+    v_max = max(flat)
+
+    if diverging:
+        abs_max = max(abs(v_min), abs(v_max)) or 1
+
+        def get_color(v):
+            t = v / abs_max  # -1 to 1
+            if t < 0:
+                # White to red (negative = damaging)
+                r = 255
+                g = int(255 * (1 + t))
+                b = int(255 * (1 + t))
+            else:
+                # White to blue (positive = benign)
+                r = int(255 * (1 - t))
+                g = int(255 * (1 - t))
+                b = 255
+            return f"rgb({r},{g},{b})"
+    else:
+        v_range = v_max - v_min or 1
+
+        def get_color(v):
+            t = (v - v_min) / v_range
+            r = int(255 - t * (255 - 30))
+            g = int(255 - t * (255 - 58))
+            b = int(255 - t * (255 - 95))
+            return f"rgb({r},{g},{b})"
+
+    # Layout
+    ml = max(140, max(len(l) for l in row_labels) * 7 + 20) if row_labels else 140
+    mr = 20
+    mt = 80 if col_labels else 40
+    mb = 30
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    cell_w = cw / n_cols
+    cell_h = ch / n_rows
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    if title:
+        svg.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    # Column labels (rotated)
+    for j, label in enumerate(col_labels):
+        cx = ml + j * cell_w + cell_w / 2
+        svg.append(
+            f'<text x="{cx:.1f}" y="{mt - 8}" text-anchor="end" '
+            f'font-size="10" fill="#374151" '
+            f'transform="rotate(-45, {cx:.1f}, {mt - 8})">{label}</text>'
+        )
+
+    # Row labels + cells
+    for i, row_label in enumerate(row_labels):
+        ry = mt + i * cell_h + cell_h / 2
+        svg.append(
+            f'<text x="{ml - 8}" y="{ry + 4:.1f}" text-anchor="end" '
+            f'font-size="10" fill="#374151">{row_label}</text>'
+        )
+        for j in range(n_cols):
+            val = matrix[i][j]
+            color = get_color(val)
+            cx = ml + j * cell_w
+            cy = mt + i * cell_h
+            svg.append(
+                f'<rect x="{cx:.1f}" y="{cy:.1f}" width="{cell_w:.1f}" '
+                f'height="{cell_h:.1f}" fill="{color}" stroke="#fff" stroke-width="1"/>'
+            )
+            if show_values:
+                if diverging:
+                    t = abs(val) / (max(abs(v_min), abs(v_max)) or 1)
+                else:
+                    t = (val - v_min) / (v_max - v_min or 1)
+                text_color = "#fff" if t > 0.55 else "#1a1a2e"
+                font_size = min(10, int(cell_w / 4), int(cell_h / 2.5))
+                font_size = max(7, font_size)
+                svg.append(
+                    f'<text x="{cx + cell_w / 2:.1f}" y="{cy + cell_h / 2 + 3:.1f}" '
+                    f'text-anchor="middle" font-size="{font_size}" '
+                    f'fill="{text_color}">{val:{value_format}}</text>'
+                )
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_dna_track(
+    sequence: str,
+    variants: list[dict],
+    gene_name: str = "",
+    width: int = 900,
+) -> str:
+    """Render a color-coded DNA sequence track with variant positions highlighted."""
+    chars_per_line = 60
+    char_w = 11
+    line_h = 22
+    label_w = 50
+    n_lines = (len(sequence) + chars_per_line - 1) // chars_per_line
+
+    # Extra space for variant annotations
+    variant_positions = {v["pos"] for v in variants}
+    svg_h = n_lines * line_h + 60
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {svg_h}" '
+        f'style="width:100%;max-width:{width}px;height:auto;font-family:monospace;">',
+        f'<rect width="{width}" height="{svg_h}" fill="#fff" rx="6"/>',
+    ]
+
+    if gene_name:
+        svg.append(
+            f'<text x="{width / 2}" y="16" text-anchor="middle" '
+            f'font-size="12" font-weight="600" fill="#1e3a5f">{gene_name}</text>'
+        )
+
+    y_offset = 28
+
+    for line_idx in range(n_lines):
+        start = line_idx * chars_per_line
+        end = min(start + chars_per_line, len(sequence))
+        chunk = sequence[start:end]
+        y = y_offset + line_idx * line_h
+
+        # Position label
+        svg.append(
+            f'<text x="{label_w - 8}" y="{y}" text-anchor="end" '
+            f'font-size="9" fill="#9ca3af">{start + 1}</text>'
+        )
+
+        for ci, base in enumerate(chunk):
+            abs_pos = start + ci
+            x = label_w + ci * char_w
+            color = BASE_COLORS.get(base, "#6b7280")
+            is_variant = abs_pos in variant_positions
+
+            if is_variant:
+                # Red highlight for variant positions
+                svg.append(
+                    f'<rect x="{x - 1}" y="{y - 13}" width="{char_w + 2}" height="{line_h}" '
+                    f'fill="#fee2e2" stroke="#dc2626" stroke-width="1.5" rx="2"/>'
+                )
+                # Small triangle marker above
+                svg.append(
+                    f'<polygon points="{x + char_w / 2:.1f},{y - 16} {x + char_w / 2 - 3:.1f},{y - 20} {x + char_w / 2 + 3:.1f},{y - 20}" '
+                    f'fill="#dc2626"/>'
+                )
+            else:
+                # Subtle background
+                svg.append(
+                    f'<rect x="{x}" y="{y - 12}" width="{char_w}" height="{line_h - 2}" '
+                    f'fill="{color}" opacity="0.08" rx="1"/>'
+                )
+
+            svg.append(
+                f'<text x="{x + char_w / 2:.1f}" y="{y}" text-anchor="middle" '
+                f'font-size="11" font-weight="{"700" if is_variant else "500"}" '
+                f'fill="{color}">{base}</text>'
+            )
+
+            # Spacer every 10 bases
+            if (abs_pos + 1) % 10 == 0 and ci < len(chunk) - 1:
+                svg.append(
+                    f'<line x1="{x + char_w + 1}" y1="{y - 11}" '
+                    f'x2="{x + char_w + 1}" y2="{y + 4}" '
+                    f'stroke="#e5e7eb" stroke-width="0.5"/>'
+                )
+
+    # Legend
+    ly = svg_h - 12
+    lx = label_w
+    for base, color in BASE_COLORS.items():
+        svg.append(f'<rect x="{lx}" y="{ly - 8}" width="8" height="8" rx="1" fill="{color}"/>')
+        svg.append(f'<text x="{lx + 12}" y="{ly}" font-size="9" fill="#6b7280">{base}</text>')
+        lx += 30
+    lx += 10
+    svg.append(f'<rect x="{lx}" y="{ly - 8}" width="8" height="8" rx="1" fill="#fee2e2" stroke="#dc2626" stroke-width="1"/>')
+    svg.append(f'<text x="{lx + 12}" y="{ly}" font-size="9" fill="#6b7280">Variant site</text>')
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_lollipop_plot(
+    variants: list[dict],
+    seq_length: int,
+    title: str = "",
+    width: int = 700,
+    height: int = 200,
+) -> str:
+    """Generate a lollipop plot showing variant positions along a gene with effect scores."""
+    if not variants:
+        return ""
+
+    ml, mr, mt, mb = 50, 30, 40, 40
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    if title:
+        svg.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="13" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    # Gene track (horizontal bar)
+    track_y = mt + ch * 0.7
+    svg.append(
+        f'<rect x="{ml}" y="{track_y - 4}" width="{cw}" height="8" '
+        f'fill="#dbeafe" rx="4" stroke="#93c5fd" stroke-width="1"/>'
+    )
+
+    # Position labels at ends
+    svg.append(
+        f'<text x="{ml}" y="{track_y + 20}" text-anchor="middle" '
+        f'font-size="9" fill="#9ca3af">1</text>'
+    )
+    svg.append(
+        f'<text x="{ml + cw}" y="{track_y + 20}" text-anchor="middle" '
+        f'font-size="9" fill="#9ca3af">{seq_length}</text>'
+    )
+
+    # Lollipops
+    scores = [v.get("score", 0) for v in variants]
+    max_score = max(abs(s) for s in scores) if scores else 1
+
+    for v in variants:
+        pos = v["pos"]
+        score = v.get("score", 0)
+        effect = v.get("known_effect", "uncertain")
+        color = EFFECT_COLORS.get(effect, "#6b7280")
+
+        x = ml + (pos / max(seq_length - 1, 1)) * cw
+        stem_h = max(20, abs(score) / max_score * (ch * 0.6))
+        circle_y = track_y - stem_h - 6
+
+        # Stem
+        svg.append(
+            f'<line x1="{x:.1f}" y1="{track_y - 4}" x2="{x:.1f}" y2="{circle_y + 5:.1f}" '
+            f'stroke="{color}" stroke-width="2"/>'
+        )
+        # Circle
+        svg.append(
+            f'<circle cx="{x:.1f}" cy="{circle_y:.1f}" r="5" fill="{color}" '
+            f'stroke="#fff" stroke-width="1.5"/>'
+        )
+        # Label
+        svg.append(
+            f'<text x="{x:.1f}" y="{circle_y - 9:.1f}" text-anchor="middle" '
+            f'font-size="8" fill="#374151" font-weight="600">{v.get("name", "")}</text>'
+        )
+
+    # Legend
+    lx = ml
+    for effect, color in EFFECT_COLORS.items():
+        svg.append(f'<circle cx="{lx + 4}" cy="{height - 10}" r="4" fill="{color}"/>')
+        svg.append(
+            f'<text x="{lx + 12}" y="{height - 6}" font-size="9" fill="#374151">'
+            f'{effect.title()}</text>'
+        )
+        lx += len(effect) * 7 + 24
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+def _make_score_comparison_chart(
+    gene_results: dict,
+    width: int = 800,
+    height: int = 350,
+) -> str:
+    """Generate a dot plot comparing VEP scores across all genes, colored by known effect."""
+    all_variants = []
+    for gene_name, gene_data in gene_results.items():
+        for v in gene_data["variants"]:
+            all_variants.append({
+                "gene": gene_name.split("(")[0].strip(),
+                "name": v["name"],
+                "score": v.get("score", 0),
+                "known_effect": v["known_effect"],
+            })
+
+    if not all_variants:
+        return ""
+
+    ml, mr, mt, mb = 120, 30, 40, 30
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    scores = [v["score"] for v in all_variants]
+    s_min, s_max = min(scores), max(scores)
+    s_pad = (s_max - s_min) * 0.1 or 0.5
+    s_min -= s_pad
+    s_max += s_pad
+    s_range = s_max - s_min or 1
+
+    def sx(s):
+        return ml + (s - s_min) / s_range * cw
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+        f'<text x="{width / 2}" y="22" text-anchor="middle" '
+        f'font-size="14" font-weight="600" fill="#1a1a2e">'
+        f'Variant Effect Scores — All Genes</text>',
+    ]
+
+    # Grid
+    for i in range(6):
+        gx = s_min + s_range * i / 5
+        px = sx(gx)
+        svg.append(
+            f'<line x1="{px:.1f}" y1="{mt}" x2="{px:.1f}" y2="{mt + ch}" '
+            f'stroke="#f3f4f6" stroke-width="1"/>'
+        )
+        svg.append(
+            f'<text x="{px:.1f}" y="{mt + ch + 16}" text-anchor="middle" '
+            f'font-size="10" fill="#9ca3af">{gx:.2f}</text>'
+        )
+
+    # Zero line
+    if s_min < 0 < s_max:
+        zx = sx(0)
+        svg.append(
+            f'<line x1="{zx:.1f}" y1="{mt}" x2="{zx:.1f}" y2="{mt + ch}" '
+            f'stroke="#374151" stroke-width="1" stroke-dasharray="4,3"/>'
+        )
+
+    # Rows per variant
+    row_h = ch / max(len(all_variants), 1)
+    for i, v in enumerate(all_variants):
+        y = mt + i * row_h + row_h / 2
+        color = EFFECT_COLORS.get(v["known_effect"], "#6b7280")
+        px = sx(v["score"])
+
+        # Label
+        label = f'{v["gene"]} {v["name"]}'
+        svg.append(
+            f'<text x="{ml - 8}" y="{y + 3:.1f}" text-anchor="end" '
+            f'font-size="9" fill="#374151">{label}</text>'
+        )
+        # Connector line
+        svg.append(
+            f'<line x1="{ml}" y1="{y:.1f}" x2="{px:.1f}" y2="{y:.1f}" '
+            f'stroke="{color}" stroke-width="1" opacity="0.3"/>'
+        )
+        # Dot
+        svg.append(
+            f'<circle cx="{px:.1f}" cy="{y:.1f}" r="5" fill="{color}" '
+            f'stroke="#fff" stroke-width="1"/>'
+        )
+
+    svg.append("</svg>")
+    return "\n".join(svg)
+
+
+# ------------------------------------------------------------------
+# Task 1: Load and validate gene variants
+# ------------------------------------------------------------------
+
+@cpu_env.task(cache="auto")
+async def load_variants(
+    variants_json: str = "",
+) -> flyte.io.Dir:
+    """Load gene variant definitions, validate sequences, and save to a temp directory."""
+    if variants_json:
+        genes = json.loads(variants_json)
+    else:
+        genes = DEFAULT_GENE_VARIANTS
+
+    # Validate
+    valid_bases = set("ATGC")
+    for gene_name, gene_data in genes.items():
+        seq = gene_data["sequence"].upper()
+        invalid = set(seq) - valid_bases
+        if invalid:
+            log.warning(f"{gene_name}: invalid bases {invalid} — removing them")
+            seq = "".join(b for b in seq if b in valid_bases)
+            gene_data["sequence"] = seq
+
+        for v in gene_data["variants"]:
+            pos = v["pos"]
+            if pos < 0 or pos >= len(seq):
+                log.warning(f"{gene_name} variant {v['name']}: position {pos} out of range [0, {len(seq)})")
+            elif seq[pos] != v["ref"]:
+                log.warning(f"{gene_name} variant {v['name']}: expected ref={v['ref']} at pos {pos}, found {seq[pos]}")
+
+    total_variants = sum(len(g["variants"]) for g in genes.values())
+    log.info(f"Loaded {len(genes)} genes with {total_variants} variants")
+
+    out_dir = tempfile.mkdtemp(prefix="genomic_vep_")
+    with open(os.path.join(out_dir, "genes.json"), "w") as f:
+        json.dump(genes, f)
+
+    return await flyte.io.Dir.from_local(out_dir)
+
+
+# ------------------------------------------------------------------
+# Task 2: Run Carbon model for variant effect scoring
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def score_variants(
+    variants_dir: flyte.io.Dir,
+    model_name: str = "HuggingFaceBio/Carbon-3B",
+) -> str:
+    """Score each variant using Carbon's log-likelihood ratio.
+
+    For each variant, we compute:
+        score = log P(alt_sequence) - log P(ref_sequence)
+
+    A negative score means the model considers the variant less likely than
+    the reference — suggestive of a damaging/pathogenic effect. A score near
+    zero means the model sees little difference (likely benign).
+    """
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    log.info(f"Loading Carbon model: {model_name}")
+
+    # Load model
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        log.warning("Running on CPU — inference will be slow. GPU recommended for production.")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        trust_remote_code=True,
+        dtype=torch.bfloat16 if device == "cuda" else torch.float32,
+    ).to(device)
+    model.eval()
+
+    # Load variants
+    variants_path = await variants_dir.download()
+    with open(os.path.join(variants_path, "genes.json")) as f:
+        genes = json.load(f)
+
+    results = {}
+    total_variants = sum(len(g["variants"]) for g in genes.values())
+    scored = 0
+
+    progress_html = """
+    <h2>Carbon Variant Effect Scoring</h2>
+    <div class="card">
+        <b>Model:</b> {model}<br>
+        <b>Device:</b> {device}<br>
+        <b>Progress:</b> {scored}/{total} variants scored
+    </div>
+    """
+
+    for gene_name, gene_data in genes.items():
+        ref_seq = gene_data["sequence"]
+        gene_results = {
+            "description": gene_data.get("description", ""),
+            "sequence": ref_seq,
+            "variants": [],
+        }
+
+        # Score reference sequence
+        ref_prompt = f"<dna>{ref_seq}"
+        ref_inputs = tokenizer(ref_prompt, return_tensors="pt", add_special_tokens=False).to(device)
+
+        with torch.no_grad():
+            ref_output = model(**ref_inputs, labels=ref_inputs["input_ids"])
+            ref_loss = ref_output.loss.item()
+            ref_ll = -ref_loss * ref_inputs["input_ids"].shape[1]
+
+        for variant in gene_data["variants"]:
+            scored += 1
+            await flyte.report.replace.aio(
+                _wrap_report(progress_html.format(
+                    model=model_name, device=device, scored=scored, total=total_variants
+                )),
+                do_flush=True,
+            )
+
+            # Create mutant sequence
+            pos = variant["pos"]
+            alt_seq = ref_seq[:pos] + variant["alt"] + ref_seq[pos + 1:]
+
+            # Score mutant
+            alt_prompt = f"<dna>{alt_seq}"
+            alt_inputs = tokenizer(alt_prompt, return_tensors="pt", add_special_tokens=False).to(device)
+
+            with torch.no_grad():
+                alt_output = model(**alt_inputs, labels=alt_inputs["input_ids"])
+                alt_loss = alt_output.loss.item()
+                alt_ll = -alt_loss * alt_inputs["input_ids"].shape[1]
+
+            # VEP score: positive = model prefers alt (likely benign), negative = model prefers ref (likely pathogenic)
+            vep_score = alt_ll - ref_ll
+
+            gene_results["variants"].append({
+                **variant,
+                "score": round(vep_score, 4),
+                "ref_ll": round(ref_ll, 4),
+                "alt_ll": round(alt_ll, 4),
+            })
+
+            log.info(
+                f"  {gene_name} | {variant['name']}: score={vep_score:.4f} "
+                f"(known: {variant['known_effect']})"
+            )
+
+        results[gene_name] = gene_results
+
+    # Generate scoring report
+    html_parts = [
+        "<h2>Carbon Variant Effect Scoring</h2>",
+        '<div class="stat-grid">',
+        f'<div class="stat"><div class="value">{len(genes)}</div><div class="label">Genes</div></div>',
+        f'<div class="stat"><div class="value">{total_variants}</div><div class="label">Variants Scored</div></div>',
+        f'<div class="stat"><div class="value">{model_name.split("/")[-1]}</div><div class="label">Model</div></div>',
+        f'<div class="stat"><div class="value">{device.upper()}</div><div class="label">Device</div></div>',
+        "</div>",
+    ]
+
+    # Per-gene tables
+    for gene_name, gene_data in results.items():
+        html_parts.append(f'<h3>{gene_name}</h3>')
+        html_parts.append(f'<div class="note">{gene_data["description"]}</div>')
+        html_parts.append("<table><tr><th>Variant</th><th>Ref</th><th>Alt</th><th>VEP Score</th><th>Known Effect</th><th>Clinical</th></tr>")
+
+        for v in gene_data["variants"]:
+            badge = EFFECT_BADGES.get(v["known_effect"], "badge-info")
+            direction = "damaging" if v["score"] < -0.1 else "neutral" if abs(v["score"]) <= 0.1 else "tolerated"
+            html_parts.append(
+                f'<tr>'
+                f'<td><b>{v["name"]}</b></td>'
+                f'<td style="color:{BASE_COLORS.get(v["ref"], "#333")};font-weight:700">{v["ref"]}</td>'
+                f'<td style="color:{BASE_COLORS.get(v["alt"], "#333")};font-weight:700">{v["alt"]}</td>'
+                f'<td><b>{v["score"]:.4f}</b> <span style="font-size:0.8em;color:#6c757d">({direction})</span></td>'
+                f'<td><span class="badge {badge}">{v["known_effect"]}</span></td>'
+                f'<td style="font-size:0.85em">{v.get("clinical", "")}</td>'
+                f'</tr>'
+            )
+        html_parts.append("</table>")
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+
+    return json.dumps(results)
+
+
+# ------------------------------------------------------------------
+# Task 3: Analyze and visualize variant effects
+# ------------------------------------------------------------------
+
+@cpu_env.task(report=True)
+async def analyze_effects(
+    scores_json: str,
+    variants_dir: flyte.io.Dir,
+) -> str:
+    """Analyze VEP scores: classification accuracy, gene-level summaries, and rich visualizations."""
+    results = json.loads(scores_json)
+
+    variants_path = await variants_dir.download()
+    with open(os.path.join(variants_path, "genes.json")) as f:
+        genes = json.load(f)
+
+    html_parts = ["<h2>Variant Effect Analysis</h2>"]
+
+    # ------------------------------------------------------------------
+    # Overall accuracy: does the model's score direction match known labels?
+    # ------------------------------------------------------------------
+    all_variants = []
+    correct = 0
+    total_known = 0
+    true_pos = 0
+    false_pos = 0
+    true_neg = 0
+    false_neg = 0
+
+    for gene_name, gene_data in results.items():
+        for v in gene_data["variants"]:
+            all_variants.append({**v, "gene": gene_name})
+            if v["known_effect"] in ("pathogenic", "benign"):
+                total_known += 1
+                predicted_pathogenic = v["score"] < -0.05
+                actual_pathogenic = v["known_effect"] == "pathogenic"
+                if predicted_pathogenic == actual_pathogenic:
+                    correct += 1
+                if predicted_pathogenic and actual_pathogenic:
+                    true_pos += 1
+                elif predicted_pathogenic and not actual_pathogenic:
+                    false_pos += 1
+                elif not predicted_pathogenic and actual_pathogenic:
+                    false_neg += 1
+                else:
+                    true_neg += 1
+
+    accuracy = correct / total_known if total_known else 0
+    precision = true_pos / (true_pos + false_pos) if (true_pos + false_pos) else 0
+    recall = true_pos / (true_pos + false_neg) if (true_pos + false_neg) else 0
+
+    html_parts.append('<div class="stat-grid">')
+    html_parts.append(f'<div class="stat"><div class="value">{accuracy:.0%}</div><div class="label">Direction Accuracy</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{precision:.0%}</div><div class="label">Precision (Pathogenic)</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{recall:.0%}</div><div class="label">Recall (Pathogenic)</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{len(all_variants)}</div><div class="label">Total Variants</div></div>')
+    html_parts.append("</div>")
+
+    html_parts.append(
+        '<div class="note">'
+        "<b>How to read VEP scores:</b> Negative scores mean Carbon considers the variant "
+        "less likely than the reference sequence — suggestive of a damaging effect. Scores near "
+        "zero indicate the model sees little difference (likely benign). The magnitude indicates "
+        "confidence."
+        "</div>"
+    )
+
+    # ------------------------------------------------------------------
+    # Cross-gene score comparison dot plot
+    # ------------------------------------------------------------------
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_score_comparison_chart(results))
+    html_parts.append("</div>")
+
+    # ------------------------------------------------------------------
+    # Per-gene visualizations
+    # ------------------------------------------------------------------
+    for gene_name, gene_data in results.items():
+        short_name = gene_name.split("(")[0].strip()
+        html_parts.append(f'<h3>{gene_name}</h3>')
+        html_parts.append(f'<div class="note">{gene_data["description"]}</div>')
+
+        # DNA track with variant positions highlighted
+        html_parts.append('<div class="chart-container">')
+        html_parts.append(_make_dna_track(
+            gene_data["sequence"],
+            gene_data["variants"],
+            gene_name=f"{short_name} Reference Sequence",
+        ))
+        html_parts.append("</div>")
+
+        # Lollipop plot
+        html_parts.append('<div class="chart-container">')
+        html_parts.append(_make_lollipop_plot(
+            gene_data["variants"],
+            len(gene_data["sequence"]),
+            title=f"{short_name} — Variant Positions & Effect Scores",
+        ))
+        html_parts.append("</div>")
+
+        # Score bar chart for this gene
+        variant_names = [v["name"] for v in gene_data["variants"]]
+        variant_scores = [v["score"] for v in gene_data["variants"]]
+        html_parts.append('<div class="chart-container">')
+        html_parts.append(_make_bar_chart(
+            variant_names,
+            {"VEP Score": variant_scores},
+            title=f"{short_name} — Log-Likelihood Ratio Scores",
+            colors=[EFFECT_COLORS.get(v["known_effect"], "#6b7280") for v in gene_data["variants"]],
+            value_format=".3f",
+        ))
+        html_parts.append("</div>")
+
+        # Variant detail cards
+        for v in gene_data["variants"]:
+            badge = EFFECT_BADGES.get(v["known_effect"], "badge-info")
+            score_color = "#dc2626" if v["score"] < -0.1 else "#059669" if v["score"] > 0.05 else "#f59e0b"
+            html_parts.append(
+                f'<div class="gene-card">'
+                f'<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">'
+                f'<b style="font-size:1.1em">{v["name"]}</b>'
+                f'<span class="badge {badge}">{v["known_effect"]}</span>'
+                f'</div>'
+                f'<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px;">'
+                f'<div><span style="color:#6c757d;font-size:0.85em">Ref base:</span> '
+                f'<b style="color:{BASE_COLORS.get(v["ref"], "#333")}">{v["ref"]}</b></div>'
+                f'<div><span style="color:#6c757d;font-size:0.85em">Alt base:</span> '
+                f'<b style="color:{BASE_COLORS.get(v["alt"], "#333")}">{v["alt"]}</b></div>'
+                f'<div><span style="color:#6c757d;font-size:0.85em">VEP Score:</span> '
+                f'<b style="color:{score_color}">{v["score"]:.4f}</b></div>'
+                f'</div>'
+                f'<div style="margin-top:8px;font-size:0.9em;color:#374151">{v.get("clinical", "")}</div>'
+                f'</div>'
+            )
+
+    # ------------------------------------------------------------------
+    # Confusion matrix as heatmap
+    # ------------------------------------------------------------------
+    html_parts.append("<h3>Classification Performance</h3>")
+    html_parts.append(
+        '<div class="note">'
+        "Using a simple threshold (score &lt; -0.05 = predicted pathogenic). "
+        "This is zero-shot — no training on these specific variants."
+        "</div>"
+    )
+
+    conf_matrix = [[true_pos, false_neg], [false_pos, true_neg]]
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_heatmap(
+        conf_matrix,
+        ["Actual Pathogenic", "Actual Benign"],
+        ["Predicted Pathogenic", "Predicted Benign"],
+        title="Confusion Matrix (Known Variants Only)",
+        value_format=".0f",
+        width=400,
+        height=300,
+    ))
+    html_parts.append("</div>")
+
+    # ------------------------------------------------------------------
+    # Score distribution by known effect
+    # ------------------------------------------------------------------
+    html_parts.append("<h3>Score Distribution by Known Effect</h3>")
+
+    pathogenic_scores = [v["score"] for v in all_variants if v["known_effect"] == "pathogenic"]
+    benign_scores = [v["score"] for v in all_variants if v["known_effect"] == "benign"]
+    uncertain_scores = [v["score"] for v in all_variants if v["known_effect"] == "uncertain"]
+
+    stats_html = '<div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:12px;">'
+    for label, scores, color in [
+        ("Pathogenic", pathogenic_scores, "#dc2626"),
+        ("Benign", benign_scores, "#059669"),
+        ("Uncertain", uncertain_scores, "#f59e0b"),
+    ]:
+        if scores:
+            mean_s = sum(scores) / len(scores)
+            min_s = min(scores)
+            max_s = max(scores)
+            stats_html += (
+                f'<div class="gene-card" style="border-left:4px solid {color}">'
+                f'<b style="color:{color}">{label}</b> (n={len(scores)})<br>'
+                f'Mean: {mean_s:.4f}<br>'
+                f'Range: [{min_s:.4f}, {max_s:.4f}]'
+                f'</div>'
+            )
+    stats_html += "</div>"
+    html_parts.append(stats_html)
+
+    # Summary
+    analysis = {
+        "total_variants": len(all_variants),
+        "total_known": total_known,
+        "accuracy": round(accuracy, 4),
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "true_pos": true_pos,
+        "false_pos": false_pos,
+        "true_neg": true_neg,
+        "false_neg": false_neg,
+        "pathogenic_mean_score": round(sum(pathogenic_scores) / len(pathogenic_scores), 4) if pathogenic_scores else None,
+        "benign_mean_score": round(sum(benign_scores) / len(benign_scores), 4) if benign_scores else None,
+    }
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+    return json.dumps(analysis)
+
+
+# ------------------------------------------------------------------
+# Task 4: Generate comprehensive summary report
+# ------------------------------------------------------------------
+
+@cpu_env.task(report=True)
+async def generate_summary(
+    scores_json: str,
+    analysis_json: str,
+) -> str:
+    """Generate the final summary report combining all results."""
+    results = json.loads(scores_json)
+    analysis = json.loads(analysis_json)
+
+    html_parts = [
+        "<h2>Genomic Variant Effect Prediction — Summary</h2>",
+        '<div class="note">'
+        "This pipeline uses <b>HuggingFace Carbon</b>, an autoregressive genomic foundation model "
+        "trained on 1 trillion tokens of DNA sequence, to perform <b>zero-shot variant effect "
+        "prediction</b>. No fine-tuning or labeled training data was used — the model scores "
+        "variants purely based on its learned understanding of DNA sequence grammar."
+        "</div>",
+    ]
+
+    # Key metrics
+    html_parts.append('<div class="stat-grid">')
+    html_parts.append(f'<div class="stat"><div class="value">{len(results)}</div><div class="label">Genes Analyzed</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{analysis["total_variants"]}</div><div class="label">Variants Scored</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{analysis["accuracy"]:.0%}</div><div class="label">Direction Accuracy</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{analysis["precision"]:.0%}</div><div class="label">Precision</div></div>')
+    html_parts.append(f'<div class="stat"><div class="value">{analysis["recall"]:.0%}</div><div class="label">Recall</div></div>')
+    html_parts.append("</div>")
+
+    # Gene summary table
+    html_parts.append("<h3>Per-Gene Summary</h3>")
+    html_parts.append(
+        "<table><tr><th>Gene</th><th>Variants</th><th>Mean Score</th>"
+        "<th>Pathogenic</th><th>Benign</th><th>Uncertain</th></tr>"
+    )
+
+    for gene_name, gene_data in results.items():
+        variants = gene_data["variants"]
+        scores = [v["score"] for v in variants]
+        mean_score = sum(scores) / len(scores) if scores else 0
+        n_path = sum(1 for v in variants if v["known_effect"] == "pathogenic")
+        n_benign = sum(1 for v in variants if v["known_effect"] == "benign")
+        n_unc = sum(1 for v in variants if v["known_effect"] == "uncertain")
+        short = gene_name.split("(")[0].strip()
+
+        html_parts.append(
+            f"<tr><td><b>{short}</b></td><td>{len(variants)}</td>"
+            f"<td>{mean_score:.4f}</td>"
+            f'<td><span class="badge badge-danger">{n_path}</span></td>'
+            f'<td><span class="badge badge-success">{n_benign}</span></td>'
+            f'<td><span class="badge badge-warning">{n_unc}</span></td></tr>'
+        )
+    html_parts.append("</table>")
+
+    # Cross-gene heatmap: gene x metric
+    gene_names = [g.split("(")[0].strip() for g in results.keys()]
+    metrics = ["Mean Score", "Min Score", "Max Score", "# Variants"]
+    matrix = []
+    for gene_data in results.values():
+        scores = [v["score"] for v in gene_data["variants"]]
+        matrix.append([
+            sum(scores) / len(scores) if scores else 0,
+            min(scores) if scores else 0,
+            max(scores) if scores else 0,
+            len(scores),
+        ])
+
+    html_parts.append("<h3>Gene-Level Metrics</h3>")
+    html_parts.append('<div class="chart-container">')
+    html_parts.append(_make_heatmap(
+        matrix,
+        gene_names,
+        metrics,
+        title="Gene-Level VEP Score Summary",
+        value_format=".2f",
+        width=600,
+        height=350,
+    ))
+    html_parts.append("</div>")
+
+    # All variants ranked by score (most damaging first)
+    html_parts.append("<h3>All Variants Ranked by Impact</h3>")
+    all_vars_sorted = []
+    for gene_name, gene_data in results.items():
+        for v in gene_data["variants"]:
+            all_vars_sorted.append({**v, "gene": gene_name.split("(")[0].strip()})
+    all_vars_sorted.sort(key=lambda x: x["score"])
+
+    html_parts.append(
+        "<table><tr><th>#</th><th>Gene</th><th>Variant</th><th>Score</th>"
+        "<th>Known</th><th>Clinical Significance</th></tr>"
+    )
+    for i, v in enumerate(all_vars_sorted):
+        badge = EFFECT_BADGES.get(v["known_effect"], "badge-info")
+        score_color = "#dc2626" if v["score"] < -0.1 else "#059669" if v["score"] > 0.05 else "#f59e0b"
+        html_parts.append(
+            f'<tr><td>{i + 1}</td><td><b>{v["gene"]}</b></td><td>{v["name"]}</td>'
+            f'<td style="color:{score_color};font-weight:700">{v["score"]:.4f}</td>'
+            f'<td><span class="badge {badge}">{v["known_effect"]}</span></td>'
+            f'<td style="font-size:0.85em">{v.get("clinical", "")}</td></tr>'
+        )
+    html_parts.append("</table>")
+
+    # Method note
+    html_parts.append(
+        '<div class="note">'
+        "<b>Method:</b> Zero-shot variant effect prediction using log-likelihood ratio scoring. "
+        "For each variant, we compute score = log P(mutant sequence | Carbon) - log P(reference sequence | Carbon). "
+        "Negative scores indicate the model considers the mutant less probable than the reference, "
+        "which correlates with pathogenicity. This approach requires no fine-tuning and generalizes "
+        "across genes and variant types.<br><br>"
+        "<b>Limitations:</b> These are short sequence windows — real clinical VEP would use longer "
+        "genomic context (Carbon supports up to 786kbp). The threshold for pathogenicity classification "
+        "(-0.05) is a simple heuristic; clinical use requires calibrated thresholds per gene."
+        "</div>"
+    )
+
+    await flyte.report.replace.aio(_wrap_report("\n".join(html_parts)), do_flush=True)
+    return json.dumps({"status": "complete", "analysis": analysis})
+
+
+# ------------------------------------------------------------------
+# Pipeline orchestrator
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@cpu_env.task(report=True)
+async def pipeline(
+    variants_json: str = "",
+    model_name: str = "HuggingFaceBio/Carbon-3B",
+) -> tuple[str, str]:
+    """
+    End-to-end genomic variant effect prediction pipeline.
+
+    Returns (scores JSON, analysis JSON).
+
+    1. Load and validate gene variants
+    2. Score variants with Carbon (log-likelihood ratio)
+    3. Analyze effects — accuracy, visualizations, classification
+    4. Generate comprehensive summary report
+    """
+    log.info("Starting genomic variant effect prediction pipeline...")
+
+    def _pipeline_progress(step: int, label: str) -> str:
+        steps = [
+            "Load Variants",
+            "Carbon Scoring",
+            "Analyze Effects",
+            "Generate Summary",
+        ]
+        dots = ""
+        for i, s in enumerate(steps):
+            if i + 1 < step:
+                icon = '<span style="color:#2563eb;">&#10003;</span>'
+            elif i + 1 == step:
+                icon = '<span style="color:#2563eb;">&#9679;</span>'
+            else:
+                icon = '<span style="color:#adb5bd;">&#9675;</span>'
+            dots += f"<span style='margin:0 8px;'>{icon} {s}</span>"
+        return f"""
+        <h2>Genomic Variant Effect Prediction</h2>
+        <div class="card" style="text-align:center;">{dots}</div>
+        <p>{label}</p>
+        """
+
+    # Stage 1: Load variants
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(1, "Loading and validating gene variants...")),
+        do_flush=True,
+    )
+    var_dir = await load_variants(variants_json=variants_json)
+
+    # Stage 2: Score with Carbon
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(2, "Running Carbon model for variant effect scoring...")),
+        do_flush=True,
+    )
+    scores_json = await score_variants(variants_dir=var_dir, model_name=model_name)
+
+    # Stage 3: Analyze effects
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(3, "Analyzing variant effects and generating visualizations...")),
+        do_flush=True,
+    )
+    analysis_json = await analyze_effects(scores_json=scores_json, variants_dir=var_dir)
+
+    # Stage 4: Summary
+    await flyte.report.replace.aio(
+        _wrap_report(_pipeline_progress(4, "Generating comprehensive summary report...")),
+        do_flush=True,
+    )
+    summary_json = await generate_summary(scores_json=scores_json, analysis_json=analysis_json)
+
+    # Final pipeline report
+    analysis = json.loads(analysis_json)
+    results = json.loads(scores_json)
+
+    final_html = f"""
+    <h2>Pipeline Complete</h2>
+    <div class="stat-grid">
+      <div class="stat"><div class="value">{len(results)}</div><div class="label">Genes Analyzed</div></div>
+      <div class="stat"><div class="value">{analysis['total_variants']}</div><div class="label">Variants Scored</div></div>
+      <div class="stat"><div class="value">{analysis['accuracy']:.0%}</div><div class="label">Direction Accuracy</div></div>
+      <div class="stat"><div class="value">{analysis['precision']:.0%}</div><div class="label">Precision</div></div>
+      <div class="stat"><div class="value">{analysis['recall']:.0%}</div><div class="label">Recall</div></div>
+    </div>
+    <div class="card">
+      <b>Model:</b> HuggingFace Carbon |
+      <b>Method:</b> Zero-shot log-likelihood ratio scoring |
+      <b>Genes:</b> {', '.join(g.split('(')[0].strip() for g in results.keys())}
+    </div>
+    <div class="note">
+      All 4 pipeline stages completed successfully. View individual task reports for detailed
+      visualizations including DNA sequence tracks, variant lollipop plots, VEP score charts,
+      confusion matrices, and ranked variant tables.
+    </div>
+    """
+
+    await flyte.report.replace.aio(_wrap_report(final_html), do_flush=True)
+
+    log.info("Pipeline complete.")
+    return scores_json, analysis_json
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/langgraph_agent_research/graph.py
+++ b/v2/tutorials/langgraph_agent_research/graph.py
@@ -28,7 +28,7 @@ import operator
 from typing import Annotated, TypedDict
 
 import flyte
-from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage
 from langgraph.graph import StateGraph, MessagesState, START, END
 from langgraph.prebuilt import ToolNode
@@ -43,15 +43,15 @@ log = logging.getLogger(__name__)
 # ------------------------------------------------------------------
 
 def build_research_subgraph(
-    openai_api_key: str,
+    anthropic_api_key: str,
     tavily_api_key: str,
     max_searches: int = 3,
-    model: str = "gpt-4.1-nano",
+    model: str = "claude-3-5-haiku-latest",
 ):
     """Build a ReAct research agent that uses Tavily search."""
     web_search = create_search_tool(tavily_api_key)
     tools = [web_search]
-    llm = ChatOpenAI(model=model, api_key=openai_api_key).bind_tools(tools)
+    llm = ChatAnthropic(model=model, api_key=anthropic_api_key).bind_tools(tools)
 
     system_prompt = f"""\
 You are a research agent. Your job is to thoroughly research a topic by searching the web. \

--- a/v2/tutorials/langgraph_agent_research/graph.py
+++ b/v2/tutorials/langgraph_agent_research/graph.py
@@ -1,0 +1,241 @@
+"""
+Research agent pipeline with Flyte-backed compute.
+
+LangGraph controls the pipeline logic: planning, routing, quality gates, looping.
+Flyte provides the compute: each step runs as a separate task with its own resources.
+
+The pipeline graph:
+
+    START → plan → research (fan-out via Send → Flyte tasks) → synthesize
+                                                                    │
+                                                              quality_check
+                                                              ╱           ╲
+                                                    gaps found?         good enough
+                                                        │                   │
+                                                  identify_gaps            END
+                                                        │
+                                                   research (again, with new topics)
+                                                        │
+                                                   synthesize → quality_check → ...
+
+The ReAct research subgraph (runs inside each Flyte task):
+
+    agent → (tool calls?) → tools → agent → ... → END
+"""
+
+import logging
+import operator
+from typing import Annotated, TypedDict
+
+import flyte
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import SystemMessage
+from langgraph.graph import StateGraph, MessagesState, START, END
+from langgraph.prebuilt import ToolNode
+from langgraph.types import Send
+from tools.search import create_search_tool
+
+log = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------
+# ReAct research subgraph (runs inside Flyte tasks)
+# ------------------------------------------------------------------
+
+def build_research_subgraph(
+    openai_api_key: str,
+    tavily_api_key: str,
+    max_searches: int = 3,
+    model: str = "gpt-4.1-nano",
+):
+    """Build a ReAct research agent that uses Tavily search."""
+    web_search = create_search_tool(tavily_api_key)
+    tools = [web_search]
+    llm = ChatOpenAI(model=model, api_key=openai_api_key).bind_tools(tools)
+
+    system_prompt = f"""\
+You are a research agent. Your job is to thoroughly research a topic by searching the web. \
+Use the web_search tool up to {max_searches} times to gather information from different angles. \
+After gathering enough information, write a clear research summary with key findings and sources."""
+
+    @flyte.trace
+    async def agent(state: MessagesState) -> MessagesState:
+        messages = [SystemMessage(content=system_prompt)] + state["messages"]
+        response = llm.invoke(messages)
+
+        if hasattr(response, "tool_calls") and response.tool_calls:
+            for tc in response.tool_calls:
+                log.info(f"[Research] Tool call: {tc['name']}({tc['args']})")
+        elif response.content:
+            log.info(f"[Research] Response: {response.content[:200]}")
+
+        return {"messages": [response]}
+
+    @flyte.trace
+    async def should_continue(state: MessagesState) -> str:
+        last = state["messages"][-1]
+        if hasattr(last, "tool_calls") and last.tool_calls:
+            return "tools"
+        return "__end__"
+
+    graph = StateGraph(MessagesState)
+    graph.add_node("agent", agent)
+    graph.add_node("tools", ToolNode(tools))
+    graph.set_entry_point("agent")
+    graph.add_conditional_edges("agent", should_continue, {
+        "tools": "tools",
+        "__end__": "__end__",
+    })
+    graph.add_edge("tools", "agent")
+
+    return graph.compile()
+
+
+# ------------------------------------------------------------------
+# Research pipeline graph — nodes dispatch to Flyte tasks
+# ------------------------------------------------------------------
+
+def build_pipeline_graph(
+    plan_task,
+    research_task,
+    synthesize_task,
+    quality_check_task,
+    **_kwargs,
+):
+    """
+    Build the research pipeline graph.
+
+    Each node dispatches to a Flyte task, making every step visible
+    in the Flyte UI with its own compute, reports, and logs.
+
+    Args:
+        plan_task: Flyte task (query, num_topics) → list[str]
+        research_task: Flyte task (topic, max_searches) → TopicReport
+        synthesize_task: Flyte task (query, results) → str
+        quality_check_task: Flyte task (query, synthesis) → QualityResult
+    """
+    # Import here to avoid circular imports
+    from models import TopicReport
+
+    # State definition — kept inside the function so Flyte doesn't wrap it
+    class PipelineState(TypedDict, total=False):
+        query: str
+        num_topics: int
+        max_searches: int
+        iteration: int
+        max_iterations: int
+        topics: list[str]
+        research_results: Annotated[list[dict], operator.add]
+        synthesis: str
+        score: int
+        gaps: list[str]
+        final_report: str
+
+    # -- Plan node → dispatches to plan_topics Flyte task ---------------
+    async def plan(state: PipelineState) -> dict:
+        """Split the query into focused sub-topics via Flyte task."""
+        query = state["query"]
+        num_topics = state.get("num_topics", 3)
+
+        topics = await plan_task(query, num_topics)
+        log.info(f"[Plan] {len(topics)} sub-topics: {topics}")
+        return {"topics": topics, "iteration": 1}
+
+    # -- Fan-out to research --------------------------------------------
+    def route_to_research(state: PipelineState) -> list[Send]:
+        """Create a Send for each topic — each dispatches to a Flyte task."""
+        topics = state.get("gaps") or state["topics"]
+        max_searches = state.get("max_searches", 2)
+        return [
+            Send("research", {"topic": t, "max_searches": max_searches})
+            for t in topics
+        ]
+
+    # -- Research node → dispatches to research_topic Flyte task --------
+    async def research(state: dict) -> dict:
+        """Run research on a single topic via a Flyte task."""
+        topic = state["topic"]
+        max_searches = state.get("max_searches", 2)
+        log.info(f"[Research] Dispatching to Flyte task: {topic}")
+
+        result = await research_task(topic, max_searches)
+        log.info(f"[Research] Flyte task complete: {topic}")
+
+        return {"research_results": [{"topic": result.topic, "report": result.report}]}
+
+    # -- Synthesize node → dispatches to synthesize Flyte task ----------
+    async def synthesize_node(state: PipelineState) -> dict:
+        """Combine all research results via Flyte task."""
+        query = state["query"]
+        results = [TopicReport(**r) for r in state["research_results"]]
+        iteration = state.get("iteration", 1)
+
+        synthesis = await synthesize_task.override(
+            short_name=f"synthesize-{iteration}"
+        )(query, results)
+
+        log.info(f"[Synthesize] Combined {len(results)} reports (iteration {iteration})")
+        return {"synthesis": synthesis}
+
+    # -- Quality check node → dispatches to quality_check Flyte task ----
+    async def quality_check_node(state: PipelineState) -> dict:
+        """Evaluate the synthesis via Flyte task."""
+        query = state["query"]
+        synthesis = state["synthesis"]
+        iteration = state.get("iteration", 1)
+        max_iterations = state.get("max_iterations", 2)
+
+        result = await quality_check_task.override(
+            short_name=f"quality-{iteration}"
+        )(query, synthesis)
+
+        score = result.score
+        gaps = result.gaps
+
+        # Don't loop forever
+        if iteration >= max_iterations:
+            gaps = []
+            log.info(f"[Quality] Max iterations reached ({max_iterations}), finishing")
+
+        log.info(f"[Quality] Score: {score}/10, Gaps: {len(gaps)} (iteration {iteration})")
+        return {"score": score, "gaps": gaps, "iteration": iteration + 1}
+
+    # -- Routing after quality check ------------------------------------
+    def after_quality_check(state: PipelineState) -> str:
+        """If gaps found, research more. Otherwise, finalize."""
+        if state.get("gaps"):
+            log.info(f"[Quality] Gaps found, researching further: {state['gaps']}")
+            return "research_more"
+        return "finalize"
+
+    # -- Identify gaps node (triggers Send fan-out on gaps) -------------
+    async def identify_gaps(state: PipelineState) -> dict:
+        """Pass-through node to trigger research fan-out on gaps."""
+        return {}
+
+    # -- Finalize node --------------------------------------------------
+    async def finalize(state: PipelineState) -> dict:
+        """Set the final report."""
+        return {"final_report": state["synthesis"]}
+
+    # -- Wire the graph -------------------------------------------------
+    graph = StateGraph(PipelineState)
+    graph.add_node("plan", plan)
+    graph.add_node("research", research)
+    graph.add_node("synthesize", synthesize_node)
+    graph.add_node("quality_check", quality_check_node)
+    graph.add_node("identify_gaps", identify_gaps)
+    graph.add_node("finalize", finalize)
+
+    graph.add_edge(START, "plan")
+    graph.add_conditional_edges("plan", route_to_research, ["research"])
+    graph.add_edge("research", "synthesize")
+    graph.add_edge("synthesize", "quality_check")
+    graph.add_conditional_edges("quality_check", after_quality_check, {
+        "research_more": "identify_gaps",
+        "finalize": "finalize",
+    })
+    graph.add_conditional_edges("identify_gaps", route_to_research, ["research"])
+    graph.add_edge("finalize", END)
+
+    return graph.compile()

--- a/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py
+++ b/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #    "flyte>=2.4.0",
 #    "langgraph>=1.0.7",
-#    "langchain-openai",
+#    "langchain-anthropic",
 #    "tavily-python",
 #    "markdown",
 #    "pydantic",
@@ -27,14 +27,14 @@ env = flyte.TaskEnvironment(
     name="langgraph-agent-research",
     image=main_img,
     secrets=[
-        flyte.Secret(key="openai-api-key", as_env_var="OPENAI_API_KEY"),
-        flyte.Secret(key="tavily-api-key", as_env_var="TAVILY_API_KEY"),
+        flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
+        flyte.Secret(key="tavily_api_key", as_env_var="TAVILY_API_KEY"),
     ],
     resources=flyte.Resources(cpu=2, memory="2Gi"),
 )
 # {{/docs-fragment env}}
 
-from langchain_openai import ChatOpenAI
+from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage
 
 from models import TopicReport, QualityResult, PipelineResult
@@ -47,7 +47,7 @@ logging.getLogger("graph").setLevel(logging.INFO)
 logging.getLogger("tools.search").setLevel(logging.INFO)
 
 
-MODEL = "gpt-4.1-nano"
+MODEL = "claude-3-5-haiku-latest"
 
 
 def md_to_html(text: str) -> str:
@@ -69,8 +69,8 @@ async def plan_topics(query: str, num_topics: int = 3) -> list[str]:
     )
     await flyte.report.flush.aio()
 
-    openai_api_key = os.getenv("OPENAI_API_KEY")
-    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+    llm = ChatAnthropic(model=MODEL, api_key=anthropic_api_key)
 
     response = llm.invoke(
         f"Break this research question into exactly {num_topics} focused sub-topics. "
@@ -98,14 +98,14 @@ async def research_topic(topic: str, max_searches: int = 2) -> TopicReport:
     """Run the ReAct research agent on a single sub-topic."""
     log.info(f"[Research Task] Starting: {topic}")
 
-    openai_api_key = os.getenv("OPENAI_API_KEY")
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
     tavily_api_key = os.getenv("TAVILY_API_KEY")
 
     await flyte.report.replace.aio(f"<h2>Researching: {topic}</h2><p>Running searches...</p>")
     await flyte.report.flush.aio()
 
     graph = build_research_subgraph(
-        openai_api_key=openai_api_key,
+        anthropic_api_key=anthropic_api_key,
         tavily_api_key=tavily_api_key,
         max_searches=max_searches,
         model=MODEL,
@@ -130,8 +130,8 @@ async def synthesize(query: str, results: list[TopicReport]) -> str:
     )
     await flyte.report.flush.aio()
 
-    openai_api_key = os.getenv("OPENAI_API_KEY")
-    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+    llm = ChatAnthropic(model=MODEL, api_key=anthropic_api_key)
 
     sections = "\n\n---\n\n".join(
         f"## {r.topic}\n\n{r.report}" for r in results
@@ -163,8 +163,8 @@ async def quality_check(query: str, synthesis: str) -> QualityResult:
     )
     await flyte.report.flush.aio()
 
-    openai_api_key = os.getenv("OPENAI_API_KEY")
-    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+    llm = ChatAnthropic(model=MODEL, api_key=anthropic_api_key)
 
     response = llm.invoke(
         f'Evaluate this research report for the question: {query}\n\n'
@@ -219,12 +219,12 @@ async def research_pipeline(
     """
     log.info(f"Starting research pipeline: {query}")
 
-    openai_api_key = os.getenv("OPENAI_API_KEY")
+    anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
     tavily_api_key = os.getenv("TAVILY_API_KEY")
 
     # Build the pipeline graph, passing all Flyte tasks as compute backends
     pipeline = build_pipeline_graph(
-        openai_api_key=openai_api_key,
+        anthropic_api_key=anthropic_api_key,
         tavily_api_key=tavily_api_key,
         plan_task=plan_topics,
         research_task=research_topic,
@@ -242,7 +242,7 @@ async def research_pipeline(
 <h2>Research Pipeline</h2>\
 <img src="data:image/png;base64,{img_b64}" alt="Research pipeline" />""")
 
-    subgraph = build_research_subgraph(openai_api_key, tavily_api_key, max_searches, model=MODEL)
+    subgraph = build_research_subgraph(anthropic_api_key, tavily_api_key, max_searches, model=MODEL)
     sub_png = subgraph.get_graph().draw_mermaid_png()
     sub_b64 = base64.b64encode(sub_png).decode()
     graph_tab.log(f"""\

--- a/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py
+++ b/v2/tutorials/langgraph_agent_research/langgraph_agent_research.py
@@ -1,0 +1,297 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "langgraph>=1.0.7",
+#    "langchain-openai",
+#    "tavily-python",
+#    "markdown",
+#    "pydantic",
+# ]
+# main = "research_pipeline"
+# params = ""
+# ///
+import json
+import os
+import base64
+import logging
+import markdown
+
+import flyte
+import flyte.report
+
+# {{docs-fragment env}}
+main_img = flyte.Image.from_uv_script(__file__, name="langgraph-agent-research", pre=True)
+
+env = flyte.TaskEnvironment(
+    name="langgraph-agent-research",
+    image=main_img,
+    secrets=[
+        flyte.Secret(key="openai-api-key", as_env_var="OPENAI_API_KEY"),
+        flyte.Secret(key="tavily-api-key", as_env_var="TAVILY_API_KEY"),
+    ],
+    resources=flyte.Resources(cpu=2, memory="2Gi"),
+)
+# {{/docs-fragment env}}
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+
+from models import TopicReport, QualityResult, PipelineResult
+from graph import build_pipeline_graph, build_research_subgraph
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+logging.getLogger("graph").setLevel(logging.INFO)
+logging.getLogger("tools.search").setLevel(logging.INFO)
+
+
+MODEL = "gpt-4.1-nano"
+
+
+def md_to_html(text: str) -> str:
+    """Convert markdown to HTML for Flyte reports."""
+    return markdown.markdown(text, extensions=["tables", "fenced_code"])
+
+
+# ------------------------------------------------------------------
+# Flyte tasks — each step is visible in the UI while running
+# ------------------------------------------------------------------
+
+@env.task(report=True)
+async def plan_topics(query: str, num_topics: int = 3) -> list[str]:
+    """Break a research query into focused sub-topics."""
+    log.info(f"Planning {num_topics} sub-topics for: {query}")
+
+    await flyte.report.replace.aio(
+        f"<h2>Planning</h2><p>Breaking query into {num_topics} sub-topics...</p>"
+    )
+    await flyte.report.flush.aio()
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+
+    response = llm.invoke(
+        f"Break this research question into exactly {num_topics} focused sub-topics. "
+        f"Return ONLY a JSON array of strings, nothing else.\n\nQuestion: {query}"
+    )
+    try:
+        topics = json.loads(response.content)
+    except json.JSONDecodeError:
+        topics = [query]
+
+    topics = topics[:num_topics]
+    log.info(f"Sub-topics: {topics}")
+
+    topic_html = "".join(f"<li>{t}</li>" for t in topics)
+    await flyte.report.replace.aio(
+        f"<h2>Planning</h2><p>Sub-topics:</p><ul>{topic_html}</ul>"
+    )
+    await flyte.report.flush.aio()
+
+    return topics
+
+
+@env.task(report=True)
+async def research_topic(topic: str, max_searches: int = 2) -> TopicReport:
+    """Run the ReAct research agent on a single sub-topic."""
+    log.info(f"[Research Task] Starting: {topic}")
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    tavily_api_key = os.getenv("TAVILY_API_KEY")
+
+    await flyte.report.replace.aio(f"<h2>Researching: {topic}</h2><p>Running searches...</p>")
+    await flyte.report.flush.aio()
+
+    graph = build_research_subgraph(
+        openai_api_key=openai_api_key,
+        tavily_api_key=tavily_api_key,
+        max_searches=max_searches,
+        model=MODEL,
+    )
+    result = await graph.ainvoke({"messages": [HumanMessage(content=f"Research this topic: {topic}")]})
+    report = result["messages"][-1].content
+    log.info(f"[Research Task] Done: {topic}")
+
+    await flyte.report.replace.aio(f"<h2>{topic}</h2>{md_to_html(report)}")
+    await flyte.report.flush.aio()
+
+    return TopicReport(topic=topic, report=report)
+
+
+@env.task(report=True)
+async def synthesize(query: str, results: list[TopicReport]) -> str:
+    """Combine sub-topic research reports into a unified synthesis."""
+    log.info(f"Synthesizing {len(results)} report(s)...")
+
+    await flyte.report.replace.aio(
+        f"<h2>Synthesis</h2><p>Combining {len(results)} reports...</p>"
+    )
+    await flyte.report.flush.aio()
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+
+    sections = "\n\n---\n\n".join(
+        f"## {r.topic}\n\n{r.report}" for r in results
+    )
+
+    response = llm.invoke(
+        f"You have research reports on sub-topics of this question:\n\n{query}\n\n"
+        f"Sub-topic reports:\n\n{sections}\n\n"
+        f"Write a comprehensive report that synthesizes all findings. "
+        f"Organize by theme, highlight connections between sub-topics, "
+        f"and end with key takeaways."
+    )
+    synthesis = response.content
+    log.info(f"Synthesis complete: {len(synthesis)} chars")
+
+    await flyte.report.replace.aio(f"<h2>Synthesis</h2>{md_to_html(synthesis)}")
+    await flyte.report.flush.aio()
+
+    return synthesis
+
+
+@env.task(report=True)
+async def quality_check(query: str, synthesis: str) -> QualityResult:
+    """Evaluate report quality and identify gaps."""
+    log.info("Evaluating quality...")
+
+    await flyte.report.replace.aio(
+        "<h2>Quality Check</h2><p>Evaluating report quality...</p>"
+    )
+    await flyte.report.flush.aio()
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    llm = ChatOpenAI(model=MODEL, api_key=openai_api_key)
+
+    response = llm.invoke(
+        f'Evaluate this research report for the question: {query}\n\n'
+        f'Report:\n{synthesis}\n\n'
+        f'Rate the report quality from 1-10 and identify any gaps or missing perspectives. '
+        f'Return JSON: {{"score": <int>, "gaps": [<string>, ...]}}\n'
+        f'If the report is comprehensive (score >= 8) or there are no significant gaps, '
+        f'return an empty gaps list.'
+    )
+
+    try:
+        evaluation = json.loads(response.content)
+        score = evaluation.get("score", 8)
+        gaps = evaluation.get("gaps", [])
+    except json.JSONDecodeError:
+        score = 8
+        gaps = []
+
+    result = QualityResult(score=score, gaps=gaps)
+    log.info(f"Score: {result.score}/10, Gaps: {len(result.gaps)}")
+
+    gap_html = "".join(f"<li>{g}</li>" for g in result.gaps) if result.gaps else "<li>None</li>"
+    await flyte.report.replace.aio(
+        f"<h2>Quality Check</h2>"
+        f"<p><b>Score:</b> {result.score}/10</p>"
+        f"<p><b>Gaps:</b></p><ul>{gap_html}</ul>"
+    )
+    await flyte.report.flush.aio()
+
+    return result
+
+
+# ------------------------------------------------------------------
+# Orchestrator: runs the LangGraph pipeline, backed by Flyte tasks
+# ------------------------------------------------------------------
+
+# {{docs-fragment pipeline}}
+@env.task(report=True)
+async def research_pipeline(
+    query: str,
+    num_topics: int = 3,
+    max_searches: int = 2,
+    max_iterations: int = 2,
+) -> PipelineResult:
+    """
+    Research pipeline workflow:
+    1. LangGraph plans sub-topics via plan_topics Flyte task
+    2. LangGraph fans out research via Send → each dispatches to research_topic Flyte task
+    3. LangGraph synthesizes results via synthesize Flyte task
+    4. LangGraph evaluates quality via quality_check Flyte task
+    5. If gaps found, loops back to step 2
+    """
+    log.info(f"Starting research pipeline: {query}")
+
+    openai_api_key = os.getenv("OPENAI_API_KEY")
+    tavily_api_key = os.getenv("TAVILY_API_KEY")
+
+    # Build the pipeline graph, passing all Flyte tasks as compute backends
+    pipeline = build_pipeline_graph(
+        openai_api_key=openai_api_key,
+        tavily_api_key=tavily_api_key,
+        plan_task=plan_topics,
+        research_task=research_topic,
+        synthesize_task=synthesize,
+        quality_check_task=quality_check,
+        model=MODEL,
+    )
+
+    # Visualize the graphs in report tabs
+    graph_tab = flyte.report.get_tab("Agent Graphs")
+
+    png_bytes = pipeline.get_graph().draw_mermaid_png()
+    img_b64 = base64.b64encode(png_bytes).decode()
+    graph_tab.log(f"""\
+<h2>Research Pipeline</h2>\
+<img src="data:image/png;base64,{img_b64}" alt="Research pipeline" />""")
+
+    subgraph = build_research_subgraph(openai_api_key, tavily_api_key, max_searches, model=MODEL)
+    sub_png = subgraph.get_graph().draw_mermaid_png()
+    sub_b64 = base64.b64encode(sub_png).decode()
+    graph_tab.log(f"""\
+<h2>Research Agent (ReAct)</h2>\
+<img src="data:image/png;base64,{sub_b64}" alt="ReAct research agent" />""")
+    await flyte.report.flush.aio()
+
+    # Run the pipeline — LangGraph controls the flow, Flyte tasks run the compute
+    result = await pipeline.ainvoke({
+        "query": query,
+        "num_topics": num_topics,
+        "max_searches": max_searches,
+        "max_iterations": max_iterations,
+        "iteration": 0,
+        "topics": [],
+        "research_results": [],
+        "synthesis": "",
+        "score": 0,
+        "gaps": [],
+        "final_report": "",
+    })
+
+    # Build the final report
+    final_report = result["final_report"]
+    sub_reports = [TopicReport(**r) for r in result["research_results"]]
+    score = result.get("score", 0)
+    iteration = result.get("iteration", 1) - 1
+
+    await flyte.report.replace.aio(f"""\
+<h2>Research Report</h2>\
+<p><b>Query:</b> {query}</p>\
+<p><b>Quality:</b> {score}/10 after {iteration} iteration(s)</p>\
+<hr/>{md_to_html(final_report)}""")
+    await flyte.report.flush.aio()
+
+    log.info(f"Research pipeline complete. Score: {score}/10, Iterations: {iteration}")
+    return PipelineResult(
+        query=query,
+        report=final_report,
+        sub_reports=sub_reports,
+        score=score,
+        iterations=iteration,
+    )
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(research_pipeline(query="Compare quantum computing approaches"))
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/langgraph_agent_research/models.py
+++ b/v2/tutorials/langgraph_agent_research/models.py
@@ -1,0 +1,21 @@
+"""Pydantic models for the research pipeline."""
+
+from pydantic import BaseModel
+
+
+class TopicReport(BaseModel):
+    topic: str
+    report: str
+
+
+class QualityResult(BaseModel):
+    score: int
+    gaps: list[str]
+
+
+class PipelineResult(BaseModel):
+    query: str
+    report: str
+    sub_reports: list[TopicReport]
+    score: int
+    iterations: int

--- a/v2/tutorials/langgraph_agent_research/tools/search.py
+++ b/v2/tutorials/langgraph_agent_research/tools/search.py
@@ -1,0 +1,26 @@
+"""Web search tool using Tavily."""
+
+import logging
+from langchain_core.tools import tool
+from tavily import TavilyClient
+import flyte
+
+log = logging.getLogger(__name__)
+
+
+def create_search_tool(tavily_api_key: str):
+    """Create a web_search tool bound to a Tavily API key."""
+    tavily = TavilyClient(api_key=tavily_api_key)
+
+    @tool
+    @flyte.trace
+    async def web_search(query: str) -> str:
+        """Search the web for information on a topic. Use this to find current facts, data, and sources."""
+        log.info(f"Searching: {query}")
+        results = tavily.search(query=query, max_results=3)
+        formatted = ""
+        for r in results.get("results", []):
+            formatted += f"- {r['title']}: {r['content'][:300]}\n  {r['url']}\n\n"
+        return formatted or "No results found."
+
+    return web_search

--- a/v2/tutorials/llm_fine_tuning_lora_qlora/llm_fine_tuning_lora_qlora.py
+++ b/v2/tutorials/llm_fine_tuning_lora_qlora/llm_fine_tuning_lora_qlora.py
@@ -1,0 +1,764 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.1.0",
+#    "transformers>=4.45.0",
+#    "peft>=0.13.0",
+#    "trl>=0.12.0",
+#    "datasets>=3.0.0",
+#    "bitsandbytes>=0.44.0",
+#    "accelerate>=0.34.0",
+# ]
+# main = "pipeline"
+# params = ""
+# ///
+import asyncio
+import json
+import logging
+import os
+import tempfile
+
+import flyte
+import flyte.io
+import flyte.report
+
+# {{docs-fragment env}}
+import os
+
+main_img = flyte.Image.from_uv_script(__file__, name="llm-fine-tuning-lora-qlora", pre=True)
+
+gpu_env = flyte.TaskEnvironment(
+    name="llm-fine-tuning-lora-qlora-gpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=1),
+    secrets=[flyte.Secret(key="huggingface-token", as_env_var="HF_TOKEN")],
+)
+
+cpu_env = flyte.TaskEnvironment(
+    name="llm-fine-tuning-lora-qlora-cpu",
+    image=main_img,
+    resources=flyte.Resources(cpu=2, memory="8Gi"),
+    depends_on=[gpu_env],
+)
+
+HF_TOKEN = os.environ.get("HF_TOKEN")
+# {{/docs-fragment env}}
+
+
+from report_helpers import make_bar_chart, make_line_chart, pipeline_step_indicator, wrap_report
+
+logging.basicConfig(level=logging.WARNING, format="%(message)s", force=True)
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+
+# ------------------------------------------------------------------
+# Task 1: Prepare dataset
+# ------------------------------------------------------------------
+
+@cpu_env.task(cache="auto")
+async def prepare_data(
+    dataset_name: str = "b-mc2/sql-create-context",
+    max_train_samples: int = 5000,
+    max_eval_samples: int = 500,
+) -> flyte.io.Dir:
+    """Download dataset from HuggingFace and format for instruction fine-tuning."""
+    from datasets import DatasetDict, load_dataset
+
+    log.info(f"Loading dataset: {dataset_name}")
+    ds = load_dataset(dataset_name, split="train")
+
+    def format_example(ex):
+        return {
+            "text": (
+                "### Task: Generate a SQL query to answer the question.\n"
+                f"### Schema:\n{ex['context']}\n"
+                f"### Question:\n{ex['question']}\n"
+                f"### SQL:\n{ex['answer']}\n<|endoftext|>"
+            )
+        }
+
+    ds = ds.map(format_example)
+
+    # Split into train and eval
+    total = len(ds)
+    train_end = min(max_train_samples, total - max_eval_samples)
+    eval_start = train_end
+    eval_end = min(eval_start + max_eval_samples, total)
+
+    processed = DatasetDict({
+        "train": ds.select(range(train_end)),
+        "eval": ds.select(range(eval_start, eval_end)),
+    })
+
+    output_dir = os.path.join(tempfile.mkdtemp(), "dataset")
+    processed.save_to_disk(output_dir)
+    log.info(f"Dataset ready: {len(processed['train'])} train, {len(processed['eval'])} eval")
+
+    return await flyte.io.Dir.from_local(output_dir)
+
+
+# ------------------------------------------------------------------
+# Task 2: Train
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def train(
+    model_name: str,
+    data_dir: flyte.io.Dir,
+    method: str = "lora",
+    epochs: int = 3,
+    lr: float = 2e-4,
+    batch_size: int = 4,
+    lora_r: int = 16,
+    lora_alpha: int = 32,
+) -> flyte.io.Dir:
+    """Fine-tune a model using full, LoRA, or QLoRA method."""
+    import torch
+    from datasets import load_from_disk
+    from transformers import AutoModelForCausalLM, AutoTokenizer, TrainerCallback
+    from trl import SFTConfig, SFTTrainer
+
+    log.info(f"Training: model={model_name}, method={method}")
+
+    # -- Load data --
+    data_path = await data_dir.download()
+    dataset = load_from_disk(data_path)
+
+    # -- Load tokenizer --
+    token_kwargs = {"token": HF_TOKEN} if HF_TOKEN else {}
+    tokenizer = AutoTokenizer.from_pretrained(model_name, **token_kwargs)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    # -- Initial report: loading model --
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Loading Model...</h2>"
+            f"<h3>{model_name}</h3>"
+            f'<div class="card">'
+            f"<p><b>Method:</b> <span class=\"badge badge-info\">{method.upper()}</span></p>"
+            f"<p><b>Dataset:</b> {len(dataset['train']):,} train / {len(dataset['eval']):,} eval</p>"
+            f"</div>"
+        ),
+        do_flush=True,
+    )
+
+    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+
+    if method == "qlora":
+        from transformers import BitsAndBytesConfig
+
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            **token_kwargs,
+            quantization_config=BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=dtype,
+                bnb_4bit_use_double_quant=True,
+            ),
+            dtype=dtype,
+            device_map="auto",
+        )
+    else:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            **token_kwargs,
+            dtype=dtype,
+            device_map="auto",
+        )
+
+    # -- Apply LoRA adapters --
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total_params = sum(p.numel() for p in model.parameters())
+
+    if method in ("lora", "qlora"):
+        from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+
+        if method == "qlora":
+            model = prepare_model_for_kbit_training(model)
+
+        lora_config = LoraConfig(
+            r=lora_r,              # Rank — size of the low-rank matrices. Higher = more capacity but more params
+            lora_alpha=lora_alpha,  # Scaling factor — controls adapter impact. Effective scale = alpha/r
+            # Attention layers — LoRA adapters inject low-rank updates here:
+            #   q_proj (Query)     — what to look for in context
+            #   k_proj (Key)       — what each token offers to match against
+            #   v_proj (Value)     — what information to extract once matched
+            #   o_proj (Output)    — combines multi-head attention results
+            # MLP layers — LoRA adapters also update the feed-forward network:
+            #   gate_proj (Gate)   — controls how much information flows through (SwiGLU activation)
+            #   up_proj (Up)       — projects to a higher dimension for richer representations
+            #   down_proj (Down)   — projects back down to the model's hidden size
+            target_modules=["q_proj", "v_proj", "k_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+            lora_dropout=0.05,     # Dropout on adapter weights — light regularization to prevent overfitting
+            bias="none",           # Don't train bias terms — keeps adapter small and stable
+            task_type="CAUSAL_LM", # Tells PEFT this is a text generation model (vs classification, etc.)
+        )
+        model = get_peft_model(model, lora_config)
+        trainable_params, total_params = model.get_nb_trainable_parameters()
+        log.info(f"Trainable params: {trainable_params:,} / {total_params:,} ({trainable_params / total_params * 100:.1f}%)")
+
+    # -- Live training report state --
+    training_log: list[dict] = []
+    loop = asyncio.get_running_loop()
+
+    method_badge = f'<span class="badge badge-info">{method.upper()}</span>'
+    if method == "qlora":
+        method_badge = f'<span class="badge badge-success">QLoRA (4-bit)</span>'
+    elif method == "full":
+        method_badge = f'<span class="badge badge-danger">Full Fine-Tune</span>'
+
+    def _build_training_report(max_steps: int) -> str:
+        """Build the live training report HTML from current training_log."""
+        stats_html = f"""
+        <h2>Training in Progress...</h2>
+        <h3>{model_name}</h3>
+        <div class="stat-grid">
+          <div class="stat"><div class="value">{method.upper()}</div><div class="label">Method</div></div>
+          <div class="stat"><div class="value">{len(dataset['train']):,}</div><div class="label">Train Examples</div></div>
+          <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>
+          <div class="stat"><div class="value">{lr}</div><div class="label">Learning Rate</div></div>
+          <div class="stat"><div class="value">{batch_size}</div><div class="label">Batch Size</div></div>
+          <div class="stat"><div class="value">{trainable_params / total_params * 100:.1f}%</div><div class="label">Trainable</div></div>
+        </div>
+        <p>Method: {method_badge} | Total params: {total_params:,} | Trainable: {trainable_params:,}</p>
+        """
+
+        charts_html = ""
+        if training_log:
+            current = training_log[-1]
+            progress_pct = current["step"] / max_steps * 100 if max_steps else 0
+            charts_html += f"""
+            <div class="card">
+              <b>Step {current['step']}/{max_steps}</b>
+              ({progress_pct:.0f}%) |
+              Epoch {current['epoch']:.2f}/{epochs} |
+              Loss: <span class="highlight">{current['loss']:.4f}</span>
+              <div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">
+                <div style="background:#0f3460;width:{progress_pct:.1f}%;height:100%;border-radius:4px;"></div>
+              </div>
+            </div>
+            """
+
+            loss_chart = make_line_chart(
+                data=training_log,
+                x_key="epoch",
+                y_keys=["loss"],
+                title="Training Loss",
+                x_label="Epoch",
+                y_label="Loss",
+                colors=["#5a7db5"],
+            )
+            charts_html += f'<div class="chart-container">{loss_chart}</div>'
+
+            if "lr" in training_log[0]:
+                lr_chart = make_line_chart(
+                    data=training_log,
+                    x_key="epoch",
+                    y_keys=["lr"],
+                    title="Learning Rate Schedule",
+                    x_label="Epoch",
+                    y_label="LR",
+                    colors=["#0f3460"],
+                )
+                charts_html += f'<div class="chart-container">{lr_chart}</div>'
+
+            if "grad_norm" in training_log[0]:
+                grad_chart = make_line_chart(
+                    data=training_log,
+                    x_key="epoch",
+                    y_keys=["grad_norm"],
+                    title="Gradient Norm",
+                    x_label="Epoch",
+                    y_label="Grad Norm",
+                    colors=["#06d6a0"],
+                )
+                charts_html += f'<div class="chart-container">{grad_chart}</div>'
+
+        return wrap_report(stats_html + charts_html)
+
+    # -- Metrics callback with live report updates --
+    class MetricsCallback(TrainerCallback):
+        def on_log(self, args, state, control, logs=None, **kwargs):
+            if not logs or "loss" not in logs:
+                return
+            entry = {
+                "step": state.global_step,
+                "epoch": round(logs.get("epoch", 0), 2),
+                "loss": round(logs["loss"], 4),
+            }
+            if "learning_rate" in logs:
+                entry["lr"] = logs["learning_rate"]
+            if "grad_norm" in logs:
+                entry["grad_norm"] = round(float(logs["grad_norm"]), 4)
+            training_log.append(entry)
+            log.info(
+                f"step={state.global_step}/{state.max_steps} "
+                f"epoch={entry['epoch']:.2f} "
+                f"loss={entry['loss']:.4f}"
+            )
+
+            asyncio.run_coroutine_threadsafe(
+                flyte.report.replace.aio(
+                    _build_training_report(state.max_steps),
+                    do_flush=True,
+                ),
+                loop,
+            )
+
+    # -- Train --
+    output_dir = os.path.join(tempfile.mkdtemp(), "checkpoints")
+    training_args = SFTConfig(
+        output_dir=output_dir,
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
+        learning_rate=lr,
+        logging_steps=10,
+        save_strategy="epoch",
+        bf16=use_bf16,
+        fp16=not use_bf16 and torch.cuda.is_available(),
+        gradient_accumulation_steps=4,
+        warmup_steps=10,
+        report_to="none",
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset["train"],
+        eval_dataset=dataset["eval"],
+        processing_class=tokenizer,
+        callbacks=[MetricsCallback()],
+    )
+
+    log.info("Starting training...")
+    await asyncio.to_thread(trainer.train)
+    log.info("Training complete.")
+
+    # -- Merge LoRA weights and save --
+    save_dir = os.path.join(tempfile.mkdtemp(), "finetuned_model")
+
+    if method in ("lora", "qlora"):
+        log.info("Merging LoRA weights into base model...")
+        model = model.merge_and_unload()
+
+    model.save_pretrained(save_dir)
+    tokenizer.save_pretrained(save_dir)
+    log.info(f"Model saved to {save_dir}")
+
+    # -- Final training report --
+    final_loss = training_log[-1]["loss"] if training_log else "N/A"
+
+    loss_chart = make_line_chart(
+        data=training_log,
+        x_key="epoch",
+        y_keys=["loss"],
+        title="Training Loss",
+        x_label="Epoch",
+        y_label="Loss",
+        colors=["#5a7db5"],
+    ) if training_log else ""
+
+    lr_chart = ""
+    if training_log and "lr" in training_log[0]:
+        lr_chart = make_line_chart(
+            data=training_log,
+            x_key="epoch",
+            y_keys=["lr"],
+            title="Learning Rate Schedule",
+            x_label="Epoch",
+            y_label="LR",
+            colors=["#0f3460"],
+        )
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Training Complete</h2>"
+            f"<h3>{model_name}</h3>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{method.upper()}</div><div class="label">Method</div></div>'
+            f'  <div class="stat"><div class="value">{final_loss}</div><div class="label">Final Loss</div></div>'
+            f'  <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>'
+            f'  <div class="stat"><div class="value">{total_params:,}</div><div class="label">Total Params</div></div>'
+            f'  <div class="stat"><div class="value">{trainable_params:,}</div><div class="label">Trainable Params</div></div>'
+            f'  <div class="stat"><div class="value">{trainable_params / total_params * 100:.1f}%</div><div class="label">% Trainable</div></div>'
+            f'</div>'
+            f'<div class="chart-container">{loss_chart}</div>'
+            f'{f"""<div class="chart-container">{lr_chart}</div>""" if lr_chart else ""}'
+        ),
+        do_flush=True,
+    )
+
+    return await flyte.io.Dir.from_local(save_dir)
+
+
+# ------------------------------------------------------------------
+# Task 3: Evaluate — before/after comparison
+# ------------------------------------------------------------------
+
+@gpu_env.task(report=True)
+async def evaluate(
+    model_name: str,
+    finetuned_dir: flyte.io.Dir,
+    data_dir: flyte.io.Dir,
+    num_examples: int = 50,
+) -> str:
+    """Compare base model vs fine-tuned model on test examples."""
+    import torch
+    from datasets import load_from_disk
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    log.info("Starting evaluation...")
+    await flyte.report.replace.aio(
+        wrap_report(
+            "<h2>Evaluation</h2>"
+            '<div class="card"><p>Loading models and running inference...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+    dtype = torch.bfloat16 if use_bf16 else torch.float32
+
+    # Load eval data
+    data_path = await data_dir.download()
+    dataset = load_from_disk(data_path)
+    eval_ds = dataset["eval"].select(range(min(num_examples, len(dataset["eval"]))))
+
+    # Load tokenizer
+    token_kwargs = {"token": HF_TOKEN} if HF_TOKEN else {}
+    tokenizer = AutoTokenizer.from_pretrained(model_name, **token_kwargs)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    def generate_sql(model, prompt, max_new_tokens=128):
+        inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+        with torch.no_grad():
+            outputs = model.generate(
+                **inputs,
+                max_new_tokens=max_new_tokens,
+                do_sample=False,
+                pad_token_id=tokenizer.eos_token_id,
+            )
+        return tokenizer.decode(outputs[0][inputs.input_ids.shape[1]:], skip_special_tokens=True).strip()
+
+    def normalize_sql(sql):
+        """Extract the first SQL statement and normalize for comparison."""
+        # Truncate at first ### or newline to isolate the SQL
+        for stop in ["###", "\n"]:
+            if stop in sql:
+                sql = sql[:sql.index(stop)]
+        return " ".join(sql.lower().split()).strip().rstrip(";")
+
+    def build_prompt(example):
+        return (
+            "### Task: Generate a SQL query to answer the question.\n"
+            f"### Schema:\n{example['context']}\n"
+            f"### Question:\n{example['question']}\n"
+            "### SQL:\n"
+        )
+
+    # -- Run base model --
+    log.info(f"Loading base model: {model_name}")
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Evaluation</h2>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{len(eval_ds)}</div><div class="label">Eval Examples</div></div>'
+            f'  <div class="stat"><div class="value">1/2</div><div class="label">Phase</div></div>'
+            f'</div>'
+            f'<div class="card"><p>Running <b>base model</b> inference...</p>'
+            f'<div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">'
+            f'<div style="background:#adb5bd;width:25%;height:100%;border-radius:4px;"></div>'
+            f'</div></div>'
+        ),
+        do_flush=True,
+    )
+
+    base_model = AutoModelForCausalLM.from_pretrained(
+        model_name, **token_kwargs, dtype=dtype, device_map="auto",
+    )
+
+    base_results = []
+    for i, example in enumerate(eval_ds):
+        prompt = build_prompt(example)
+        generated = generate_sql(base_model, prompt)
+        base_results.append(generated)
+        if (i + 1) % 10 == 0:
+            log.info(f"Base model: {i + 1}/{len(eval_ds)}")
+            pct = (i + 1) / len(eval_ds) * 50
+            await flyte.report.replace.aio(
+                wrap_report(
+                    f"<h2>Evaluation</h2>"
+                    f'<div class="card"><p>Running <b>base model</b> inference... {i + 1}/{len(eval_ds)}</p>'
+                    f'<div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">'
+                    f'<div style="background:#adb5bd;width:{pct:.0f}%;height:100%;border-radius:4px;"></div>'
+                    f'</div></div>'
+                ),
+                do_flush=True,
+            )
+
+    del base_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # -- Run fine-tuned model --
+    log.info("Loading fine-tuned model...")
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Evaluation</h2>"
+            f'<div class="card"><p>Running <b>fine-tuned model</b> inference...</p>'
+            f'<div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">'
+            f'<div style="background:#0f3460;width:50%;height:100%;border-radius:4px;"></div>'
+            f'</div></div>'
+        ),
+        do_flush=True,
+    )
+
+    ft_path = await finetuned_dir.download()
+    ft_model = AutoModelForCausalLM.from_pretrained(
+        ft_path, dtype=dtype, device_map="auto",
+    )
+
+    ft_results = []
+    for i, example in enumerate(eval_ds):
+        prompt = build_prompt(example)
+        generated = generate_sql(ft_model, prompt)
+        ft_results.append(generated)
+        if (i + 1) % 10 == 0:
+            log.info(f"Fine-tuned model: {i + 1}/{len(eval_ds)}")
+            pct = 50 + (i + 1) / len(eval_ds) * 50
+            await flyte.report.replace.aio(
+                wrap_report(
+                    f"<h2>Evaluation</h2>"
+                    f'<div class="card"><p>Running <b>fine-tuned model</b> inference... {i + 1}/{len(eval_ds)}</p>'
+                    f'<div style="background:#e9ecef;border-radius:4px;height:8px;margin-top:8px;">'
+                    f'<div style="background:#0f3460;width:{pct:.0f}%;height:100%;border-radius:4px;"></div>'
+                    f'</div></div>'
+                ),
+                do_flush=True,
+            )
+
+    del ft_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    # -- Score --
+    base_correct = 0
+    ft_correct = 0
+    comparisons = []
+
+    for i, example in enumerate(eval_ds):
+        expected = example["answer"]
+        base_gen = base_results[i]
+        ft_gen = ft_results[i]
+
+        base_match = normalize_sql(base_gen) == normalize_sql(expected)
+        ft_match = normalize_sql(ft_gen) == normalize_sql(expected)
+
+        if base_match:
+            base_correct += 1
+        if ft_match:
+            ft_correct += 1
+
+        comparisons.append({
+            "question": example["question"],
+            "schema": example["context"],
+            "expected": expected,
+            "base": base_gen,
+            "finetuned": ft_gen,
+            "base_correct": base_match,
+            "ft_correct": ft_match,
+        })
+
+    total = len(eval_ds)
+    base_acc = base_correct / total * 100
+    ft_acc = ft_correct / total * 100
+    improvement = ft_acc - base_acc
+
+    log.info(f"Base model accuracy: {base_acc:.1f}% ({base_correct}/{total})")
+    log.info(f"Fine-tuned accuracy: {ft_acc:.1f}% ({ft_correct}/{total})")
+
+    # -- Build final eval report --
+    improvement_badge = (
+        f'<span class="badge badge-success">+{improvement:.1f}pp</span>'
+        if improvement > 0
+        else f'<span class="badge badge-danger">{improvement:.1f}pp</span>'
+    )
+
+    bar_chart = make_bar_chart(
+        labels=["Exact Match Accuracy"],
+        series={
+            "Base Model": [base_acc],
+            "Fine-Tuned": [ft_acc],
+        },
+        title="Base vs Fine-Tuned Accuracy",
+        colors=["#adb5bd", "#0f3460"],
+        y_max_cap=100.0,
+    )
+
+    examples_html = ""
+    for c in comparisons[:10]:
+        base_badge = '<span class="badge badge-success">correct</span>' if c["base_correct"] else '<span class="badge badge-danger">wrong</span>'
+        ft_badge = '<span class="badge badge-success">correct</span>' if c["ft_correct"] else '<span class="badge badge-danger">wrong</span>'
+        examples_html += f"""
+        <div class="card">
+          <p><b>Q:</b> {c['question']}</p>
+          <p style="font-size:0.85em; color:#6c757d;"><b>Schema:</b> {c['schema'][:200]}...</p>
+          <table>
+            <tr><th>Source</th><th>SQL</th><th>Result</th></tr>
+            <tr><td>Expected</td><td><code>{c['expected']}</code></td><td></td></tr>
+            <tr><td>Base</td><td><code>{c['base'][:200]}</code></td><td>{base_badge}</td></tr>
+            <tr><td>Fine-tuned</td><td><code>{c['finetuned'][:200]}</code></td><td>{ft_badge}</td></tr>
+          </table>
+        </div>"""
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Evaluation Results</h2>"
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{base_acc:.1f}%</div><div class="label">Base Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{ft_acc:.1f}%</div><div class="label">Fine-Tuned Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{improvement:+.1f}pp</div><div class="label">Improvement</div></div>'
+            f'  <div class="stat"><div class="value">{total}</div><div class="label">Eval Examples</div></div>'
+            f'</div>'
+            f'<div class="chart-container">{bar_chart}</div>'
+            f'<h3>Example Comparisons {improvement_badge}</h3>'
+            f'{examples_html}'
+            f'<div class="note">'
+            f'<b>Note:</b> Exact match accuracy compares normalized SQL output. '
+            f'The fine-tuned model may generate semantically correct queries that differ in formatting.'
+            f'</div>'
+        ),
+        do_flush=True,
+    )
+
+    return json.dumps({
+        "base_accuracy": round(base_acc, 1),
+        "finetuned_accuracy": round(ft_acc, 1),
+        "improvement": round(ft_acc - base_acc, 1),
+        "num_examples": total,
+        "comparisons": comparisons[:10],
+    })
+
+
+# ------------------------------------------------------------------
+# Pipeline: orchestrate everything
+# ------------------------------------------------------------------
+
+
+# {{docs-fragment pipeline}}
+@cpu_env.task(report=True)
+async def pipeline(
+    model_name: str = "HuggingFaceTB/SmolLM2-135M",
+    dataset_name: str = "b-mc2/sql-create-context",
+    method: str = "lora",
+    epochs: int = 3,
+    lr: float = 2e-4,
+    batch_size: int = 4,
+    max_train_samples: int = 5000,
+    max_eval_samples: int = 500,
+    num_eval_examples: int = 50,
+    lora_r: int = 16,
+    lora_alpha: int = 32,
+) -> flyte.io.Dir:
+    """
+    End-to-end LLM fine-tuning pipeline.
+
+    1. Download and format dataset
+    2. Fine-tune model (full / LoRA / QLoRA)
+    3. Evaluate: before/after comparison on test set
+
+    Returns the fine-tuned model directory so it can be served directly.
+    """
+    log.info(f"Pipeline: {model_name} | method={method} | dataset={dataset_name}")
+    steps = ["Prepare Data", "Train", "Evaluate"]
+
+    method_badge = f'<span class="badge badge-info">{method.upper()}</span>'
+
+    # Step 1: Prepare data
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>LLM Fine-Tuning Pipeline</h2>"
+            f"<h3>{model_name} {method_badge}</h3>"
+            f'{pipeline_step_indicator(0, steps)}'
+            f'<div class="card"><p>Downloading and formatting dataset: <b>{dataset_name}</b>...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    data_dir = await prepare_data(dataset_name, max_train_samples, max_eval_samples)
+
+    # Step 2: Train
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>LLM Fine-Tuning Pipeline</h2>"
+            f"<h3>{model_name} {method_badge}</h3>"
+            f'{pipeline_step_indicator(1, steps)}'
+            f'<div class="card"><p>Training in progress... check the <b>train</b> task report for live charts.</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    finetuned_dir = await train(
+        model_name, data_dir, method, epochs, lr, batch_size, lora_r, lora_alpha,
+    )
+
+    # Step 3: Evaluate
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>LLM Fine-Tuning Pipeline</h2>"
+            f"<h3>{model_name} {method_badge}</h3>"
+            f'{pipeline_step_indicator(2, steps)}'
+            f'<div class="card"><p>Evaluating base vs fine-tuned model...</p></div>'
+        ),
+        do_flush=True,
+    )
+
+    result = await evaluate(model_name, finetuned_dir, data_dir, num_eval_examples)
+    metrics = json.loads(result)
+
+    # Final pipeline report
+    improvement = metrics["improvement"]
+    improvement_badge = (
+        f'<span class="badge badge-success">+{improvement:.1f}pp</span>'
+        if improvement > 0
+        else f'<span class="badge badge-danger">{improvement:.1f}pp</span>'
+    )
+
+    await flyte.report.replace.aio(
+        wrap_report(
+            f"<h2>Pipeline Complete</h2>"
+            f"<h3>{model_name} {method_badge}</h3>"
+            f'{pipeline_step_indicator(3, steps)}'
+            f'<div class="stat-grid">'
+            f'  <div class="stat"><div class="value">{metrics["base_accuracy"]}%</div><div class="label">Base Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{metrics["finetuned_accuracy"]}%</div><div class="label">Fine-Tuned Accuracy</div></div>'
+            f'  <div class="stat"><div class="value">{improvement:+.1f}pp</div><div class="label">Improvement {improvement_badge}</div></div>'
+            f'  <div class="stat"><div class="value">{method.upper()}</div><div class="label">Method</div></div>'
+            f'  <div class="stat"><div class="value">{epochs}</div><div class="label">Epochs</div></div>'
+            f'  <div class="stat"><div class="value">{metrics["num_examples"]}</div><div class="label">Eval Examples</div></div>'
+            f'</div>'
+            f'<div class="note">'
+            f'Check the <b>train</b> task report for training loss/LR charts, '
+            f'and the <b>evaluate</b> task report for detailed example comparisons.'
+            f'</div>'
+        ),
+        do_flush=True,
+    )
+
+    log.info(f"Pipeline complete. Improvement: {metrics['improvement']:+.1f}pp")
+    return finetuned_dir
+
+# {{/docs-fragment pipeline}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(pipeline)
+    print(run.url)
+    run.wait()

--- a/v2/tutorials/llm_fine_tuning_lora_qlora/report_helpers.py
+++ b/v2/tutorials/llm_fine_tuning_lora_qlora/report_helpers.py
@@ -1,0 +1,306 @@
+"""Flyte report helpers — CSS, SVG charts, and HTML wrappers."""
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .highlight { color: #0f3460; font-weight: 700; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+  .report .badge-success { background: #d4edda; color: #155724; }
+  .report .badge-info { background: #d1ecf1; color: #0c5460; }
+  .report .badge-danger { background: #f8d7da; color: #721c24; }
+  .report .chart-container { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 16px 0; }
+</style>
+"""
+
+
+def wrap_report(html: str) -> str:
+    """Wrap HTML content with report styling."""
+    return f'{REPORT_CSS}<div class="report">{html}</div>'
+
+
+def make_line_chart(
+    data: list[dict],
+    x_key: str,
+    y_keys: list[str],
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+    x_range_override: tuple[float, float] | None = None,
+    y_display_names: dict[str, str] | None = None,
+) -> str:
+    """Generate an SVG line chart from a list of dicts."""
+    default_colors = ["#5a7db5", "#0f3460", "#06d6a0", "#ffc107", "#6c757d"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 50
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    x_vals = [d[x_key] for d in data] if data else []
+    if x_range_override:
+        x_min, x_max = x_range_override
+    elif x_vals:
+        x_min, x_max = min(x_vals), max(x_vals)
+    else:
+        x_min, x_max = 0, 1
+    x_range = x_max - x_min or 1
+
+    all_y = []
+    for key in y_keys:
+        all_y.extend(d[key] for d in data if key in d)
+    y_min = min(all_y) if all_y else 0
+    y_max = max(all_y) if all_y else 1
+    y_pad = (y_max - y_min) * 0.1 or 0.1
+    y_min_plot = max(0, y_min - y_pad)
+    y_max_plot = y_max + y_pad
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap)
+    y_range = y_max_plot - y_min_plot or 1
+
+    def sx(v):
+        return ml + (v - x_min) / x_range * cw
+
+    def sy(v):
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Grid lines
+    for i in range(6):
+        y_tick = y_min_plot + y_range * i / 5
+        py = sy(y_tick)
+        lines.append(
+            f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" '
+            f'stroke="#e9ecef" stroke-width="1"/>'
+        )
+        lines.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6c757d">{y_tick:.3f}</text>'
+        )
+
+    # Axes
+    lines.append(
+        f'<line x1="{ml}" y1="{mt}" x2="{ml}" y2="{mt + ch}" '
+        f'stroke="#adb5bd" stroke-width="1.5"/>'
+    )
+    lines.append(
+        f'<line x1="{ml}" y1="{mt + ch}" x2="{ml + cw}" y2="{mt + ch}" '
+        f'stroke="#adb5bd" stroke-width="1.5"/>'
+    )
+
+    # X-axis ticks
+    if x_vals:
+        n_x_ticks = min(len(data), 10)
+        step = max(1, len(data) // n_x_ticks)
+        for i in range(0, len(data), step):
+            px = sx(x_vals[i])
+            lines.append(
+                f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" '
+                f'font-size="11" fill="#6c757d">{x_vals[i]:.1f}</text>'
+            )
+    else:
+        for i in range(6):
+            x_tick = x_min + x_range * i / 5
+            px = sx(x_tick)
+            lines.append(
+                f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" '
+                f'font-size="11" fill="#6c757d">{x_tick:.1f}</text>'
+            )
+
+    # Plot series
+    if not data:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{mt + ch / 2}" text-anchor="middle" '
+            f'font-size="13" fill="#adb5bd" font-style="italic">Waiting for data...</text>'
+        )
+    for si, key in enumerate(y_keys):
+        color = colors[si % len(colors)]
+        points = [(sx(d[x_key]), sy(d[key])) for d in data if key in d]
+        if not points:
+            continue
+        if len(points) >= 2:
+            path_d = f"M {points[0][0]:.1f},{points[0][1]:.1f}"
+            for px, py in points[1:]:
+                path_d += f" L {px:.1f},{py:.1f}"
+            dash = ' stroke-dasharray="6,3"' if si % 2 == 1 else ""
+            lines.append(
+                f'<path d="{path_d}" fill="none" stroke="{color}" '
+                f'stroke-width="2" stroke-linejoin="round"{dash}/>'
+            )
+        if len(points) <= 30:
+            for px, py in points:
+                lines.append(
+                    f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{color}"/>'
+                )
+
+    if title:
+        lines.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+    if x_label:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{height - 6}" text-anchor="middle" '
+            f'font-size="12" fill="#6c757d">{x_label}</text>'
+        )
+    if y_label:
+        lines.append(
+            f'<text x="14" y="{mt + ch / 2}" text-anchor="middle" '
+            f'font-size="12" fill="#6c757d" '
+            f'transform="rotate(-90, 14, {mt + ch / 2})">{y_label}</text>'
+        )
+
+    # Legend
+    names = y_display_names or {}
+    if len(y_keys) > 1:
+        lx = ml + 10
+        for si, key in enumerate(y_keys):
+            color = colors[si % len(colors)]
+            ly = mt + 14 + si * 18
+            lines.append(
+                f'<rect x="{lx}" y="{ly - 6}" width="12" height="12" '
+                f'rx="2" fill="{color}"/>'
+            )
+            label = names.get(key, key)
+            lines.append(
+                f'<text x="{lx + 16}" y="{ly + 4}" font-size="11" '
+                f'fill="#1a1a2e">{label}</text>'
+            )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def make_bar_chart(
+    labels: list[str],
+    series: dict[str, list[float]],
+    title: str = "",
+    colors: list[str] | None = None,
+    width: int = 700,
+    height: int = 300,
+    y_max_cap: float | None = None,
+) -> str:
+    """Generate an SVG grouped bar chart."""
+    if not labels:
+        return ""
+
+    default_colors = ["#adb5bd", "#0f3460", "#06d6a0", "#5a7db5"]
+    colors = colors or default_colors
+
+    ml, mr, mt, mb = 60, 20, 40, 60
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    all_vals = [v for vals in series.values() for v in vals]
+    y_max = max(all_vals) if all_vals else 1
+    y_max_plot = y_max * 1.15 or 1
+    if y_max_cap is not None:
+        y_max_plot = min(y_max_plot, y_max_cap) or y_max_cap
+
+    n_groups = len(labels)
+    n_series = len(series)
+    group_width = cw / n_groups
+    bar_width = group_width * 0.7 / max(n_series, 1)
+    gap = group_width * 0.15
+
+    def sy(v):
+        return mt + ch - (v / y_max_plot) * ch
+
+    lines_svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    for i in range(6):
+        y_tick = y_max_plot * i / 5
+        py = sy(y_tick)
+        lines_svg.append(
+            f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" '
+            f'stroke="#e9ecef" stroke-width="1"/>'
+        )
+        lines_svg.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" '
+            f'font-size="11" fill="#6c757d">{y_tick:.1f}</text>'
+        )
+
+    for gi, label in enumerate(labels):
+        gx = ml + gi * group_width + gap
+        for si, (name, vals) in enumerate(series.items()):
+            color = colors[si % len(colors)]
+            bx = gx + si * bar_width
+            val = vals[gi]
+            by = sy(val)
+            bh = mt + ch - by
+            lines_svg.append(
+                f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_width - 1:.1f}" '
+                f'height="{bh:.1f}" fill="{color}" rx="2"/>'
+            )
+            lines_svg.append(
+                f'<text x="{bx + bar_width / 2:.1f}" y="{by - 4:.1f}" '
+                f'text-anchor="middle" font-size="10" fill="#1a1a2e">'
+                f'{val:.1f}%</text>'
+            )
+        lines_svg.append(
+            f'<text x="{gx + n_series * bar_width / 2:.1f}" y="{mt + ch + 18}" '
+            f'text-anchor="middle" font-size="11" fill="#6c757d">{label}</text>'
+        )
+
+    if title:
+        lines_svg.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" '
+            f'font-size="14" font-weight="600" fill="#1a1a2e">{title}</text>'
+        )
+
+    lx = ml + cw - len(series) * 100
+    for si, name in enumerate(series):
+        color = colors[si % len(colors)]
+        lines_svg.append(
+            f'<rect x="{lx + si * 100}" y="{mt + ch + 35}" width="12" '
+            f'height="12" rx="2" fill="{color}"/>'
+        )
+        lines_svg.append(
+            f'<text x="{lx + si * 100 + 16}" y="{mt + ch + 46}" font-size="11" '
+            f'fill="#1a1a2e">{name}</text>'
+        )
+
+    lines_svg.append("</svg>")
+    return "\n".join(lines_svg)
+
+
+def pipeline_step_indicator(current: int, steps: list[str]) -> str:
+    """Build a visual step indicator (checkmark/dot/circle)."""
+    html = '<div style="display:flex;gap:24px;margin:16px 0;">'
+    for i, label in enumerate(steps):
+        if i < current:
+            icon = '<span style="color:#155724;font-size:1.2em;">&#10003;</span>'
+            color = "#155724"
+        elif i == current:
+            icon = '<span style="color:#0f3460;font-size:1.2em;">&#9679;</span>'
+            color = "#0f3460"
+        else:
+            icon = '<span style="color:#adb5bd;font-size:1.2em;">&#9675;</span>'
+            color = "#adb5bd"
+        html += f'<div style="text-align:center;"><div>{icon}</div><div style="font-size:0.85em;color:{color};">{label}</div></div>'
+    html += '</div>'
+    return html


### PR DESCRIPTION
## Summary
- Port seven tutorials from [unionai/workshops](https://github.com/unionai/workshops) into `v2/tutorials/`, adapted to unionai-examples conventions (`uv` script headers, `flyte.Image.from_uv_script`, `docs-fragment` markers, standard `if __name__ == "__main__"` entry points).
- **Biotech:** cross-species gene comparison (Carbon + ESMFold), genomic variant effect prediction (Carbon VEP)
- **Computer vision:** RT-DETR object detection fine-tuning
- **Financial services:** fraud detection with Feast + XGBoost
- **Model training:** LLM LoRA/QLoRA fine-tuning, BERT emotion classification
- **Agents:** LangGraph research agent with Flyte-backed tasks

## Test plan
- [ ] `uv run --script genomic_gene_comparison.py` (requires GPU)
- [ ] `uv run --script genomic_variant_effect.py` (requires GPU)
- [ ] `uv run --script detr_object_detection.py --epochs 1 --batch_size 2` (requires GPU)
- [ ] `uv run --script fraud_detection_feast.py`
- [ ] `uv run --script llm_fine_tuning_lora_qlora.py --method lora --epochs 1 --max_train_samples 100`
- [ ] `uv run --script bert_fine_tuning_emotion.py --max_train_samples 200 --epochs 1`
- [ ] `uv run --script langgraph_agent_research.py` (requires OpenAI + Tavily secrets)


Made with [Cursor](https://cursor.com)