### PR TITLE
Add GRPO + LoRA RL tutorial (native Flyte orchestration)

### DIFF
--- a/v2/tutorials/rl_grpo_lora/README.md
+++ b/v2/tutorials/rl_grpo_lora/README.md
@@ -1,0 +1,280 @@
+# RL (GRPO) for LLMs on Union with flyte-sdk
+
+A reference architecture for running a **reinforcement-learning loop for LLMs (GRPO-style) natively
+on Union** with `flyte-sdk` — no Ray, no external scheduler. Flyte tasks *are* the orchestrator.
+
+The loop is the standard shape:
+
+```
+sample prompts → generate rollouts (vLLM) → score (reward) → policy update → refresh rollout adapter → repeat
+```
+
+This README is the **design doc**. A runnable example (`rl_grpo_lora.py`) will live next to it.
+
+## Design decisions
+
+- **No Ray** — orchestrate the loop with Flyte async tasks (`asyncio` directly).
+- **vLLM** for rollout generation (already supported in `examples/genai/vllm/`).
+- **Keep the inference model hot** across iterations — a reusable container (see the crux section).
+- **Pipeline rollout → reward** with `asyncio.create_task` + `as_completed` (not a map barrier), so
+  reward scoring overlaps in-flight rollouts.
+- **LoRA by default.** The frozen base stays loaded in the warm replica; each iteration the trainer
+  emits a small LoRA adapter the rollout engine attaches via vLLM's `LoRARequest`. This avoids
+  in-place full-weight updates (the riskiest piece), keeps the adapter handoff tiny (a few MB), and
+  shrinks the trainer to a single GPU. Full-weight RL is deferred.
+- **Base model via `flyte.prefetch.hf_model`** — stream the base into Flyte object store once,
+  **pre-sharded for vLLM** (`ShardConfig`/`VLLMShardArgs`), so every rollout replica and the trainer
+  load it directly with no reshard and no FUSE/Volume. Faster to load into vLLM than mounting a Volume.
+- **Volumes are not needed for the MVP** — prefetch covers the base, `flyte.Dir` covers the adapter.
+  A Volume stays a fallback only for very large *full-weight* checkpoints.
+- **Single-node trainer** for the MVP; `ClusteredTaskEnvironment` is the scale-out path.
+
+## TL;DR — MVP vs deferred
+
+| Concern | **MVP (build now)** | Deferred (add when needed) |
+|---|---|---|
+| Orchestration | async **driver task** runs the `for it in range(N)` loop (no Ray) | — |
+| Hot rollout model | **reusable container** (`ReusePolicy`) — in-process vLLM `LLM`, **or** a vLLM **sidecar** via env-level `pod_template` (both work today) | App for *deployed* serving |
+| Rollout fan-out + reward | `asyncio.create_task` all rollouts → `as_completed` scores each as it finishes → `gather` | autoscale `replicas=(min,max)` tuning |
+| Reward | rule-based / verifiable reward in plain tasks (GRPO-style) | model-based reward = 2nd reusable vLLM env |
+| Policy update | **LoRA** (PEFT) + TRL `GRPOTrainer`, single node, frozen base | full-weight update; `ClusteredTaskEnvironment`+`TorchRun` multi-node |
+| Base model weights | **`flyte.prefetch.hf_model(repo=..., shard_config=...)`** → vLLM-sharded `Dir` in object store | Volume / bake into image |
+| Adapter handoff trainer→rollout | tiny **LoRA adapter** as `flyte.Dir`; vLLM attaches via `LoRARequest` | full-weight `Dir` + vLLM `collective_rpc`; Volume for big full weights |
+| Resume / checkpoint | `flyte.Checkpoint` on the driver loop | — |
+
+The only genuinely new piece vs a normal training job is **keeping vLLM warm + swapping the LoRA
+adapter each iteration**. Everything else is ordinary Flyte tasks.
+
+## Architecture
+
+```
+flyte.prefetch.hf_model(repo, shard_config=vLLM) ──► base model Dir in object store (once)
+     │  loaded directly by vLLM on rollout + trainer (pre-sharded, no reshard, no FUSE)
+     ▼
+driver task (plain async, no Ray)
+┌───────────────────────────────────────────────────────────┐
+│ adapter = initial_lora;  base = prefetched_model_dir       │
+│ for it in range(N):                                        │
+│   prompts = sample(dataset)                                │
+│   # launch all rollouts at once on warm replicas          │
+│   futs = [create_task(generate(base, p, adapter, it))...] ─┼─► reusable vLLM env (WARM, base prefetched)
+│   # score each rollout the instant it completes           │
+│   for fut in as_completed(futs):                          │
+│       r = await fut;  rewards.append(create_task(score(r)))┼─► reward tasks (overlap rollouts)
+│   rollouts, rewards = ..., await gather(*rewards)          │
+│   adapter = await train_step(base, rollouts, rewards,     ─┼─► trainer env (1 node, LoRA/GRPO)
+│                              adapter)                       │
+│   await checkpoint.save(loop_state)         # → flyte.Dir  │
+└───────────────────────────────────────────────────────────┘
+     the LoRA adapter (a few MB) flows as a flyte.Dir output, passed by the driver
+```
+
+Three tasks across two GPU envs + a driver, plus a one-time prefetch.
+
+### 0. Prefetch the base model (runs once, before the loop)
+
+```python
+import flyte.prefetch
+from flyte.prefetch import ShardConfig, VLLMShardArgs
+
+# stream base into object store, pre-sharded for vLLM — faster load, no FUSE/Volume
+run = flyte.prefetch.hf_model(
+    repo="Qwen/Qwen3-8B",
+    shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(tensor_parallel_size=1)),
+    hf_token_key="HF_TOKEN",
+)
+run.wait()
+```
+
+The vLLM examples use this exact pattern — see `examples/genai/vllm/vllm_app.py`, which wires the
+prefetched dir into a server via `flyte.app.RunOutput(type="directory", run_name=run.name)`.
+
+### 1. Rollout generator — reusable, warm vLLM (the core feature)
+
+```python
+rollout_env = flyte.TaskEnvironment(
+    name="rl-rollout",
+    image=flyte.Image.from_debian_base().with_pip_packages("vllm", "transformers"),
+    resources=flyte.Resources(gpu=flyte.GPU("H100", 1), memory="80Gi", shm="auto"),
+    reusable=flyte.ReusePolicy(replicas=(1, 4), concurrency=4, idle_ttl=300),
+    secrets=[flyte.Secret(key="hf-token", as_env_var="HF_TOKEN")],
+)
+
+_ENGINE = None            # module-global → persists across calls in a warm replica
+_ADAPTER_DIR = {}         # version -> local adapter path (downloaded once)
+
+@rollout_env.task
+async def generate(base: flyte.Dir, prompts: list[str], adapter: flyte.Dir, version: int) -> list[Rollout]:
+    global _ENGINE
+    if _ENGINE is None:
+        local_base = await base.download()                        # prefetched, vLLM-sharded → load directly
+        _ENGINE = build_vllm_engine(local_base, enable_lora=True) # loaded once, stays warm
+    if version not in _ADAPTER_DIR:
+        _ADAPTER_DIR[version] = await adapter.download()          # tiny LoRA adapter → local path
+    lora = LoRARequest(f"policy-v{version}", version, _ADAPTER_DIR[version])
+    return run_generation(_ENGINE, prompts, lora_request=lora)    # attach adapter per request
+```
+
+The base never reloads — only the small adapter is attached via `LoRARequest`.
+
+Fan out and pipeline reward as each rollout finishes (following
+`examples/streaming/basic_as_completed.py` — no map barrier, reward overlaps in-flight rollouts):
+
+```python
+rollout_futs = [asyncio.create_task(generate(base, b, adapter, it)) for b in prompt_batches]
+rollouts, reward_futs = [], []
+for fut in asyncio.as_completed(rollout_futs):       # ready in completion order
+    r = await fut
+    rollouts.append(r)
+    reward_futs.append(asyncio.create_task(score(r)))   # score now, while others still run
+rewards = await asyncio.gather(*reward_futs)
+```
+
+### 2. Reward — plain tasks, scored per completed rollout
+
+```python
+reward_env = flyte.TaskEnvironment(name="rl-reward", resources=flyte.Resources(cpu=2, memory="4Gi"))
+
+@reward_env.task
+async def score(rollout: Rollout) -> float: ...
+# driven via asyncio.as_completed (see above), not a map barrier
+```
+
+MVP uses rule-based / verifiable rewards (math/exec/format checks). Model-based reward later = a
+second reusable vLLM env, same pattern as #1.
+
+### 3. Policy trainer — LoRA, single node
+
+```python
+train_env = flyte.TaskEnvironment(
+    name="rl-train",
+    image=flyte.Image.from_debian_base().with_pip_packages(
+        "torch", "trl", "peft", "transformers", "accelerate"),
+    resources=flyte.Resources(gpu=flyte.GPU("H100", 1), memory="80Gi", shm="auto"),
+)
+
+@train_env.task
+async def train_step(base: flyte.Dir, rollouts: list[Rollout], rewards: list[float],
+                     adapter: flyte.Dir) -> flyte.Dir:
+    local_base = await base.download()                  # same prefetched base dir
+    # one GRPO step with TRL GRPOTrainer + a PEFT LoRA config (frozen base, train adapter only),
+    # resuming from the previous adapter; save_pretrained() the adapter and return it as a flyte.Dir
+    # (a few MB). Pattern mirrors examples/checkpoint/unsloth_sft_checkpoint.py
+    ...
+```
+
+Full-weight RL would drop PEFT, train all params, and return the whole model `Dir` — bigger GPUs,
+bigger handoff; deferred.
+
+### 4. Driver — the loop (replaces Ray)
+
+A normal `@env.task async def train_rl(...)` that owns the loop. Each iteration: launch all rollouts
+with `asyncio.create_task`, drain them with `asyncio.as_completed` (scoring each rollout the moment it
+finishes so reward overlaps rollout), `asyncio.gather` the rewards, then call `train_step`. Wrap each
+iteration in `flyte.group(f"iter-{it}")` for the UI and use `flyte.Checkpoint` to resume a preempted
+driver. No Ray, no map barrier.
+
+## Keeping the model hot: reusable vs sidecar vs app
+
+| Pattern | Engine lives in | Adapter refresh | SDK status |
+|---|---|---|---|
+| **A. Reusable task, in-process `LLM`** | the warm task process | attach `LoRARequest` per call | ✅ works today |
+| **B. Reusable task + vLLM sidecar** | 2nd container in same pod (localhost HTTP) | HTTP load-adapter | ✅ works today (env-level `pod_template`) |
+| **C. App (`AppEnvironment`)** | independent autoscaled service + URL | HTTP / restart | ✅ but for *deployed serving* |
+
+Both A and B run on the same `ReusePolicy` env and are valid choices:
+
+- **Pattern A** — simplest: hold the `LLM` (frozen base) as a module global in the reusable env; it
+  stays warm across calls and we attach the per-iteration LoRA adapter via `LoRARequest`. No HTTP,
+  fewest moving parts. **Default for the MVP.**
+- **Pattern B (sidecar)** — define a vLLM server as a sidecar container via the **environment-level**
+  `pod_template` on the reusable env; the task talks to it over `localhost`. This works today —
+  reusable allows an env-level `pod_template` (sidecars). Benefits: engine-process isolation and an
+  OpenAI-compatible HTTP surface. The only restriction is you cannot pass `pod_template=` at the
+  `@env.task(...)` decorator level on a reusable env — set it on `TaskEnvironment(...)` instead. Pick
+  B if you want process isolation; otherwise A is simpler.
+- **Pattern C (apps)** — the *final deployed* model, separate from the loop.
+
+### How LoRA works here (and why no `VLLMAppEnvironment` changes are needed)
+
+LoRA never modifies the base weights, which is exactly why the warm replica works:
+
+1. The frozen base loads **once** — `LLM(model=base, enable_lora=True)` keeps it resident and reserves
+   LoRA slots.
+2. An adapter is tiny — just PEFT's low-rank `A`/`B` matrices (`adapter_model.safetensors` +
+   `adapter_config.json`, a few MB).
+3. Per request, `llm.generate(prompts, lora_request=LoRARequest(name, id, path))` applies
+   `W + (B·A)·scale` on the fly. The base in GPU memory is untouched; vLLM caches adapters by `id`.
+4. "Swapping weights each iteration" is just pointing at a new adapter dir with a new `id`. No
+   `collective_rpc`, no reshard, no reload.
+
+On the trainer side, TRL `GRPOTrainer` takes a `peft_config`, so only `A`/`B` train (base frozen) and
+`save_pretrained()` emits just the adapter `Dir`.
+
+Because the rollout worker uses vLLM's **in-process** `LLM` API (Pattern A), the loop needs **no
+changes to `flyteplugins.vllm` / `VLLMAppEnvironment`** — that plugin is an App (`vllm serve`) for the
+*deployed* model, a different entry point. **Deployment decision:** at the end of training,
+`merge_and_unload()` the final adapter into the base and serve the merged weights as a normal
+`VLLMAppEnvironment(model_path=...)` — zero plugin changes. (Serving hot-swappable adapters from a
+standing App would need a small `lora_path` enhancement to stage a second dir; out of scope for now.)
+
+## Flyte primitives used
+
+| Need | flyte-sdk primitive | MVP? |
+|---|---|---|
+| Warm GPU container with loaded model | `TaskEnvironment(reusable=ReusePolicy(...))` | ✅ |
+| Rollout fan-out + per-item reward | `asyncio.create_task` + `as_completed` + `gather` | ✅ |
+| GPU selection | `flyte.Resources(gpu=flyte.GPU("H100", 1), shm="auto")` | ✅ |
+| Inference engine | vLLM (`examples/genai/vllm/`) | ✅ |
+| Driver loop | async `@task` (no Ray) | ✅ |
+| Adapter handoff | `flyte.Dir` task output | ✅ |
+| Base-model prefetch | `flyte.prefetch.hf_model(repo, shard_config=...)` (vLLM-sharded → object store) | ✅ |
+| Resume | `flyte.Checkpoint` | ✅ |
+| Observability | Flyte UI DAG + `@task(report=True)` + `flyte.group` | ✅ |
+| Persistent volumes | `flyteplugins.union.io.Volume` / `ROVolume` | ⛔ deferred (prefetch covers base) |
+| Distributed training | `ClusteredTaskEnvironment` + `TorchRun` | ⛔ deferred |
+| Long-running serving | `flyte.app.AppEnvironment` | ⛔ deferred |
+
+## When to add the deferred pieces
+
+- **Full-weight RL** — when LoRA capacity is insufficient for the objective: train all params, emit
+  the whole model `Dir`, and hot-swap via vLLM `collective_rpc` (or restart).
+- **Volumes** — only if full-weight RL produces large checkpoints where re-downloading each iteration
+  hurts; a mounted Volume with versioned `v{it}/` paths avoids repeated transfer. (Base model is
+  covered by `flyte.prefetch.hf_model`; LoRA adapters are fine on `Dir`.)
+- **ClusteredTaskEnvironment + TorchRun** — when the policy model no longer trains on one node;
+  multi-node FSDP over a JobSet. The `train_step` body stays nearly identical; only the env changes.
+- **App serving** — the deployment phase, separate from the RL loop.
+
+The vLLM **sidecar** (Pattern B) is *not* deferred — it works today via an env-level `pod_template`
+and can be the rollout engine from the start if you prefer process isolation.
+
+## Components to reuse
+
+- `examples/genai/vllm/vllm_app.py` — `flyte.prefetch.hf_model` + vLLM load pattern (the base-model
+  prefetch this loop reuses); `vllm_app_sharded.py` for tensor parallelism.
+- `src/flyte/prefetch/_hf_model.py` — `hf_model(repo, shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(...)))`.
+- `examples/checkpoint/unsloth_sft_checkpoint.py` — TRL + PEFT LoRA + `flyte.Checkpoint` integration.
+- `examples/streaming/basic_as_completed.py` — the rollout→reward pipelining pattern (reusable env +
+  `create_task` + `as_completed` + `gather`); the driver loop is built directly on this.
+
+## Open questions to validate before writing code
+
+1. **vLLM dynamic LoRA attach** for the pinned vLLM version — `LLM(enable_lora=True)` + per-request
+   `LoRARequest(name, id, path)`, and whether new adapter versions attach without a restart. Prototype
+   in one warm replica first. (Full-weight `collective_rpc` is the deferred fallback.)
+2. **Reusable replica adapter convergence** — confirm all rollout replicas pick up the new adapter
+   version before that iteration's rollouts begin (the lazy version-check handles it; verify under
+   autoscaling `replicas=(1,4)`).
+3. **Consuming the prefetch output in a task** — `hf_model` returns a `Run`; apps wire it via
+   `flyte.app.RunOutput`. Confirm the cleanest way to pass the prefetched model dir into the reusable
+   `generate`/`train_step` *tasks* as a `flyte.Dir`, and that the vLLM-sharded layout loads directly.
+4. **GRPO loss ownership** — TRL `GRPOTrainer` (fast start) vs a hand-rolled step (full control of the
+   Flyte-driven loop).
+
+## Next step
+
+Build the runnable MVP as `rl_grpo_lora.py` in this folder: driver (async `as_completed` loop) +
+rollout (reusable warm vLLM, `enable_lora`, base via `flyte.prefetch.hf_model`) + reward + single-node
+TRL/PEFT GRPO `train_step`, with the LoRA adapter passed as a `flyte.Dir`. Validate vLLM dynamic LoRA
+attach end-to-end on a remote GPU before any scale-out.

--- a/v2/tutorials/rl_grpo_lora/README.md
+++ b/v2/tutorials/rl_grpo_lora/README.md
@@ -18,12 +18,14 @@ piece by piece. It has been validated end-to-end on a Union demo cluster (Qwen3-
 
 ---
 
-## Why Flyte is a great fit for RL training
+## Why Flyte with Union is a great fit for RL training
 
 RL training loops are awkward to run well: they mix very different kinds of work (GPU generation, CPU
 scoring, GPU training), they run for a long time so failures are inevitable, and they're hard to
-observe. These are exactly the problems Flyte is built for — which is why the loop in this tutorial is
-just a `for` loop of plain functions, with no bespoke infrastructure around it.
+observe. These are exactly the problems Flyte with Union is built for — which is why the loop in this
+tutorial is just a `for` loop of plain functions, with no bespoke infrastructure around it. (You write
+plain Flyte tasks; Union runs them — provisioning the GPUs, keeping warm pools alive, and serving the
+UI and reports.)
 
 - **Right hardware for each step, automatically.** Generation, reward, and training have different
   needs. Each is its own `TaskEnvironment` with its own resources — GPU for rollouts and the trainer,
@@ -437,7 +439,7 @@ Patterns this tutorial builds on, from the flyte-sdk examples:
 ---
 
 Everything here — warm GPU pools, CPU reward fan-out, a resumable driver loop, live reporting — is
-plain `flyte-sdk`. That's the takeaway: an RL training loop, which usually means standing up and
-operating a distributed system, becomes a handful of decorated Python functions on Flyte. Start with
-this small example, then scale the model, the reward, and the hardware without changing the shape of
-your code.
+plain `flyte-sdk` running on Union. That's the takeaway: an RL training loop, which usually means
+standing up and operating a distributed system, becomes a handful of decorated Python functions with
+Flyte and Union. Start with this small example, then scale the model, the reward, and the hardware
+without changing the shape of your code.

--- a/v2/tutorials/rl_grpo_lora/README.md
+++ b/v2/tutorials/rl_grpo_lora/README.md
@@ -1,83 +1,148 @@
-# RL (GRPO) for LLMs on Union with flyte-sdk
+# Reinforcement Learning for LLMs (GRPO + LoRA) on Union
 
-A reference architecture for running a **reinforcement-learning loop for LLMs (GRPO-style) natively
-on Union** with `flyte-sdk` — no Ray, no external scheduler. Flyte tasks *are* the orchestrator.
+A hands-on tutorial that builds a **reinforcement-learning loop for LLMs** — the same shape used to
+train reasoning models — and runs it on Union with `flyte-sdk`. You write ordinary Python functions;
+Flyte tasks *are* the orchestrator. No extra cluster or scheduler to stand up.
 
-The loop is the standard shape:
+By the end you'll understand, and have running:
+
+- the **RL-for-LLMs loop** (sample → generate → score → update → repeat) and the **GRPO** objective,
+- how to keep a **vLLM engine warm** across iterations so you don't reload the model every step,
+- how to train a **LoRA adapter** with a custom policy-gradient step and hand it back to the rollout
+  engine,
+- how to **pipeline** generation and reward scoring so they overlap,
+- and how to make the whole thing **resumable** with a live progress **report**.
+
+The full, runnable code is in [`rl_grpo_lora.py`](./rl_grpo_lora.py); this README explains it
+piece by piece. It has been validated end-to-end on a Union demo cluster (Qwen3-0.6B, L4 GPUs).
+
+---
+
+## Why Flyte is a great fit for RL training
+
+RL training loops are awkward to run well: they mix very different kinds of work (GPU generation, CPU
+scoring, GPU training), they run for a long time so failures are inevitable, and they're hard to
+observe. These are exactly the problems Flyte is built for — which is why the loop in this tutorial is
+just a `for` loop of plain functions, with no bespoke infrastructure around it.
+
+- **Right hardware for each step, automatically.** Generation, reward, and training have different
+  needs. Each is its own `TaskEnvironment` with its own resources — GPU for rollouts and the trainer,
+  cheap CPU for reward and the driver — and Flyte schedules each on the right machine. You're not
+  paying for a GPU to run a CPU reward function.
+- **Warm pools for expensive engines.** Loading a model into vLLM is slow. A `ReusePolicy`
+  environment keeps warm replicas alive between calls, so you load the base **once** and reuse it for
+  every iteration — the single most important optimization in an RL-for-LLMs loop, and it's one
+  argument.
+- **The loop is just Python.** The orchestrator *is* your async driver task. You fan out rollouts with
+  `asyncio.create_task`, overlap reward with `as_completed`, and call the trainer — all standard
+  Python, but each call runs in its own container, scales independently, and shows up in the UI.
+- **Long runs survive failures.** RL runs for hours or days; spot preemptions and OOMs happen.
+  `flyte.Checkpoint` resumes the loop mid-run, task `retries` recover transient failures, and the warm
+  pool autoscales and recovers without you writing a control plane.
+- **Observability out of the box.** Every rollout, reward, and gradient step is a tracked task with
+  logs and lineage. `flyte.group` organizes iterations in the DAG, and `report=True` streams a live
+  HTML report (reward, accuracy, loss) as training progresses.
+- **Data plumbing is handled.** The LoRA adapter flows trainer → generator as a `flyte.io.Dir` output;
+  the base model is prefetched into object storage once. No manual file shuffling, no shared
+  filesystem to manage.
+- **One system, from laptop to multi-node.** The same code runs on one GPU or scales out by changing
+  an environment (multi-GPU rollouts, multi-node training) — no second framework, no separate cluster
+  to stand up and babysit.
+
+The rest of this tutorial shows each of these in action.
+
+---
+
+## 1. The idea: RL for LLMs in one loop
+
+Reinforcement learning fine-tunes a language model against a **reward** instead of fixed target text.
+The loop is always the same shape:
 
 ```
-sample prompts → generate rollouts (vLLM) → score (reward) → policy update → refresh rollout adapter → repeat
+   sample prompts
+        │
+        ▼
+   generate several candidate answers per prompt        ← the "policy" (our LLM) acts
+        │
+        ▼
+   score each answer with a reward function             ← how good was it?
+        │
+        ▼
+   nudge the policy toward higher-reward answers         ← the gradient step
+        │
+        ▼
+   repeat with the improved policy
 ```
 
-This README is the **design doc**. A runnable example (`rl_grpo_lora.py`) will live next to it.
+### What is GRPO?
 
-## Design decisions
+**GRPO** (Group Relative Policy Optimization) is the algorithm behind models like DeepSeek-R1. Its one
+big idea: to decide whether an answer was "good," compare it to **other answers to the same prompt**,
+rather than training a separate value network to predict a baseline (as PPO does).
 
-- **No Ray** — orchestrate the loop with Flyte async tasks (`asyncio` directly).
-- **vLLM** for rollout generation (already supported in `examples/genai/vllm/`).
-- **Keep the inference model hot** across iterations — a reusable container (see the crux section).
-- **Pipeline rollout → reward** with `asyncio.create_task` + `as_completed` (not a map barrier), so
-  reward scoring overlaps in-flight rollouts.
-- **LoRA by default.** The frozen base stays loaded in the warm replica; each iteration the trainer
-  emits a small LoRA adapter the rollout engine attaches via vLLM's `LoRARequest`. This avoids
-  in-place full-weight updates (the riskiest piece), keeps the adapter handoff tiny (a few MB), and
-  shrinks the trainer to a single GPU. Full-weight RL is deferred.
-- **Base model via `flyte.prefetch.hf_model`** — stream the base into Flyte object store once,
-  **pre-sharded for vLLM** (`ShardConfig`/`VLLMShardArgs`), so every rollout replica and the trainer
-  load it directly with no reshard and no FUSE/Volume. Faster to load into vLLM than mounting a Volume.
-- **Volumes are not needed for the MVP** — prefetch covers the base, `flyte.Dir` covers the adapter.
-  A Volume stays a fallback only for very large *full-weight* checkpoints.
-- **Single-node trainer** for the MVP; `ClusteredTaskEnvironment` is the scale-out path.
+For each prompt we sample a **group** of `G` answers and compute a *group-relative advantage*:
 
-## TL;DR — MVP vs deferred
+```
+advantage(answer_i) = (reward_i − mean(rewards in group)) / (std(rewards in group) + ε)
+```
 
-| Concern | **MVP (build now)** | Deferred (add when needed) |
+Answers above their group's average get a positive advantage (make them more likely); answers below
+get a negative one (make them less likely). The training objective we maximize is:
+
+```
+J(θ) = mean over answers [ advantage_i · (average log-probability the policy assigns to answer_i) ]
+```
+
+That's it — no critic, no replay buffer. This tutorial implements that objective directly so you can
+see exactly what each line does (see [§5.4](#54-the-grpo-update-train_step)). The full GRPO paper adds
+a PPO-style clipped ratio and a KL penalty to a reference model; we omit both to keep the math
+legible — valid for the single-gradient-step-per-iteration setup here, and called out in the code.
+
+### Why LoRA?
+
+Updating all of a model's weights every iteration is expensive and makes the weight handoff between
+"trainer" and "generator" huge. Instead we freeze the base model and train a small **LoRA adapter** —
+a pair of low-rank matrices added on top of the frozen weights. The adapter is only a few **megabytes**,
+which is what makes the warm-engine trick below practical: the generator keeps the big frozen base
+resident and just swaps in the tiny adapter each iteration.
+
+### Coming from Ray / RLlib?
+
+If you've written RL with Ray, the mental map is direct:
+
+| In Ray/RLlib | Here (Union + flyte-sdk) |
+|---|---|
+| Rollout worker actors | the **warm vLLM pool** (`generate`) |
+| Learner / trainer | the **`train_step`** task |
+| Driver / Tune loop | a plain **`async` driver task** (`train_rl`) |
+| `ray.remote` calls | calling another `@task` (`await generate(...)`) |
+
+The difference is there's no separate Ray cluster to launch and babysit. Each box is just a Python
+function with a decorator; Flyte schedules them, moves data between them, retries them, and shows them
+in a UI.
+
+---
+
+## 2. How the work is laid out
+
+The loop is four task environments plus a one-time model prefetch:
+
+| Environment | Hardware | Job |
 |---|---|---|
-| Orchestration | async **driver task** runs the `for it in range(N)` loop (no Ray) | — |
-| Hot rollout model | **reusable container** (`ReusePolicy`) — in-process vLLM `LLM`, **or** a vLLM **sidecar** via env-level `pod_template` (both work today) | App for *deployed* serving |
-| Rollout fan-out + reward | `asyncio.create_task` all rollouts → `as_completed` scores each as it finishes → `gather` | autoscale `replicas=(min,max)` tuning |
-| Reward | rule-based / verifiable reward in plain tasks (GRPO-style) | model-based reward = 2nd reusable vLLM env |
-| Policy update | **LoRA** (PEFT) + TRL `GRPOTrainer`, single node, frozen base | full-weight update; `ClusteredTaskEnvironment`+`TorchRun` multi-node |
-| Base model weights | **`flyte.prefetch.hf_model(repo=..., shard_config=...)`** → vLLM-sharded `Dir` in object store | Volume / bake into image |
-| Adapter handoff trainer→rollout | tiny **LoRA adapter** as `flyte.Dir`; vLLM attaches via `LoRARequest` | full-weight `Dir` + vLLM `collective_rpc`; Volume for big full weights |
-| Resume / checkpoint | `flyte.Checkpoint` on the driver loop | — |
+| `generate` (rollout) | GPU, **warm pool** | run vLLM, produce candidate answers with the current adapter |
+| `score` (reward) | CPU | grade each answer (rule-based / verifiable) |
+| `train_step` (trainer) | GPU | one GRPO step, emit the new LoRA adapter |
+| `train_rl` (driver) | CPU | run the `for` loop, wire everything together, checkpoint |
 
-The only genuinely new piece vs a normal training job is **keeping vLLM warm + swapping the LoRA
-adapter each iteration**. Everything else is ordinary Flyte tasks.
+The one thing that's special is the **warm pool**. Loading an 8-billion-parameter (or even a small
+0.6B) model into a vLLM engine takes time. If `generate` were a fresh container every call, you'd pay
+that cost on every rollout. So `generate` lives in a **reusable** environment: Flyte keeps a small pool
+of warm replicas alive between calls, each holding the loaded engine in memory. Everything else is an
+ordinary ephemeral pod — cheap to start, and stateless between iterations.
 
-## Architecture
+### Warm-pool topology
 
-```
-flyte.prefetch.hf_model(repo, shard_config=vLLM) ──► base model Dir in object store (once)
-     │  loaded directly by vLLM on rollout + trainer (pre-sharded, no reshard, no FUSE)
-     ▼
-driver task (plain async, no Ray)
-┌───────────────────────────────────────────────────────────┐
-│ adapter = initial_lora;  base = prefetched_model_dir       │
-│ for it in range(N):                                        │
-│   prompts = sample(dataset)                                │
-│   # launch all rollouts at once on warm replicas          │
-│   futs = [create_task(generate(base, p, adapter, it))...] ─┼─► reusable vLLM env (WARM, base prefetched)
-│   # score each rollout the instant it completes           │
-│   for fut in as_completed(futs):                          │
-│       r = await fut;  rewards.append(create_task(score(r)))┼─► reward tasks (overlap rollouts)
-│   rollouts, rewards = ..., await gather(*rewards)          │
-│   adapter = await train_step(base, rollouts, rewards,     ─┼─► trainer env (1 node, LoRA/GRPO)
-│                              adapter)                       │
-│   await checkpoint.save(loop_state)         # → flyte.Dir  │
-└───────────────────────────────────────────────────────────┘
-     the LoRA adapter (a few MB) flows as a flyte.Dir output, passed by the driver
-```
-
-Three tasks across two GPU envs + a driver, plus a one-time prefetch.
-
-### Warm-pool topology — which parts are reused vs ephemeral
-
-Only **one** of the four environments is a warm pool: the **rollout generator**. It is the only place
-where cold-start cost (loading the frozen base into a vLLM engine, ~a minute) is large relative to the
-work each call does, so a `ReusePolicy` pool pays that once per replica and every iteration after just
-attaches a few-MB LoRA adapter. The driver, reward, and trainer are ordinary ephemeral pods — cheap to
-start, and holding no state between iterations (the trainer resumes from the adapter `Dir`).
+Only the rollout generator is a warm pool (🔥). The driver, reward, and trainer are ephemeral (❄):
 
 ```mermaid
 flowchart TB
@@ -113,214 +178,266 @@ flowchart TB
     style POOL fill:#fffbeb,stroke:#b45309,stroke-width:3px;
 ```
 
-🔥 = warm / reused across iterations (`ReusePolicy`) &nbsp;·&nbsp; ❄ = ephemeral (new container per call).
-This matches what the validated cluster run showed: the `generate` actions ran as Flyte **`actor`** tasks
-(the warm pool), while `init_adapter` / `score` / `train_step` ran as ordinary **`python`** pods.
+🔥 = warm / reused across iterations (`ReusePolicy`) &nbsp;·&nbsp; ❄ = ephemeral (new container per
+call). In the validated run, the `generate` actions ran as Flyte **`actor`** tasks (the warm pool),
+while `init_adapter` / `score` / `train_step` ran as ordinary **`python`** pods.
 
-### 0. Prefetch the base model (runs once, before the loop)
+---
+
+## 3. Prerequisites
+
+- A Union/Flyte deployment with **GPU** capacity (the tutorial uses `L4:1`; any single modern GPU works
+  for a small model).
+- A **Hugging Face token** stored as a Union secret. The example reads a secret named `hf-token`; create
+  yours with `flyte create secret hf-token` (or rename `HF_SECRET` in the code to match an existing one).
+- `flyte-sdk` configured for your endpoint (`flyte create config ...`).
+
+Run it with:
+
+```bash
+python rl_grpo_lora.py
+```
+
+The script prefetches the base model, then launches the training loop. The first run also builds the
+container image (vLLM + flashinfer + PEFT), which takes a few minutes; later runs reuse it.
+
+---
+
+## 4. The model weights: prefetch once
+
+vLLM (the generator) and Transformers/PEFT (the trainer) both need the base model's weights. Rather
+than have every task download from Hugging Face, we **prefetch once** into Union's object store and
+pass the resulting directory into the tasks as a `flyte.io.Dir`:
 
 ```python
 import flyte.prefetch
-from flyte.prefetch import ShardConfig, VLLMShardArgs
 
-# stream base into object store, pre-sharded for vLLM — faster load, no FUSE/Volume
-run = flyte.prefetch.hf_model(
-    repo="Qwen/Qwen3-8B",
-    shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(tensor_parallel_size=1)),
-    hf_token_key="HF_TOKEN",
-)
+run = flyte.prefetch.hf_model(repo="Qwen/Qwen3-0.6B", hf_token_key="hf-token")
 run.wait()
+base_dir = run.outputs()[0]          # the model Dir, passed into train_rl(base=base_dir)
 ```
 
-The vLLM examples use this exact pattern — see `examples/genai/vllm/vllm_app.py`, which wires the
-prefetched dir into a server via `flyte.app.RunOutput(type="directory", run_name=run.name)`.
+> **Note — plain weights, not vLLM-sharded.** `hf_model` can pre-shard for vLLM, but that layout isn't
+> readable by the Transformers/PEFT trainer. For a single GPU (`tensor_parallel_size=1`) vLLM loads
+> plain Hugging Face weights directly with no downside, so we prefetch plain weights and share one
+> directory with both the generator and the trainer. Pre-sharding only pays off for multi-GPU rollout
+> replicas, which would then need a separate copy for the trainer.
 
-### 1. Rollout generator — reusable, warm vLLM (the core feature)
+---
+
+## 5. Walkthrough
+
+### 5.1 Rollouts on a warm vLLM pool (`generate`)
+
+This is the core technique. The environment is marked **reusable** so Flyte keeps warm replicas
+between calls, and we hold the engine in a **module-global** so it survives across invocations of the
+same replica:
 
 ```python
 rollout_env = flyte.TaskEnvironment(
-    name="rl-rollout",
-    image=flyte.Image.from_debian_base().with_pip_packages("vllm", "transformers"),
-    resources=flyte.Resources(gpu=flyte.GPU("H100", 1), memory="80Gi", shm="auto"),
-    reusable=flyte.ReusePolicy(replicas=(1, 4), concurrency=4, idle_ttl=300),
-    secrets=[flyte.Secret(key="hf-token", as_env_var="HF_TOKEN")],
+    name="rl-grpo-rollout",
+    image=image,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=flyte.GPU("L4", 1), shm="auto"),
+    reusable=flyte.ReusePolicy(replicas=(1, 4), concurrency=1, idle_ttl=300, scaledown_ttl=120),
+    secrets=[HF_SECRET],
 )
 
-_ENGINE = None            # module-global → persists across calls in a warm replica
-_ADAPTER_DIR = {}         # version -> local adapter path (downloaded once)
+_ENGINE = None             # persists across calls within a warm replica
+_ADAPTER_PATHS = {}        # adapter version -> local path (downloaded once)
 
 @rollout_env.task
-async def generate(base: flyte.Dir, prompts: list[str], adapter: flyte.Dir, version: int) -> list[Rollout]:
+async def generate(base, question, answer, adapter, version, group_id) -> list[Rollout]:
     global _ENGINE
-    if _ENGINE is None:
-        local_base = await base.download()                        # prefetched, vLLM-sharded → load directly
-        _ENGINE = build_vllm_engine(local_base, enable_lora=True) # loaded once, stays warm
-    if version not in _ADAPTER_DIR:
-        _ADAPTER_DIR[version] = await adapter.download()          # tiny LoRA adapter → local path
-    lora = LoRARequest(f"policy-v{version}", version, _ADAPTER_DIR[version])
-    return run_generation(_ENGINE, prompts, lora_request=lora)    # attach adapter per request
+    from vllm import LLM, SamplingParams
+    from vllm.lora.request import LoRARequest
+
+    if _ENGINE is None:                                   # builds ONCE per replica, then stays warm
+        local_base = await base.download()
+        _ENGINE = LLM(model=local_base, enable_lora=True, max_lora_rank=LORA_RANK, ...)
+
+    if version not in _ADAPTER_PATHS:                     # download each adapter version once
+        _ADAPTER_PATHS[version] = await adapter.download()
+
+    lora = LoRARequest(f"policy-v{version}", version + 1, _ADAPTER_PATHS[version])
+    sampling = SamplingParams(n=GROUP_SIZE, temperature=1.0, max_tokens=MAX_NEW_TOKENS)
+    outputs = await asyncio.to_thread(_ENGINE.generate, [build_prompt(question)], sampling,
+                                      lora_request=lora)
+    return [Rollout(group_id=group_id, question=question, completion=o.text, answer=answer)
+            for o in outputs[0].outputs]
 ```
 
-The base never reloads — only the small adapter is attached via `LoRARequest`.
+Key points:
 
-Fan out and pipeline reward as each rollout finishes (following
-`examples/streaming/basic_as_completed.py` — no map barrier, reward overlaps in-flight rollouts):
+- **`enable_lora=True`** reserves adapter slots when the engine starts. The frozen base loads once.
+- Each call attaches the iteration's adapter with **`LoRARequest(name, id, path)`** — vLLM applies
+  `W + (B·A)·scale` on the fly. The base weights in GPU memory are never touched; "swapping weights"
+  is just pointing at a new adapter directory with a new id. (`id` must be ≥ 1, hence `version + 1`.)
+- One call returns a whole **group** of `GROUP_SIZE` completions for one prompt — exactly the group
+  GRPO needs to compute relative advantages.
 
-```python
-rollout_futs = [asyncio.create_task(generate(base, b, adapter, it)) for b in prompt_batches]
-rollouts, reward_futs = [], []
-for fut in asyncio.as_completed(rollout_futs):       # ready in completion order
-    r = await fut
-    rollouts.append(r)
-    reward_futs.append(asyncio.create_task(score(r)))   # score now, while others still run
-rewards = await asyncio.gather(*reward_futs)
-```
+### 5.2 Reward (`score`)
 
-### 2. Reward — plain tasks, scored per completed rollout
+The reward is a plain CPU task. This tutorial uses a **verifiable** reward — a tiny arithmetic dataset
+where we can check the answer exactly — which is the cleanest way to see RL actually working:
 
 ```python
-reward_env = flyte.TaskEnvironment(name="rl-reward", resources=flyte.Resources(cpu=2, memory="4Gi"))
-
 @reward_env.task
-async def score(rollout: Rollout) -> float: ...
-# driven via asyncio.as_completed (see above), not a map barrier
+async def score(rollout: Rollout) -> float:
+    reward = 0.0
+    if "####" in rollout.completion:          # format bonus: did it follow instructions?
+        reward += 0.2
+    if _extract_answer(rollout.completion) == rollout.answer:   # correctness
+        reward += 1.0
+    return reward
 ```
 
-MVP uses rule-based / verifiable rewards (math/exec/format checks). Model-based reward later = a
-second reusable vLLM env, same pattern as #1.
+Verifiable rewards (math, code execution, format checks) are ideal for learning the mechanics. A
+model-based reward later is just a second warm vLLM environment scored the same way.
 
-### 3. Policy trainer — LoRA, single node
+### 5.3 Pipelining generation and reward
+
+Rather than wait for *all* rollouts to finish before scoring (a barrier), we launch every rollout at
+once and score each group **the moment it completes**, so reward computation overlaps generation still
+in flight:
 
 ```python
-train_env = flyte.TaskEnvironment(
-    name="rl-train",
-    image=flyte.Image.from_debian_base().with_pip_packages(
-        "torch", "trl", "peft", "transformers", "accelerate"),
-    resources=flyte.Resources(gpu=flyte.GPU("H100", 1), memory="80Gi", shm="auto"),
-)
+rollout_futs = [asyncio.create_task(generate(base, q, a, adapter, version, gid))
+                for gid, (q, a) in enumerate(prompts)]
 
-@train_env.task
-async def train_step(base: flyte.Dir, rollouts: list[Rollout], rewards: list[float],
-                     adapter: flyte.Dir) -> flyte.Dir:
-    local_base = await base.download()                  # same prefetched base dir
-    # one GRPO step with TRL GRPOTrainer + a PEFT LoRA config (frozen base, train adapter only),
-    # resuming from the previous adapter; save_pretrained() the adapter and return it as a flyte.Dir
-    # (a few MB). Pattern mirrors examples/checkpoint/unsloth_sft_checkpoint.py
-    ...
+rollouts, reward_futs = [], []
+for fut in asyncio.as_completed(rollout_futs):    # yields in completion order
+    for r in await fut:
+        rollouts.append(r)
+        reward_futs.append(asyncio.create_task(score(r)))   # score now, others still running
+
+rewards = await asyncio.gather(*reward_futs)      # aligned with rollouts
 ```
 
-Full-weight RL would drop PEFT, train all params, and return the whole model `Dir` — bigger GPUs,
-bigger handoff; deferred.
+This is ordinary `asyncio` — `create_task` to fan out, `as_completed` to drain, `gather` to collect.
+Because each `await generate(...)` / `score(...)` is a Flyte task call, you get this overlap *across
+containers* for free.
 
-### 4. Driver — the loop (replaces Ray)
+### 5.4 The GRPO update (`train_step`)
 
-A normal `@env.task async def train_rl(...)` that owns the loop. Each iteration: launch all rollouts
-with `asyncio.create_task`, drain them with `asyncio.as_completed` (scoring each rollout the moment it
-finishes so reward overlaps rollout), `asyncio.gather` the rewards, then call `train_step`. Wrap each
-iteration in `flyte.group(f"iter-{it}")` for the UI and use `flyte.Checkpoint` to resume a preempted
-driver. No Ray, no map barrier.
+The trainer resumes the previous adapter (frozen base, trainable LoRA), computes group-relative
+advantages, takes **one** policy-gradient step, and saves the new adapter:
 
-## Keeping the model hot: reusable vs sidecar vs app
+```python
+@train_env.task
+async def train_step(base, rollouts, rewards, adapter, version) -> tuple[flyte.io.Dir, float, int]:
+    model = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True)  # resume adapter
+    advantages = _group_normalized_advantages(rollouts, rewards)                     # GRPO baseline
 
-| Pattern | Engine lives in | Adapter refresh | SDK status |
-|---|---|---|---|
-| **A. Reusable task, in-process `LLM`** | the warm task process | attach `LoRARequest` per call | ✅ works today |
-| **B. Reusable task + vLLM sidecar** | 2nd container in same pod (localhost HTTP) | HTTP load-adapter | ✅ works today (env-level `pod_template`) |
-| **C. App (`AppEnvironment`)** | independent autoscaled service + URL | HTTP / restart | ✅ but for *deployed serving* |
+    optimizer.zero_grad()
+    for rollout, advantage in zip(rollouts, advantages):
+        # log-prob the policy assigns to the completion tokens
+        seq_log_prob = completion_log_prob(model, rollout)
+        loss = -advantage * seq_log_prob                  # push up good answers, down bad ones
+        loss.backward()                                   # accumulate across the batch
+    optimizer.step()                                      # one GRPO step
 
-Both A and B run on the same `ReusePolicy` env and are valid choices:
+    model.save_pretrained(out_dir)                        # writes only the small adapter
+    return await flyte.io.Dir.from_local(out_dir), mean_loss, contributing
+```
 
-- **Pattern A** — simplest: hold the `LLM` (frozen base) as a module global in the reusable env; it
-  stays warm across calls and we attach the per-iteration LoRA adapter via `LoRARequest`. No HTTP,
-  fewest moving parts. **Default for the MVP.**
-- **Pattern B (sidecar)** — define a vLLM server as a sidecar container via the **environment-level**
-  `pod_template` on the reusable env; the task talks to it over `localhost`. This works today —
-  reusable allows an env-level `pod_template` (sidecars). Benefits: engine-process isolation and an
-  OpenAI-compatible HTTP surface. The only restriction is you cannot pass `pod_template=` at the
-  `@env.task(...)` decorator level on a reusable env — set it on `TaskEnvironment(...)` instead. Pick
-  B if you want process isolation; otherwise A is simpler.
-- **Pattern C (apps)** — the *final deployed* model, separate from the loop.
+`_group_normalized_advantages` is the GRPO formula from [§1](#what-is-grpo): standardize each reward
+against its prompt group. `save_pretrained` on a PEFT model writes only `adapter_config.json` +
+`adapter_model.safetensors` (a few MB) — that `Dir` is the entire trainer→generator handoff.
 
-### How LoRA works here (and why no `VLLMAppEnvironment` changes are needed)
+> **Why a custom step instead of a library trainer?** Libraries like TRL's `GRPOTrainer` own the whole
+> loop — they generate completions and call the reward function *internally*. That's great for a
+> self-contained job, but it would bypass our warm vLLM pool and the as-completed pipelining, which are
+> the whole point of running this on Union. Driving one explicit gradient step keeps generation, reward,
+> and the update as separate, observable Flyte tasks.
 
-LoRA never modifies the base weights, which is exactly why the warm replica works:
+### 5.5 The driver loop (`train_rl`)
 
-1. The frozen base loads **once** — `LLM(model=base, enable_lora=True)` keeps it resident and reserves
-   LoRA slots.
-2. An adapter is tiny — just PEFT's low-rank `A`/`B` matrices (`adapter_model.safetensors` +
-   `adapter_config.json`, a few MB).
-3. Per request, `llm.generate(prompts, lora_request=LoRARequest(name, id, path))` applies
-   `W + (B·A)·scale` on the fly. The base in GPU memory is untouched; vLLM caches adapters by `id`.
-4. "Swapping weights each iteration" is just pointing at a new adapter dir with a new `id`. No
-   `collective_rpc`, no reshard, no reload.
+The driver is a normal `async` task that owns the `for` loop. Each iteration it fans out rollouts,
+scores them, takes a GRPO step, then **checkpoints** loop state and **publishes a report**:
 
-On the trainer side, TRL `GRPOTrainer` takes a `peft_config`, so only `A`/`B` train (base frozen) and
-`save_pretrained()` emits just the adapter `Dir`.
+```python
+@driver_env.task(report=True)
+async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> flyte.io.Dir:
+    cp = flyte.ctx().checkpoint
+    # resume from a previous attempt if one exists ...
+    adapter = await init_adapter(base)          # iteration 0 starts from a fresh adapter
 
-Because the rollout worker uses vLLM's **in-process** `LLM` API (Pattern A), the loop needs **no
-changes to `flyteplugins.vllm` / `VLLMAppEnvironment`** — that plugin is an App (`vllm serve`) for the
-*deployed* model, a different entry point. **Deployment decision:** at the end of training,
-`merge_and_unload()` the final adapter into the base and serve the merged weights as a normal
-`VLLMAppEnvironment(model_path=...)` — zero plugin changes. (Serving hot-swappable adapters from a
-standing App would need a small `lora_path` enhancement to stage a second dir; out of scope for now.)
+    for it in range(start_iter, num_iterations):
+        with flyte.group(f"iter-{it}"):         # groups this iteration's tasks in the UI
+            rollouts, rewards = ...             # fan out + as_completed (see §5.3)
+            adapter, loss, _ = await train_step(base, rollouts, rewards, adapter, it + 1)
+            await cp.save(loop_state)           # resumable: survives preemption
+            await _publish_report(history, status="running")    # live HTML report
+    return adapter
+```
 
-## Flyte primitives used
+Two things worth calling out:
 
-| Need | flyte-sdk primitive | MVP? |
-|---|---|---|
-| Warm GPU container with loaded model | `TaskEnvironment(reusable=ReusePolicy(...))` | ✅ |
-| Rollout fan-out + per-item reward | `asyncio.create_task` + `as_completed` + `gather` | ✅ |
-| GPU selection | `flyte.Resources(gpu=flyte.GPU("H100", 1), shm="auto")` | ✅ |
-| Inference engine | vLLM (`examples/genai/vllm/`) | ✅ |
-| Driver loop | async `@task` (no Ray) | ✅ |
-| Adapter handoff | `flyte.Dir` task output | ✅ |
-| Base-model prefetch | `flyte.prefetch.hf_model(repo, shard_config=...)` (vLLM-sharded → object store) | ✅ |
-| Resume | `flyte.Checkpoint` | ✅ |
-| Observability | Flyte UI DAG + `@task(report=True)` + `flyte.group` | ✅ |
-| Persistent volumes | `flyteplugins.union.io.Volume` / `ROVolume` | ⛔ deferred (prefetch covers base) |
-| Distributed training | `ClusteredTaskEnvironment` + `TorchRun` | ⛔ deferred |
-| Long-running serving | `flyte.app.AppEnvironment` | ⛔ deferred |
+- **`flyte.Checkpoint`** persists `{iteration, adapter location, report history}` each step. If the
+  driver is preempted, it resumes mid-run instead of starting over.
+- **`flyte.group("iter-N")`** nests each iteration's tasks in the UI so the DAG is readable.
 
-## When to add the deferred pieces
+### 5.6 The live report
 
-- **Full-weight RL** — when LoRA capacity is insufficient for the objective: train all params, emit
-  the whole model `Dir`, and hot-swap via vLLM `collective_rpc` (or restart).
-- **Volumes** — only if full-weight RL produces large checkpoints where re-downloading each iteration
-  hurts; a mounted Volume with versioned `v{it}/` paths avoids repeated transfer. (Base model is
-  covered by `flyte.prefetch.hf_model`; LoRA adapters are fine on `Dir`.)
-- **ClusteredTaskEnvironment + TorchRun** — when the policy model no longer trains on one node;
-  multi-node FSDP over a JobSet. The `train_step` body stays nearly identical; only the env changes.
-- **App serving** — the deployment phase, separate from the RL loop.
+`report=True` plus [`report_helpers.py`](./report_helpers.py) gives you a self-contained HTML report,
+re-published every iteration, showing reward / accuracy / format-rate / loss charts, a per-iteration
+table, and the best sample completion. It's pure Python (inline SVG, no plotting dependency) so the
+CPU driver stays light. Open it from the run's **Report** tab in the Union UI.
 
-The vLLM **sidecar** (Pattern B) is *not* deferred — it works today via an env-level `pod_template`
-and can be the rollout engine from the start if you prefer process isolation.
+---
 
-## Components to reuse
+## 6. What this validates
 
-- `examples/genai/vllm/vllm_app.py` — `flyte.prefetch.hf_model` + vLLM load pattern (the base-model
-  prefetch this loop reuses); `vllm_app_sharded.py` for tensor parallelism.
-- `src/flyte/prefetch/_hf_model.py` — `hf_model(repo, shard_config=ShardConfig(engine="vllm", args=VLLMShardArgs(...)))`.
-- `examples/checkpoint/unsloth_sft_checkpoint.py` — TRL + PEFT LoRA + `flyte.Checkpoint` integration.
-- `examples/streaming/basic_as_completed.py` — the rollout→reward pipelining pattern (reusable env +
-  `create_task` + `as_completed` + `gather`); the driver loop is built directly on this.
+Running `python rl_grpo_lora.py` against a Union demo cluster (Qwen3-0.6B, L4 GPUs, 3 GRPO iterations)
+exercises the whole loop:
 
-## Open questions to validate before writing code
+- prefetch → `init_adapter` → **12 warm-vLLM rollouts** → **72 pipelined reward tasks** →
+  **3 GRPO steps** → final LoRA adapter (`v3`) returned as a `flyte.io.Dir`,
+- with the live report published each iteration, the driver checkpointing per step, and the rollout
+  tasks running as warm **`actor`** replicas.
 
-1. **vLLM dynamic LoRA attach** for the pinned vLLM version — `LLM(enable_lora=True)` + per-request
-   `LoRARequest(name, id, path)`, and whether new adapter versions attach without a restart. Prototype
-   in one warm replica first. (Full-weight `collective_rpc` is the deferred fallback.)
-2. **Reusable replica adapter convergence** — confirm all rollout replicas pick up the new adapter
-   version before that iteration's rollouts begin (the lazy version-check handles it; verify under
-   autoscaling `replicas=(1,4)`).
-3. **Consuming the prefetch output in a task** — `hf_model` returns a `Run`; apps wire it via
-   `flyte.app.RunOutput`. Confirm the cleanest way to pass the prefetched model dir into the reusable
-   `generate`/`train_step` *tasks* as a `flyte.Dir`, and that the vLLM-sharded layout loads directly.
-4. **GRPO loss ownership** — TRL `GRPOTrainer` (fast start) vs a hand-rolled step (full control of the
-   Flyte-driven loop).
+(With a 0.6B model and a toy dataset this proves the *machinery*, not convergence — scale the model and
+dataset for a real learning signal.)
 
-## Next step
+---
 
-Build the runnable MVP as `rl_grpo_lora.py` in this folder: driver (async `as_completed` loop) +
-rollout (reusable warm vLLM, `enable_lora`, base via `flyte.prefetch.hf_model`) + reward + single-node
-TRL/PEFT GRPO `train_step`, with the LoRA adapter passed as a `flyte.Dir`. Validate vLLM dynamic LoRA
-attach end-to-end on a remote GPU before any scale-out.
+## 7. Going further
+
+The example is intentionally the smallest thing that runs end to end. Natural next steps:
+
+- **A real task & bigger policy.** Swap `BASE_MODEL_REPO` and `DATASET` for a larger model and a real
+  verifiable-reward dataset (math, code, tool use). The code is unchanged.
+- **Model-based reward.** Replace the rule in `score` with a call to a second warm vLLM environment
+  (e.g. an LLM judge) — same warm-pool pattern as the generator.
+- **Multi-GPU rollouts.** Raise `tensor_parallel_size` and prefetch a vLLM-sharded copy for the
+  generator (keeping a plain copy for the trainer).
+- **Multi-node training.** When the policy outgrows one GPU, move `train_step` to a
+  `ClusteredTaskEnvironment` with `TorchRun`; the body stays nearly the same.
+- **Full-weight RL.** If LoRA capacity isn't enough, train all parameters and hand off the full model
+  directory instead of an adapter.
+- **Serving the result.** Merge the final adapter into the base (`merge_and_unload()`) and serve it
+  with `VLLMAppEnvironment`.
+- **The full GRPO objective.** Add the PPO-style clipped ratio and a KL penalty to a reference model
+  for stability over many steps.
+
+---
+
+## 8. Files & references
+
+- [`rl_grpo_lora.py`](./rl_grpo_lora.py) — the full example: prefetch, warm-vLLM rollouts, reward,
+  GRPO `train_step`, and the async driver loop.
+- [`report_helpers.py`](./report_helpers.py) — dependency-free HTML/SVG report toolkit.
+
+Patterns this tutorial builds on, from the flyte-sdk examples:
+
+- `examples/genai/vllm/vllm_app.py` — the `flyte.prefetch.hf_model` + vLLM image recipe.
+- `examples/streaming/basic_as_completed.py` — the reusable-env + `as_completed` pipelining pattern.
+- `examples/checkpoint/unsloth_sft_checkpoint.py` — TRL/PEFT LoRA + `flyte.Checkpoint`.
+
+---
+
+Everything here — warm GPU pools, CPU reward fan-out, a resumable driver loop, live reporting — is
+plain `flyte-sdk`. That's the takeaway: an RL training loop, which usually means standing up and
+operating a distributed system, becomes a handful of decorated Python functions on Flyte. Start with
+this small example, then scale the model, the reward, and the hardware without changing the shape of
+your code.

--- a/v2/tutorials/rl_grpo_lora/README.md
+++ b/v2/tutorials/rl_grpo_lora/README.md
@@ -71,6 +71,52 @@ driver task (plain async, no Ray)
 
 Three tasks across two GPU envs + a driver, plus a one-time prefetch.
 
+### Warm-pool topology — which parts are reused vs ephemeral
+
+Only **one** of the four environments is a warm pool: the **rollout generator**. It is the only place
+where cold-start cost (loading the frozen base into a vLLM engine, ~a minute) is large relative to the
+work each call does, so a `ReusePolicy` pool pays that once per replica and every iteration after just
+attaches a few-MB LoRA adapter. The driver, reward, and trainer are ordinary ephemeral pods — cheap to
+start, and holding no state between iterations (the trainer resumes from the adapter `Dir`).
+
+```mermaid
+flowchart TB
+    P["flyte.prefetch.hf_model(Qwen3-0.6B)<br/><i>runs once, before the loop</i>"] --> B["base model Dir<br/>in object store"]
+
+    D["DRIVER · train_rl<br/>❄ ephemeral · CPU · one pod for the whole run<br/>async <code>for it in range(N)</code>:<br/>fan out → score → GRPO step → checkpoint"]
+
+    subgraph POOL["🔥 WARM POOL · rl-grpo-rollout · GPU — ReusePolicy(replicas=1..4, concurrency=1, idle_ttl=300)"]
+      direction LR
+      R1["replica 1<br/>vLLM + BASE<br/>(frozen, resident)"]
+      R2["replica 2<br/>vLLM + BASE<br/>(frozen, resident)"]
+      R3["replica 3..4<br/>autoscaled on load"]
+    end
+
+    S["score × N<br/>❄ ephemeral · CPU<br/>fresh pod per call (driven by as_completed)"]
+    T["train_step<br/>❄ ephemeral · GPU<br/>one GRPO step per iteration"]
+
+    D -- "generate(prompt, adapter, version)" --> POOL
+    POOL -- "rollouts" --> S
+    S -- "rewards" --> T
+    T == "new LoRA adapter (few MB, flyte.Dir)" ==> D
+    D -. "attached next iteration via LoRARequest" .-> POOL
+
+    B -. "loaded once per replica" .-> POOL
+    B -. "downloaded per step" .-> T
+
+    classDef warm fill:#fde68a,stroke:#b45309,stroke-width:2px,color:#1a1a2e;
+    classDef ephem fill:#e0f2fe,stroke:#0369a1,color:#1a1a2e;
+    classDef store fill:#ede9fe,stroke:#6d28d9,color:#1a1a2e;
+    class R1,R2,R3 warm;
+    class D,S,T ephem;
+    class P,B store;
+    style POOL fill:#fffbeb,stroke:#b45309,stroke-width:3px;
+```
+
+🔥 = warm / reused across iterations (`ReusePolicy`) &nbsp;·&nbsp; ❄ = ephemeral (new container per call).
+This matches what the validated cluster run showed: the `generate` actions ran as Flyte **`actor`** tasks
+(the warm pool), while `init_adapter` / `score` / `train_step` ran as ordinary **`python`** pods.
+
 ### 0. Prefetch the base model (runs once, before the loop)
 
 ```python

--- a/v2/tutorials/rl_grpo_lora/README.md
+++ b/v2/tutorials/rl_grpo_lora/README.md
@@ -1,55 +1,60 @@
 # Reinforcement Learning for LLMs (GRPO + LoRA) on Union
 
-A hands-on tutorial that builds a **reinforcement-learning loop for LLMs** — the same shape used to
-train reasoning models — and runs it on Union with `flyte-sdk`. You write ordinary Python functions;
-Flyte tasks *are* the orchestrator. No extra cluster or scheduler to stand up.
+This is a hands-on tutorial that demonstrates a **reinforcement-learning loop for LLMs** — the same
+kind of loop the major labs use to train reasoning models. It is implemented **entirely on Flyte's
+SDK**: Flyte orchestrates the tasks and applies tricks like **reusable-container warm pools** to keep
+the loop fast. The benefit of Flyte really shows here — it **autoscales to the resources you have**,
+**isolates concurrent runs** from each other, resumes after failures, and streams progress to a live
+report. And once you have Union/Flyte installed, getting this example running is trivial: it's one
+`python` command.
 
 By the end you'll understand, and have running:
 
 - the **RL-for-LLMs loop** (sample → generate → score → update → repeat) and the **GRPO** objective,
-- how to keep a **vLLM engine warm** across iterations so you don't reload the model every step,
-- how to train a **LoRA adapter** with a custom policy-gradient step and hand it back to the rollout
-  engine,
-- how to **pipeline** generation and reward scoring so they overlap,
-- and how to make the whole thing **resumable** with a live progress **report**.
+- how Flyte keeps a **vLLM engine warm** across iterations so you never reload the model,
+- how a small **LoRA adapter** is trained with one policy-gradient step and handed back to the
+  generator,
+- how generation and reward scoring **pipeline** so they overlap, and
+- how the whole run is **resumable** with a live progress **report**.
 
-The full, runnable code is in [`rl_grpo_lora.py`](./rl_grpo_lora.py); this README explains it
+The full, runnable code is in [`rl_grpo_lora.py`](./rl_grpo_lora.py); this README walks through it
 piece by piece. It has been validated end-to-end on a Union demo cluster (Qwen3-0.6B, L4 GPUs).
 
 ---
 
 ## Why Flyte with Union is a great fit for RL training
 
-RL training loops are awkward to run well: they mix very different kinds of work (GPU generation, CPU
-scoring, GPU training), they run for a long time so failures are inevitable, and they're hard to
-observe. These are exactly the problems Flyte with Union is built for — which is why the loop in this
-tutorial is just a `for` loop of plain functions, with no bespoke infrastructure around it. (You write
-plain Flyte tasks; Union runs them — provisioning the GPUs, keeping warm pools alive, and serving the
-UI and reports.)
+RL training loops are genuinely awkward to run well. They mix wildly different work — GPU text
+generation, cheap CPU scoring, GPU gradient steps — in a tight loop; they run long enough that
+failures are a certainty, not a risk; and they're hard to watch while they run. Flyte with Union is
+built for exactly this shape of problem, which is why the loop in this tutorial is nothing more than a
+`for` loop of ordinary Python functions. You write plain Flyte tasks; Union runs them — provisioning
+the GPUs, keeping the warm pools alive, and serving the UI and reports.
 
-- **Right hardware for each step, automatically.** Generation, reward, and training have different
-  needs. Each is its own `TaskEnvironment` with its own resources — GPU for rollouts and the trainer,
-  cheap CPU for reward and the driver — and Flyte schedules each on the right machine. You're not
-  paying for a GPU to run a CPU reward function.
-- **Warm pools for expensive engines.** Loading a model into vLLM is slow. A `ReusePolicy`
-  environment keeps warm replicas alive between calls, so you load the base **once** and reuse it for
-  every iteration — the single most important optimization in an RL-for-LLMs loop, and it's one
-  argument.
-- **The loop is just Python.** The orchestrator *is* your async driver task. You fan out rollouts with
-  `asyncio.create_task`, overlap reward with `as_completed`, and call the trainer — all standard
-  Python, but each call runs in its own container, scales independently, and shows up in the UI.
-- **Long runs survive failures.** RL runs for hours or days; spot preemptions and OOMs happen.
-  `flyte.Checkpoint` resumes the loop mid-run, task `retries` recover transient failures, and the warm
-  pool autoscales and recovers without you writing a control plane.
-- **Observability out of the box.** Every rollout, reward, and gradient step is a tracked task with
-  logs and lineage. `flyte.group` organizes iterations in the DAG, and `report=True` streams a live
-  HTML report (reward, accuracy, loss) as training progresses.
-- **Data plumbing is handled.** The LoRA adapter flows trainer → generator as a `flyte.io.Dir` output;
-  the base model is prefetched into object storage once. No manual file shuffling, no shared
-  filesystem to manage.
-- **One system, from laptop to multi-node.** The same code runs on one GPU or scales out by changing
-  an environment (multi-GPU rollouts, multi-node training) — no second framework, no separate cluster
-  to stand up and babysit.
+What you get, essentially for free:
+
+- **The right hardware for each step.** Generation, reward, and training have different needs, so each
+  is its own task environment with its own resources — GPU for rollouts and the trainer, cheap CPU for
+  reward and the driver. You never pay for a GPU to run a reward function.
+- **Warm pools for the expensive parts.** Loading a model into vLLM is slow, so the generator runs in
+  a *reusable* environment: Flyte holds a pool of warm replicas with the model already resident, and
+  every iteration reuses them. It's the single biggest speedup in an RL-for-LLMs loop, and it costs one
+  line of config.
+- **Autoscaling to the resources you have.** The warm pool scales between a min and max replica count
+  with demand, so the rollout fan-out spreads across whatever GPUs are available and scales back down
+  when the loop is idle — you don't size a cluster up front.
+- **Isolation across concurrent runs.** Every run is its own set of containers with its own warm pool,
+  state, and report. You (and your teammates) can run many experiments at once without them stepping on
+  each other.
+- **Long runs that survive failures.** RL runs for hours or days; spot preemptions and OOMs happen.
+  `flyte.Checkpoint` resumes the loop mid-run, task retries recover transient errors, and the pool
+  recovers replicas on its own — no control plane to write.
+- **Observability and data plumbing, handled.** Every rollout, reward, and gradient step is a tracked
+  task with logs and lineage; `flyte.group` organizes iterations in the DAG and `report=True` streams a
+  live report. The LoRA adapter flows trainer → generator as a `flyte.io.Dir`, and the base model is
+  prefetched into object storage once — no shared filesystem, no manual file shuffling.
+- **One system, laptop to multi-node.** The same code runs on a single GPU or scales out by changing an
+  environment — no second framework, no separate cluster to stand up and babysit.
 
 The rest of this tutorial shows each of these in action.
 
@@ -57,8 +62,8 @@ The rest of this tutorial shows each of these in action.
 
 ## 1. The idea: RL for LLMs in one loop
 
-Reinforcement learning fine-tunes a language model against a **reward** instead of fixed target text.
-The loop is always the same shape:
+Reinforcement learning fine-tunes a language model against a **reward** instead of against fixed target
+text. Whatever the lab or the algorithm, the loop has the same shape:
 
 ```
    sample prompts
@@ -78,9 +83,10 @@ The loop is always the same shape:
 
 ### What is GRPO?
 
-**GRPO** (Group Relative Policy Optimization) is the algorithm behind models like DeepSeek-R1. Its one
-big idea: to decide whether an answer was "good," compare it to **other answers to the same prompt**,
-rather than training a separate value network to predict a baseline (as PPO does).
+**GRPO** (Group Relative Policy Optimization) is the algorithm behind reasoning models like
+DeepSeek-R1. Its one big idea: to judge whether an answer was "good," compare it against **other
+answers to the same prompt**, instead of training a separate value network to predict a baseline (as
+PPO does). That makes it simple and cheap to run — a perfect fit for a tutorial.
 
 For each prompt we sample a **group** of `G` answers and compute a *group-relative advantage*:
 
@@ -88,29 +94,30 @@ For each prompt we sample a **group** of `G` answers and compute a *group-relati
 advantage(answer_i) = (reward_i − mean(rewards in group)) / (std(rewards in group) + ε)
 ```
 
-Answers above their group's average get a positive advantage (make them more likely); answers below
-get a negative one (make them less likely). The training objective we maximize is:
+Answers above their group's average get a positive advantage (make them more likely); answers below it
+get a negative one (make them less likely). The objective we maximize is:
 
 ```
 J(θ) = mean over answers [ advantage_i · (average log-probability the policy assigns to answer_i) ]
 ```
 
-That's it — no critic, no replay buffer. This tutorial implements that objective directly so you can
-see exactly what each line does (see [§5.4](#54-the-grpo-update-train_step)). The full GRPO paper adds
-a PPO-style clipped ratio and a KL penalty to a reference model; we omit both to keep the math
-legible — valid for the single-gradient-step-per-iteration setup here, and called out in the code.
+That's the whole idea — no critic, no replay buffer. The tutorial implements this objective directly
+so you can read exactly what every line does (see [§5.4](#54-the-grpo-update-train_step)). The full
+GRPO paper adds a PPO-style clipped ratio and a KL penalty to a reference model; we leave both out to
+keep the math legible — fine for the single-gradient-step-per-iteration setup here, and noted in the
+code.
 
 ### Why LoRA?
 
-Updating all of a model's weights every iteration is expensive and makes the weight handoff between
-"trainer" and "generator" huge. Instead we freeze the base model and train a small **LoRA adapter** —
-a pair of low-rank matrices added on top of the frozen weights. The adapter is only a few **megabytes**,
-which is what makes the warm-engine trick below practical: the generator keeps the big frozen base
-resident and just swaps in the tiny adapter each iteration.
+Updating *all* of a model's weights each iteration is expensive, and it makes the handoff between the
+trainer and the generator enormous. So we freeze the base model and train a small **LoRA adapter** — a
+pair of low-rank matrices layered on top of the frozen weights. The adapter is only a few
+**megabytes**, and that's what makes the warm-engine trick work: the generator keeps the big frozen
+base resident and just swaps in the tiny adapter each iteration.
 
 ### Coming from Ray / RLlib?
 
-If you've written RL with Ray, the mental map is direct:
+If you've built RL with Ray, the mental map is direct:
 
 | In Ray/RLlib | Here (Union + flyte-sdk) |
 |---|---|
@@ -119,9 +126,8 @@ If you've written RL with Ray, the mental map is direct:
 | Driver / Tune loop | a plain **`async` driver task** (`train_rl`) |
 | `ray.remote` calls | calling another `@task` (`await generate(...)`) |
 
-The difference is there's no separate Ray cluster to launch and babysit. Each box is just a Python
-function with a decorator; Flyte schedules them, moves data between them, retries them, and shows them
-in a UI.
+The difference is there's no separate cluster to launch and operate. Each box is just a Python function
+with a decorator; Flyte schedules them, moves data between them, retries them, and shows them in a UI.
 
 ---
 
@@ -132,15 +138,15 @@ The loop is four task environments plus a one-time model prefetch:
 | Environment | Hardware | Job |
 |---|---|---|
 | `generate` (rollout) | GPU, **warm pool** | run vLLM, produce candidate answers with the current adapter |
-| `score` (reward) | CPU | grade each answer (rule-based / verifiable) |
+| `score_group` (reward) | CPU | grade a group of answers (rule-based / verifiable) |
 | `train_step` (trainer) | GPU | one GRPO step, emit the new LoRA adapter |
 | `train_rl` (driver) | CPU | run the `for` loop, wire everything together, checkpoint |
 
-The one thing that's special is the **warm pool**. Loading an 8-billion-parameter (or even a small
-0.6B) model into a vLLM engine takes time. If `generate` were a fresh container every call, you'd pay
-that cost on every rollout. So `generate` lives in a **reusable** environment: Flyte keeps a small pool
-of warm replicas alive between calls, each holding the loaded engine in memory. Everything else is an
-ordinary ephemeral pod — cheap to start, and stateless between iterations.
+The interesting part is the **warm pool**. Loading even a small model into a vLLM engine takes time, so
+if `generate` were a fresh container on every call you'd pay that cost on every rollout. Instead
+`generate` runs in a **reusable** environment: Flyte keeps a pool of warm replicas alive between calls,
+each holding the loaded engine in memory, and **autoscales** that pool with demand. Everything else is
+an ordinary ephemeral pod — cheap to start, and stateless between iterations.
 
 ### Warm-pool topology
 
@@ -159,7 +165,7 @@ flowchart TB
       R3["replica 3..4<br/>autoscaled on load"]
     end
 
-    S["score × N<br/>❄ ephemeral · CPU<br/>fresh pod per call (driven by as_completed)"]
+    S["score_group × groups<br/>❄ ephemeral · CPU<br/>one task per prompt group (as_completed)"]
     T["train_step<br/>❄ ephemeral · GPU<br/>one GRPO step per iteration"]
 
     D -- "generate(prompt, adapter, version)" --> POOL
@@ -182,34 +188,37 @@ flowchart TB
 
 🔥 = warm / reused across iterations (`ReusePolicy`) &nbsp;·&nbsp; ❄ = ephemeral (new container per
 call). In the validated run, the `generate` actions ran as Flyte **`actor`** tasks (the warm pool),
-while `init_adapter` / `score` / `train_step` ran as ordinary **`python`** pods.
+while `init_adapter` / `score_group` / `train_step` ran as ordinary **`python`** pods.
 
 ---
 
-## 3. Prerequisites
+## 3. Getting started
 
-- A Union/Flyte deployment with **GPU** capacity (the tutorial uses `L4:1`; any single modern GPU works
-  for a small model).
+Once Union/Flyte is installed, running this is trivial — a single command. You'll need:
+
+- A Union/Flyte deployment with **GPU** capacity (the tutorial uses `L4:1`; any single modern GPU is
+  enough for a small model).
 - A **Hugging Face token** stored as a Union secret. The example reads a secret named `hf-token`; create
-  yours with `flyte create secret hf-token` (or rename `HF_SECRET` in the code to match an existing one).
-- `flyte-sdk` configured for your endpoint (`flyte create config ...`).
+  it with `flyte create secret hf-token` (or point `HF_SECRET` in the code at an existing one).
+- `flyte-sdk` pointed at your endpoint (`flyte create config ...`).
 
-Run it with:
+Then:
 
 ```bash
 python rl_grpo_lora.py
 ```
 
-The script prefetches the base model, then launches the training loop. The first run also builds the
-container image (vLLM + flashinfer + PEFT), which takes a few minutes; later runs reuse it.
+That prefetches the base model and launches the training loop. The very first run also builds the
+container image (vLLM + flashinfer + PEFT), which takes a few minutes; every run after reuses it, so
+you're straight into training.
 
 ---
 
 ## 4. The model weights: prefetch once
 
-vLLM (the generator) and Transformers/PEFT (the trainer) both need the base model's weights. Rather
-than have every task download from Hugging Face, we **prefetch once** into Union's object store and
-pass the resulting directory into the tasks as a `flyte.io.Dir`:
+Both vLLM (the generator) and Transformers/PEFT (the trainer) need the base model's weights. Rather
+than have every task pull from Hugging Face, Flyte **prefetches once** into object storage and hands
+the resulting directory to the tasks as a `flyte.io.Dir`:
 
 ```python
 import flyte.prefetch
@@ -220,10 +229,10 @@ base_dir = run.outputs()[0]          # the model Dir, passed into train_rl(base=
 ```
 
 > **Note — plain weights, not vLLM-sharded.** `hf_model` can pre-shard for vLLM, but that layout isn't
-> readable by the Transformers/PEFT trainer. For a single GPU (`tensor_parallel_size=1`) vLLM loads
+> readable by the Transformers/PEFT trainer. On a single GPU (`tensor_parallel_size=1`) vLLM loads
 > plain Hugging Face weights directly with no downside, so we prefetch plain weights and share one
-> directory with both the generator and the trainer. Pre-sharding only pays off for multi-GPU rollout
-> replicas, which would then need a separate copy for the trainer.
+> directory between the generator and the trainer. Pre-sharding only pays off for multi-GPU rollout
+> replicas, which would then want a separate copy for the trainer.
 
 ---
 
@@ -231,9 +240,10 @@ base_dir = run.outputs()[0]          # the model Dir, passed into train_rl(base=
 
 ### 5.1 Rollouts on a warm vLLM pool (`generate`)
 
-This is the core technique. The environment is marked **reusable** so Flyte keeps warm replicas
-between calls, and we hold the engine in a **module-global** so it survives across invocations of the
-same replica:
+This is the core technique, and where Flyte's warm pool earns its keep. The environment is marked
+**reusable**, so Flyte holds warm replicas between calls. The expensive per-replica work — loading the
+engine and downloading each adapter — is wrapped in `@alru_cache`, so it runs once and is reused for
+every call that replica handles:
 
 ```python
 rollout_env = flyte.TaskEnvironment(
@@ -244,63 +254,85 @@ rollout_env = flyte.TaskEnvironment(
     secrets=[HF_SECRET],
 )
 
-_ENGINE = None             # persists across calls within a warm replica
-_ADAPTER_PATHS = {}        # adapter version -> local path (downloaded once)
+@alru_cache(maxsize=1)                      # build the engine ONCE per warm replica
+async def _load_engine(base_uri: str) -> Any:
+    from vllm import LLM
+    local_base = await flyte.io.Dir.from_existing_remote(base_uri).download()
+    return LLM(model=local_base, enable_lora=True, max_lora_rank=LORA_RANK, ...)
+
+@alru_cache(maxsize=None)                   # download each adapter version ONCE per replica
+async def _adapter_local_path(adapter_uri: str) -> str:
+    return await flyte.io.Dir.from_existing_remote(adapter_uri).download()
 
 @rollout_env.task
-async def generate(base, question, answer, adapter, version, group_id) -> list[Rollout]:
-    global _ENGINE
-    from vllm import LLM, SamplingParams
+async def generate(base: flyte.io.Dir, question: str, answer: str,
+                   adapter: flyte.io.Dir, version: int, group_id: int) -> list[Rollout]:
+    from vllm import SamplingParams
     from vllm.lora.request import LoRARequest
 
-    if _ENGINE is None:                                   # builds ONCE per replica, then stays warm
-        local_base = await base.download()
-        _ENGINE = LLM(model=local_base, enable_lora=True, max_lora_rank=LORA_RANK, ...)
+    engine: Any = await _load_engine(base.path)              # cached: loaded once, then warm
+    adapter_path: str = await _adapter_local_path(adapter.path)
 
-    if version not in _ADAPTER_PATHS:                     # download each adapter version once
-        _ADAPTER_PATHS[version] = await adapter.download()
-
-    lora = LoRARequest(f"policy-v{version}", version + 1, _ADAPTER_PATHS[version])
+    lora = LoRARequest(f"policy-v{version}", version + 1, adapter_path)
     sampling = SamplingParams(n=GROUP_SIZE, temperature=1.0, max_tokens=MAX_NEW_TOKENS)
-    outputs = await asyncio.to_thread(_ENGINE.generate, [build_prompt(question)], sampling,
-                                      lora_request=lora)
+    outputs: Any = await asyncio.to_thread(engine.generate, [build_prompt(question)],
+                                           sampling, lora_request=lora)
     return [Rollout(group_id=group_id, question=question, completion=o.text, answer=answer)
             for o in outputs[0].outputs]
 ```
 
-Key points:
+The `ReusePolicy(replicas=(1, 4), ...)` is what makes this autoscale: Flyte runs as few as one warm
+replica when idle and spins up to four as the rollout fan-out demands, then scales back down. A few
+more details worth noticing:
 
-- **`enable_lora=True`** reserves adapter slots when the engine starts. The frozen base loads once.
+- **`@alru_cache` keyed on the remote URI** does the warm-state caching declaratively — `_load_engine`
+  (`maxsize=1`) builds the vLLM engine the first time and returns the same instance forever after;
+  `_adapter_local_path` downloads each adapter version exactly once. We key on the `Dir.path` string
+  (hashable) rather than the `Dir` object.
+- **`enable_lora=True`** reserves adapter slots when the engine starts, and the frozen base loads once.
 - Each call attaches the iteration's adapter with **`LoRARequest(name, id, path)`** — vLLM applies
-  `W + (B·A)·scale` on the fly. The base weights in GPU memory are never touched; "swapping weights"
-  is just pointing at a new adapter directory with a new id. (`id` must be ≥ 1, hence `version + 1`.)
+  `W + (B·A)·scale` on the fly. The base in GPU memory is never touched; "swapping weights" is just
+  pointing at a new adapter directory with a new id. (`id` must be ≥ 1, hence `version + 1`.)
+- **`asyncio.to_thread`** runs vLLM's blocking `generate()` off the event loop, so the reusable
+  replica's background heartbeat stays responsive while the GPU is busy — the standard way to call
+  blocking code from an `async` task. (We don't reach for `flyte.extras.DynamicBatcher` here: it shines
+  when *many concurrent producers* feed one GPU, whereas this env runs `concurrency=1` and each call
+  already submits a full group of `GROUP_SIZE` sequences as one vLLM batch.)
 - One call returns a whole **group** of `GROUP_SIZE` completions for one prompt — exactly the group
   GRPO needs to compute relative advantages.
 
-### 5.2 Reward (`score`)
+### 5.2 Reward (`score_group`)
 
-The reward is a plain CPU task. This tutorial uses a **verifiable** reward — a tiny arithmetic dataset
-where we can check the answer exactly — which is the cleanest way to see RL actually working:
+The reward is a plain CPU task. We use a **verifiable** reward — a tiny arithmetic dataset where the
+answer can be checked exactly — because it's the cleanest way to watch RL actually working. We score a
+**whole prompt group per call** rather than one task per rollout:
 
 ```python
-@reward_env.task
-async def score(rollout: Rollout) -> float:
-    reward = 0.0
-    if "####" in rollout.completion:          # format bonus: did it follow instructions?
-        reward += 0.2
-    if _extract_answer(rollout.completion) == rollout.answer:   # correctness
+def _reward(rollout: Rollout) -> float:           # pure Python: format bonus + exact-match
+    reward = 0.2 if "####" in rollout.completion else 0.0
+    if _extract_answer(rollout.completion) == rollout.answer:
         reward += 1.0
     return reward
+
+@reward_env.task
+async def score_group(rollouts: list[Rollout]) -> list[float]:
+    return [_reward(r) for r in rollouts]
 ```
 
-Verifiable rewards (math, code execution, format checks) are ideal for learning the mechanics. A
-model-based reward later is just a second warm vLLM environment scored the same way.
+Why per group? The rule-based reward is microseconds of work, so a task *per rollout* would pay
+container startup over and over for trivial compute (with `GROUP_SIZE=6` that's 24 tiny pods an
+iteration). Scoring at the **group** granularity — the unit `generate` already returns — keeps reward
+an observable, pipelined Flyte task while cutting the pod count by `GROUP_SIZE`×.
+
+> A warm pool wouldn't be the right fix here: a pool amortizes *expensive per-replica state* (like a
+> model in GPU memory), and `score_group` has none. When the reward becomes **model-based** (an
+> LLM-as-judge or a reward model), it gains that state — and then it *should* run on a warm vLLM pool,
+> exactly like the generator. Picking the right tool per task is part of what Flyte makes easy.
 
 ### 5.3 Pipelining generation and reward
 
-Rather than wait for *all* rollouts to finish before scoring (a barrier), we launch every rollout at
-once and score each group **the moment it completes**, so reward computation overlaps generation still
-in flight:
+Instead of waiting for *all* rollouts before scoring (a barrier), we launch every rollout at once and
+score each group **the moment it finishes**, so reward overlaps generation that's still in flight:
 
 ```python
 rollout_futs = [asyncio.create_task(generate(base, q, a, adapter, version, gid))
@@ -308,16 +340,19 @@ rollout_futs = [asyncio.create_task(generate(base, q, a, adapter, version, gid))
 
 rollouts, reward_futs = [], []
 for fut in asyncio.as_completed(rollout_futs):    # yields in completion order
-    for r in await fut:
-        rollouts.append(r)
-        reward_futs.append(asyncio.create_task(score(r)))   # score now, others still running
+    group = await fut
+    rollouts.extend(group)
+    reward_futs.append(asyncio.create_task(score_group(group)))   # score this group now
 
-rewards = await asyncio.gather(*reward_futs)      # aligned with rollouts
+group_rewards = await asyncio.gather(*reward_futs)        # aligned with append order
+rewards = [r for gr in group_rewards for r in gr]         # flatten → aligned with rollouts
 ```
 
-This is ordinary `asyncio` — `create_task` to fan out, `as_completed` to drain, `gather` to collect.
-Because each `await generate(...)` / `score(...)` is a Flyte task call, you get this overlap *across
-containers* for free.
+This is just `asyncio` — `create_task` to fan out, `as_completed` to drain, `gather` to collect — but
+because each `await generate(...)` / `score_group(...)` is a Flyte task call, the overlap happens
+*across containers*, and Flyte spreads it over the warm pool's autoscaled replicas. Scoring at group
+granularity (one reward task per group, the unit `generate` produces) keeps that overlap with far fewer
+pods.
 
 ### 5.4 The GRPO update (`train_step`)
 
@@ -344,13 +379,13 @@ async def train_step(base, rollouts, rewards, adapter, version) -> tuple[flyte.i
 
 `_group_normalized_advantages` is the GRPO formula from [§1](#what-is-grpo): standardize each reward
 against its prompt group. `save_pretrained` on a PEFT model writes only `adapter_config.json` +
-`adapter_model.safetensors` (a few MB) — that `Dir` is the entire trainer→generator handoff.
+`adapter_model.safetensors` (a few MB) — and that `Dir` *is* the entire trainer → generator handoff.
 
 > **Why a custom step instead of a library trainer?** Libraries like TRL's `GRPOTrainer` own the whole
-> loop — they generate completions and call the reward function *internally*. That's great for a
+> loop — they generate completions and call the reward function *internally*. That's handy for a
 > self-contained job, but it would bypass our warm vLLM pool and the as-completed pipelining, which are
-> the whole point of running this on Union. Driving one explicit gradient step keeps generation, reward,
-> and the update as separate, observable Flyte tasks.
+> the whole point of running this on Flyte. Driving one explicit gradient step keeps generation,
+> reward, and the update as separate, observable Flyte tasks.
 
 ### 5.5 The driver loop (`train_rl`)
 
@@ -373,30 +408,31 @@ async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> 
     return adapter
 ```
 
-Two things worth calling out:
+This is where Flyte's reliability shows up with almost no code:
 
 - **`flyte.Checkpoint`** persists `{iteration, adapter location, report history}` each step. If the
-  driver is preempted, it resumes mid-run instead of starting over.
-- **`flyte.group("iter-N")`** nests each iteration's tasks in the UI so the DAG is readable.
+  driver is preempted (spot reclaim, OOM), it resumes mid-run instead of starting over.
+- **`flyte.group("iter-N")`** nests each iteration's tasks in the UI so the DAG stays readable.
 
 ### 5.6 The live report
 
 `report=True` plus [`report_helpers.py`](./report_helpers.py) gives you a self-contained HTML report,
-re-published every iteration, showing reward / accuracy / format-rate / loss charts, a per-iteration
-table, and the best sample completion. It's pure Python (inline SVG, no plotting dependency) so the
-CPU driver stays light. Open it from the run's **Report** tab in the Union UI.
+re-published every iteration, with reward / accuracy / format-rate / loss charts, a per-iteration
+table, and the best sample completion. It's pure Python (inline SVG, no plotting dependency), so the
+CPU driver stays light. Open it from the run's **Report** tab in the Union UI and watch training move
+in real time.
 
 ---
 
 ## 6. What this validates
 
 Running `python rl_grpo_lora.py` against a Union demo cluster (Qwen3-0.6B, L4 GPUs, 3 GRPO iterations)
-exercises the whole loop:
+exercises the whole loop on real hardware:
 
-- prefetch → `init_adapter` → **12 warm-vLLM rollouts** → **72 pipelined reward tasks** →
-  **3 GRPO steps** → final LoRA adapter (`v3`) returned as a `flyte.io.Dir`,
+- prefetch → `init_adapter` → **12 warm-vLLM rollouts** (4 prompts × 3 iterations) → **12 group reward
+  tasks** → **3 GRPO steps** → final LoRA adapter (`v3`) returned as a `flyte.io.Dir`,
 - with the live report published each iteration, the driver checkpointing per step, and the rollout
-  tasks running as warm **`actor`** replicas.
+  tasks running as warm, autoscaled **`actor`** replicas.
 
 (With a 0.6B model and a toy dataset this proves the *machinery*, not convergence — scale the model and
 dataset for a real learning signal.)
@@ -405,12 +441,13 @@ dataset for a real learning signal.)
 
 ## 7. Going further
 
-The example is intentionally the smallest thing that runs end to end. Natural next steps:
+The example is deliberately the smallest thing that runs end to end. Because it's all plain Flyte, each
+of these is a small change, not a rewrite:
 
-- **A real task & bigger policy.** Swap `BASE_MODEL_REPO` and `DATASET` for a larger model and a real
-  verifiable-reward dataset (math, code, tool use). The code is unchanged.
-- **Model-based reward.** Replace the rule in `score` with a call to a second warm vLLM environment
-  (e.g. an LLM judge) — same warm-pool pattern as the generator.
+- **A real task and a bigger policy.** Swap `BASE_MODEL_REPO` and `DATASET` for a larger model and a
+  real verifiable-reward dataset (math, code, tool use). The loop code is unchanged.
+- **Model-based reward.** Replace the rule in `score_group` with a call to a second warm vLLM
+  environment (an LLM judge) — the same warm-pool pattern as the generator.
 - **Multi-GPU rollouts.** Raise `tensor_parallel_size` and prefetch a vLLM-sharded copy for the
   generator (keeping a plain copy for the trainer).
 - **Multi-node training.** When the policy outgrows one GPU, move `train_step` to a
@@ -438,8 +475,8 @@ Patterns this tutorial builds on, from the flyte-sdk examples:
 
 ---
 
-Everything here — warm GPU pools, CPU reward fan-out, a resumable driver loop, live reporting — is
-plain `flyte-sdk` running on Union. That's the takeaway: an RL training loop, which usually means
-standing up and operating a distributed system, becomes a handful of decorated Python functions with
-Flyte and Union. Start with this small example, then scale the model, the reward, and the hardware
-without changing the shape of your code.
+The takeaway: an RL training loop — warm GPU pools, CPU reward fan-out, a resumable driver, live
+reporting — usually means standing up and operating a distributed system. On Flyte with Union it's a
+handful of decorated Python functions that autoscale to your hardware and stay isolated per run. Start
+with this small example, then scale the model, the reward, and the hardware without changing the shape
+of your code.

--- a/v2/tutorials/rl_grpo_lora/report_helpers.py
+++ b/v2/tutorials/rl_grpo_lora/report_helpers.py
@@ -1,0 +1,314 @@
+"""HTML report helpers for the GRPO loop.
+
+Pure-python (no extra dependencies) so the CPU driver task stays light. Builds a single self-contained
+HTML body for ``flyte.report`` that shows per-iteration GRPO progress (reward, accuracy, format
+adherence, loss) plus a running summary. The driver rebuilds and re-publishes this every iteration via
+``flyte.report.replace.aio(render_report(...), do_flush=True)`` so progress streams live in the UI.
+
+The visual style intentionally mirrors the sibling ``llm_fine_tuning_lora_qlora`` example.
+"""
+
+from __future__ import annotations
+
+import html
+from dataclasses import dataclass
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report .stat .delta-up { color: #1e7e34; font-size: 0.8em; }
+  .report .stat .delta-down { color: #b02a37; font-size: 0.8em; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .chart-container { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 16px 0; }
+  .report pre.sample { background: #1a1a2e; color: #e6e6e6; padding: 12px 14px; border-radius: 6px; overflow-x: auto; white-space: pre-wrap; font-size: 0.85em; line-height: 1.4; }
+  .report .muted { color: #6c757d; font-size: 0.85em; }
+</style>
+"""
+
+
+@dataclass
+class IterationMetrics:
+    """One row of GRPO progress, accumulated by the driver after each outer step."""
+
+    iteration: int
+    adapter_version: int
+    num_rollouts: int
+    mean_reward: float
+    max_reward: float
+    accuracy: float  # fraction of completions with the exactly-correct answer
+    format_rate: float  # fraction of completions that emitted the '####' marker
+    mean_loss: float  # mean GRPO loss reported by train_step
+    contributing: int  # rollouts that produced a gradient (non-zero advantage)
+    sample_question: str
+    sample_completion: str
+    sample_reward: float
+
+
+def wrap_report(body: str) -> str:
+    """Wrap an HTML fragment with the report stylesheet + container div."""
+    return f'{REPORT_CSS}<div class="report">{body}</div>'
+
+
+def make_line_chart(
+    data: list[dict],
+    x_key: str,
+    y_keys: list[str],
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    y_display_names: dict[str, str] | None = None,
+    colors: list[str] | None = None,
+    width: int = 720,
+    height: int = 300,
+) -> str:
+    """Generate a self-contained SVG line chart from a list of dicts (no plotting deps)."""
+    colors = colors or ["#0f3460", "#06d6a0", "#ffc107", "#5a7db5", "#6c757d"]
+
+    ml, mr, mt, mb = 60, 20, 40, 50
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    x_vals = [d[x_key] for d in data] if data else []
+    x_min, x_max = (min(x_vals), max(x_vals)) if x_vals else (0, 1)
+    x_range = (x_max - x_min) or 1
+
+    all_y = [d[k] for k in y_keys for d in data if k in d]
+    y_min = min(all_y) if all_y else 0.0
+    y_max = max(all_y) if all_y else 1.0
+    y_pad = (y_max - y_min) * 0.1 or 0.1
+    y_min_plot = y_min - y_pad
+    y_max_plot = y_max + y_pad
+    y_range = (y_max_plot - y_min_plot) or 1
+
+    def sx(v: float) -> float:
+        return ml + (v - x_min) / x_range * cw
+
+    def sy(v: float) -> float:
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Horizontal grid + y ticks
+    for i in range(6):
+        y_tick = y_min_plot + y_range * i / 5
+        py = sy(y_tick)
+        lines.append(f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" stroke="#e9ecef" stroke-width="1"/>')
+        lines.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" font-size="11" fill="#6c757d">{y_tick:.2f}</text>'
+        )
+
+    # Axes
+    lines.append(f'<line x1="{ml}" y1="{mt}" x2="{ml}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+    lines.append(f'<line x1="{ml}" y1="{mt + ch}" x2="{ml + cw}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+
+    # X ticks (integer iteration labels)
+    for i, xv in enumerate(x_vals):
+        px = sx(xv)
+        lines.append(
+            f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" font-size="11" fill="#6c757d">{int(xv)}</text>'
+        )
+
+    if not data:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{mt + ch / 2}" text-anchor="middle" font-size="13" '
+            f'fill="#adb5bd" font-style="italic">Waiting for the first iteration...</text>'
+        )
+
+    # Series
+    for si, key in enumerate(y_keys):
+        color = colors[si % len(colors)]
+        points = [(sx(d[x_key]), sy(d[key])) for d in data if key in d]
+        if not points:
+            continue
+        if len(points) >= 2:
+            path_d = f"M {points[0][0]:.1f},{points[0][1]:.1f}" + "".join(
+                f" L {px:.1f},{py:.1f}" for px, py in points[1:]
+            )
+            lines.append(f'<path d="{path_d}" fill="none" stroke="{color}" stroke-width="2" stroke-linejoin="round"/>')
+        for px, py in points:
+            lines.append(f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{color}"/>')
+
+    if title:
+        lines.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" '
+            f'fill="#1a1a2e">{html.escape(title)}</text>'
+        )
+    if x_label:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{height - 6}" text-anchor="middle" font-size="12" '
+            f'fill="#6c757d">{html.escape(x_label)}</text>'
+        )
+    if y_label:
+        lines.append(
+            f'<text x="14" y="{mt + ch / 2}" text-anchor="middle" font-size="12" fill="#6c757d" '
+            f'transform="rotate(-90, 14, {mt + ch / 2})">{html.escape(y_label)}</text>'
+        )
+
+    # Legend
+    names = y_display_names or {}
+    if len(y_keys) > 1:
+        for si, key in enumerate(y_keys):
+            color = colors[si % len(colors)]
+            ly = mt + 14 + si * 18
+            lines.append(f'<rect x="{ml + 10}" y="{ly - 6}" width="12" height="12" rx="2" fill="{color}"/>')
+            lines.append(
+                f'<text x="{ml + 28}" y="{ly + 4}" font-size="11" fill="#1a1a2e">{html.escape(names.get(key, key))}</text>'
+            )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def _delta_html(curr: float, prev: float | None, fmt: str = "{:+.3f}") -> str:
+    if prev is None:
+        return ""
+    d = curr - prev
+    cls = "delta-up" if d >= 0 else "delta-down"
+    arrow = "▲" if d >= 0 else "▼"
+    return f'<div class="{cls}">{arrow} {fmt.format(d)}</div>'
+
+
+def render_report(
+    history: list[IterationMetrics],
+    *,
+    base_model: str,
+    num_iterations: int,
+    group_size: int,
+    prompts_per_iter: int,
+    lora_rank: int,
+    learning_rate: float,
+    status: str = "running",
+) -> str:
+    """Render the full GRPO progress report (returns an HTML body for ``flyte.report.replace``)."""
+    latest = history[-1] if history else None
+    prev = history[-2] if len(history) >= 2 else None
+
+    # --- Header + run config ---
+    parts: list[str] = []
+    badge = "✅ complete" if status == "complete" else "⏳ running"
+    parts.append(f"<h2>GRPO + LoRA training progress &nbsp;<span class='muted'>({badge})</span></h2>")
+    parts.append(
+        "<div class='card'>"
+        f"<b>Base model:</b> <code>{html.escape(base_model)}</code> &nbsp;|&nbsp; "
+        f"<b>Iterations:</b> {len(history)}/{num_iterations} &nbsp;|&nbsp; "
+        f"<b>Group size (G):</b> {group_size} &nbsp;|&nbsp; "
+        f"<b>Prompts/iter:</b> {prompts_per_iter} &nbsp;|&nbsp; "
+        f"<b>LoRA rank:</b> {lora_rank} &nbsp;|&nbsp; "
+        f"<b>LR:</b> {learning_rate:g}"
+        "</div>"
+    )
+    parts.append(
+        "<div class='note'><b>Objective:</b> single-step, group-normalized GRPO policy gradient — "
+        "maximize <code>mean( A&#770;<sub>i</sub> &middot; mean&#8203;<sub>t</sub> log &pi;<sub>&theta;</sub>"
+        "(o<sub>i,t</sub>) )</code> with "
+        "<code>A&#770;<sub>i</sub> = (r<sub>i</sub> &minus; mean&#8203;<sub>group</sub>) / "
+        "(std&#8203;<sub>group</sub> + &epsilon;)</code> over completions, training the LoRA adapter only. "
+        "(No PPO clip / no KL term in this MVP — see <code>README.md</code>.)</div>"
+    )
+
+    # --- Summary stat cards (latest values, with delta vs previous iter) ---
+    if latest is not None:
+        parts.append("<h3>Latest iteration</h3>")
+        parts.append("<div class='stat-grid'>")
+        cards = [
+            ("Mean reward", f"{latest.mean_reward:.3f}", _delta_html(latest.mean_reward, prev.mean_reward if prev else None)),
+            ("Accuracy", f"{latest.accuracy * 100:.1f}%", _delta_html(latest.accuracy, prev.accuracy if prev else None, "{:+.1%}")),
+            ("Format rate", f"{latest.format_rate * 100:.1f}%", _delta_html(latest.format_rate, prev.format_rate if prev else None, "{:+.1%}")),
+            ("Mean loss", f"{latest.mean_loss:.4f}", _delta_html(latest.mean_loss, prev.mean_loss if prev else None, "{:+.4f}")),
+            ("Adapter version", f"v{latest.adapter_version}", ""),
+        ]
+        for label, value, delta in cards:
+            parts.append(f"<div class='stat'><div class='value'>{value}</div>{delta}<div class='label'>{label}</div></div>")
+        parts.append("</div>")
+
+    # --- Charts ---
+    chart_data = [
+        {
+            "iter": m.iteration,
+            "mean_reward": m.mean_reward,
+            "accuracy": m.accuracy,
+            "format_rate": m.format_rate,
+            "mean_loss": m.mean_loss,
+        }
+        for m in history
+    ]
+    parts.append("<div class='chart-container'>")
+    parts.append(
+        make_line_chart(
+            chart_data,
+            x_key="iter",
+            y_keys=["mean_reward", "accuracy", "format_rate"],
+            title="Reward & correctness vs. iteration",
+            x_label="iteration",
+            y_display_names={"mean_reward": "mean reward", "accuracy": "accuracy", "format_rate": "format rate"},
+        )
+    )
+    parts.append("</div>")
+    parts.append("<div class='chart-container'>")
+    parts.append(
+        make_line_chart(
+            chart_data,
+            x_key="iter",
+            y_keys=["mean_loss"],
+            title="GRPO loss vs. iteration",
+            x_label="iteration",
+            colors=["#b02a37"],
+        )
+    )
+    parts.append("</div>")
+
+    # --- Per-iteration table ---
+    parts.append("<h3>Per-iteration metrics</h3>")
+    parts.append(
+        "<table><tr><th>Iter</th><th>Adapter</th><th>Rollouts</th><th>Mean reward</th>"
+        "<th>Max reward</th><th>Accuracy</th><th>Format</th><th>Mean loss</th><th>Contributing</th></tr>"
+    )
+    for m in history:
+        parts.append(
+            f"<tr><td>{m.iteration}</td><td>v{m.adapter_version}</td><td>{m.num_rollouts}</td>"
+            f"<td>{m.mean_reward:.3f}</td><td>{m.max_reward:.3f}</td>"
+            f"<td>{m.accuracy * 100:.1f}%</td><td>{m.format_rate * 100:.1f}%</td>"
+            f"<td>{m.mean_loss:.4f}</td><td>{m.contributing}/{m.num_rollouts}</td></tr>"
+        )
+    parts.append("</table>")
+
+    # --- Best sample from the latest iteration (qualitative signal) ---
+    if latest is not None:
+        parts.append("<h3>Best completion (latest iteration)</h3>")
+        parts.append(
+            f"<p class='muted'>Question: <b>{html.escape(latest.sample_question)}</b> &nbsp;|&nbsp; "
+            f"reward = {latest.sample_reward:.2f}</p>"
+        )
+        parts.append(f"<pre class='sample'>{html.escape(latest.sample_completion.strip()) or '(empty)'}</pre>")
+
+    # --- Final summary ---
+    if status == "complete" and history:
+        first, last = history[0], history[-1]
+        parts.append("<h2>Summary</h2>")
+        parts.append(
+            "<div class='card'>"
+            f"Trained <b>{len(history)}</b> GRPO iterations on <code>{html.escape(base_model)}</code>. "
+            f"Mean reward moved <b>{first.mean_reward:.3f} → {last.mean_reward:.3f}</b> "
+            f"({last.mean_reward - first.mean_reward:+.3f}); "
+            f"accuracy <b>{first.accuracy * 100:.1f}% → {last.accuracy * 100:.1f}%</b>; "
+            f"format adherence <b>{first.format_rate * 100:.1f}% → {last.format_rate * 100:.1f}%</b>. "
+            f"Final adapter: <b>v{last.adapter_version}</b>."
+            "</div>"
+        )
+
+    return wrap_report("".join(parts))

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -22,8 +22,8 @@ the implementation. The loop has the standard RL-for-LLMs shape::
 
     sample prompts -> generate rollouts (vLLM) -> score (reward) -> policy update (LoRA) -> refresh adapter -> repeat
 
-Flyte fits this well: each stage runs in its own right-sized environment (GPU rollouts and trainer,
-CPU reward and driver), the driver is just an ``async`` ``for`` loop, the run is resumable via
+Flyte with Union fits this well: each stage runs in its own right-sized environment (GPU rollouts and
+trainer, CPU reward and driver), the driver is just an ``async`` ``for`` loop, the run is resumable via
 ``flyte.Checkpoint``, and progress streams to a live ``flyte.report``. The one technique unique to
 RL-for-LLMs is *keeping vLLM warm in a reusable container and swapping the LoRA adapter each
 iteration* — everything else is ordinary Flyte.

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #    "flyte>=2.4.0",
+#    "unionai-reuse>=0.1.3",
 #    "torch>=2.5.0",
 #    "transformers>=4.51.0",
 #    "peft>=0.13.0",
@@ -71,8 +72,12 @@ Signatures below were checked against source, not assumed:
 
 Run::
 
-    # remote (needs a GPU-backed Union deployment + an HF token secret named `huggingface-token`)
+    # remote (needs a GPU-backed Union deployment + an HF token secret named `hf-token`)
     python rl_grpo_lora.py
+
+Validated end to end on a Union demo cluster (Qwen3-0.6B, L4 GPUs, 3 GRPO iterations): prefetch →
+init_adapter → 12 warm-vLLM rollouts → 72 pipelined reward tasks → 3 GRPO train steps → final LoRA
+adapter (v3) returned as a flyte.Dir, with the live flyte.report published each iteration.
 """
 
 from __future__ import annotations
@@ -147,12 +152,26 @@ class Rollout(BaseModel):
 # ----------------------------------------------------------------------------------------------------
 # Images & environments
 # ----------------------------------------------------------------------------------------------------
-# One image (built from the uv-script header above) shared by every env. The module top level only
-# imports flyte + pydantic; torch/vllm/transformers/peft are imported lazily inside the GPU tasks, so
-# the CPU tasks pay no import cost despite sharing the image.
-image = flyte.Image.from_uv_script(__file__, name="rl-grpo-lora", pre=True)
+# One image shared by every env. Built explicitly (rather than from the uv-script header) so we can
+# pull vLLM's flashinfer kernels as *precompiled cubin wheels* — without them vLLM tries to JIT-compile
+# attention at runtime and fails with "Could not find nvcc" (no CUDA toolkit in the base image). This
+# recipe mirrors the proven examples/genai/vllm/vllm_app.py. torch comes transitively from vllm.
+# `unionai-reuse` provides the actor bridge required by the reusable rollout env. The module top level
+# only imports flyte + pydantic; torch/vllm/transformers/peft are imported lazily inside the GPU tasks.
+image = (
+    flyte.Image.from_debian_base(name="rl-grpo-lora")
+    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
+    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
+    .with_pip_packages(
+        "vllm==0.11.0",
+        "transformers==4.57.6",
+        "peft>=0.13.0",
+        "accelerate>=0.34.0",
+        "unionai-reuse>=0.1.3",
+    )
+)
 
-HF_SECRET = flyte.Secret(key="huggingface-token", as_env_var="HF_TOKEN")
+HF_SECRET = flyte.Secret(key="hf-token", as_env_var="HF_TOKEN")
 
 # Rollout generator: warm, reusable vLLM. concurrency=1 because a single in-process vLLM engine
 # batches internally and is not safe to drive from several coroutines at once; the driver still
@@ -181,11 +200,13 @@ train_env = flyte.TaskEnvironment(
     secrets=[HF_SECRET],
 )
 
-# Driver: plain async orchestration, no GPU.
+# Driver: plain async orchestration, no GPU. It invokes tasks in the rollout/reward/train envs, so it
+# must declare them via depends_on so their images/environments are registered alongside the driver's.
 driver_env = flyte.TaskEnvironment(
     name="rl-grpo-driver",
     image=image,
     resources=flyte.Resources(cpu=1, memory="2Gi"),
+    depends_on=[rollout_env, reward_env, train_env],
 )
 
 # Module globals — persist across calls *within a warm reusable replica*.
@@ -558,10 +579,17 @@ if __name__ == "__main__":
     # Prefetch the base ONCE into the Flyte object store as plain HF weights (see module docstring for
     # why we do not vLLM-shard for this single-GPU MVP). hf_model returns a Run; its sole output is the
     # model Dir, which we pass straight into the driver task as a flyte.io.Dir.
-    run = flyte.prefetch.hf_model(repo=BASE_MODEL_REPO, hf_token_key="HF_TOKEN")
+    run = flyte.prefetch.hf_model(repo=BASE_MODEL_REPO, hf_token_key="hf-token")
     run.wait()
     print(f"Prefetched base model: {run.url}")
-    base_dir = asyncio.run(run.outputs())[0]
+    # hf_model's sole output is the model Dir. run.outputs() may be sync or awaitable depending on the
+    # SDK build, so handle both. The result is an ActionOutputs tuple; element 0 is the base Dir.
+    import inspect
+
+    outputs = run.outputs()
+    if inspect.isawaitable(outputs):
+        outputs = asyncio.run(outputs)
+    base_dir = outputs[0]
 
     rl_run = flyte.run(train_rl, base=base_dir, num_iterations=NUM_ITERATIONS)
     print(rl_run.url)

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -1,0 +1,568 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "torch>=2.5.0",
+#    "transformers>=4.51.0",
+#    "peft>=0.13.0",
+#    "vllm>=0.11.0",
+#    "accelerate>=0.34.0",
+# ]
+# main = "train_rl"
+# params = ""
+# ///
+"""
+GRPO-style RL for LLMs on Union with flyte-sdk
+==============================================
+
+A runnable, MVP reinforcement-learning loop for LLMs (GRPO with LoRA), orchestrated *natively* by
+Flyte async tasks — **no Ray, no external scheduler**. The design doc is the sibling ``README.md``;
+read it first. The loop has the standard shape::
+
+    sample prompts -> generate rollouts (vLLM) -> score (reward) -> policy update (LoRA) -> refresh adapter -> repeat
+
+The only genuinely new piece versus a normal training job is *keeping vLLM warm in a reusable
+container and swapping the LoRA adapter each iteration*. Everything else is ordinary Flyte tasks.
+
+What runs where
+---------------
+- ``generate``   — **reusable, warm** ``TaskEnvironment`` (``ReusePolicy``). Holds an in-process vLLM
+                   ``LLM(enable_lora=True)`` engine as a module global so the frozen base never
+                   reloads; the per-iteration LoRA adapter is attached per request via ``LoRARequest``.
+- ``score``      — plain CPU ``@task``, rule-based / verifiable reward (exact-match + format).
+- ``init_adapter`` / ``train_step`` — single-node GPU ``@task``; one GRPO step over the
+                   externally-generated rollouts, training only the PEFT LoRA adapter (base frozen),
+                   returning the new adapter as a ``flyte.io.Dir`` (a few MB).
+- ``train_rl``   — the driver: a plain async ``@task`` running ``for it in range(N)``, fanning out
+                   rollouts with ``asyncio.create_task`` and scoring each the moment it finishes with
+                   ``asyncio.as_completed`` (no ``flyte.map`` barrier), then calling ``train_step``.
+                   Resumes loop state from ``flyte.Checkpoint`` and wraps each iteration in
+                   ``flyte.group(f"iter-{it}")``.
+
+Two deliberate deviations from the README (both documented inline where they bite):
+
+1. **Hand-rolled GRPO step instead of TRL ``GRPOTrainer``.** The README's data flow passes
+   *externally generated* rollouts + rewards into ``train_step``. TRL's ``GRPOTrainer`` owns
+   generation *and* reward computation internally (it takes ``reward_funcs`` + a prompt dataset and
+   generates completions itself), so it cannot consume pre-computed rollouts — using it would bypass
+   the warm vLLM rollout env, which is the entire point of this architecture. The GRPO loss here is
+   the standard group-normalized policy gradient (advantage = ``(r - mean_group)/(std_group + eps)``),
+   trained through the PEFT LoRA params only. See ``train_step``.
+
+2. **Plain-HF prefetch instead of ``ShardConfig(engine="vllm")``.** vLLM's pre-sharded layout
+   (``model-rank-*-part-*.safetensors``) is *not* readable by the HF/PEFT trainer, and for
+   ``tensor_parallel_size=1`` + a small model vLLM loads plain HF weights directly with no benefit
+   lost. vLLM pre-sharding only pays off for TP>1 rollout replicas, which would then need a *separate*
+   HF copy of the base for the trainer. For the single-GPU MVP one plain-HF ``Dir`` feeds both.
+
+API verification
+----------------
+Signatures below were checked against source, not assumed:
+- ``flyte`` (src/flyte): ``TaskEnvironment``, ``ReusePolicy(replicas, idle_ttl, concurrency,
+  scaledown_ttl)``, ``Resources``, ``GPU``, ``Secret(key, as_env_var)``, ``Image.from_uv_script``,
+  ``Checkpoint`` (``await load()/save(bytes|path)``), ``group``, ``io.Dir`` (``download``,
+  ``from_local``, ``from_existing_remote``), ``prefetch.hf_model`` (returns a ``Run``; the output
+  ``Dir`` is ``(await run.outputs())[0]``).
+- vLLM 0.11.0 (uv cache): ``vllm.LLM(model=..., enable_lora=True, max_lora_rank=...)``,
+  ``LLM.generate(prompts, sampling_params, lora_request=...)``,
+  ``vllm.lora.request.LoRARequest(lora_name, lora_int_id, lora_path)`` (``lora_int_id >= 1``).
+- PEFT (stable API): ``LoraConfig`` / ``get_peft_model`` / ``PeftModel.from_pretrained(...,
+  is_trainable=True)`` / ``save_pretrained``.
+
+Run::
+
+    # remote (needs a GPU-backed Union deployment + an HF token secret named `huggingface-token`)
+    python rl_grpo_lora.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+
+from pydantic import BaseModel
+
+import flyte
+import flyte.io
+import flyte.report
+from report_helpers import IterationMetrics, render_report
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------------------------------------
+# Configuration (small + cheap on purpose — this is an MVP meant to validate the wiring end to end)
+# ----------------------------------------------------------------------------------------------------
+BASE_MODEL_REPO = "Qwen/Qwen3-0.6B"  # small, fast; swap for a bigger policy once the loop is proven
+
+NUM_ITERATIONS = 3  # GRPO outer steps the driver runs
+PROMPTS_PER_ITER = 4  # prompts (= GRPO groups) sampled per iteration
+GROUP_SIZE = 6  # completions per prompt; GRPO normalizes advantage within each group
+MAX_NEW_TOKENS = 256
+SAMPLING_TEMPERATURE = 1.0  # >0 so the group has diverse samples to rank
+
+LORA_RANK = 16
+LORA_ALPHA = 32
+LEARNING_RATE = 1e-5
+
+# Fixed prompt template shared verbatim by the rollout (vLLM) and trainer (HF) sides so completion
+# tokens line up. Kept deliberately tokenizer-agnostic (no chat template) to avoid vLLM/HF drift.
+SYSTEM_PREAMBLE = (
+    "You are a careful math assistant. Reason briefly, then give the final integer answer on its own "
+    "line prefixed by '#### '."
+)
+
+
+def build_prompt(question: str) -> str:
+    """Render a question into the exact text both rollout and trainer condition on."""
+    return f"{SYSTEM_PREAMBLE}\n\nQuestion: {question}\nAnswer:"
+
+
+# A tiny, fully verifiable dataset (no external download → deterministic + cheap). Each entry is
+# (question, ground-truth integer answer as a string).
+DATASET: list[tuple[str, str]] = [
+    ("What is 12 + 7?", "19"),
+    ("What is 9 * 6?", "54"),
+    ("What is 45 - 18?", "27"),
+    ("What is 100 / 4?", "25"),
+    ("What is 13 + 28?", "41"),
+    ("What is 7 * 8?", "56"),
+    ("What is 81 - 36?", "45"),
+    ("What is 144 / 12?", "12"),
+]
+
+
+# ----------------------------------------------------------------------------------------------------
+# Rollout payload — one sampled completion for one prompt, tagged with its GRPO group.
+# ----------------------------------------------------------------------------------------------------
+class Rollout(BaseModel):
+    group_id: int  # which prompt group this completion belongs to (advantage is normalized per group)
+    question: str  # raw question (reward + trainer re-render the prompt via build_prompt)
+    completion: str  # text the policy generated
+    answer: str  # ground-truth answer, for the verifiable reward
+
+
+# ----------------------------------------------------------------------------------------------------
+# Images & environments
+# ----------------------------------------------------------------------------------------------------
+# One image (built from the uv-script header above) shared by every env. The module top level only
+# imports flyte + pydantic; torch/vllm/transformers/peft are imported lazily inside the GPU tasks, so
+# the CPU tasks pay no import cost despite sharing the image.
+image = flyte.Image.from_uv_script(__file__, name="rl-grpo-lora", pre=True)
+
+HF_SECRET = flyte.Secret(key="huggingface-token", as_env_var="HF_TOKEN")
+
+# Rollout generator: warm, reusable vLLM. concurrency=1 because a single in-process vLLM engine
+# batches internally and is not safe to drive from several coroutines at once; the driver still
+# pipelines by fanning generate() calls across replicas.
+rollout_env = flyte.TaskEnvironment(
+    name="rl-grpo-rollout",
+    image=image,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=flyte.GPU("L4", 1), shm="auto"),
+    reusable=flyte.ReusePolicy(replicas=(1, 4), concurrency=1, idle_ttl=300, scaledown_ttl=120),
+    secrets=[HF_SECRET],
+    env_vars={"VLLM_USE_V1": "1"},
+)
+
+# Reward: cheap, rule-based, CPU only.
+reward_env = flyte.TaskEnvironment(
+    name="rl-grpo-reward",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="2Gi"),
+)
+
+# Trainer: single node, one GPU is plenty for a 0.6B base + LoRA.
+train_env = flyte.TaskEnvironment(
+    name="rl-grpo-train",
+    image=image,
+    resources=flyte.Resources(cpu=4, memory="24Gi", gpu=flyte.GPU("L4", 1), shm="auto"),
+    secrets=[HF_SECRET],
+)
+
+# Driver: plain async orchestration, no GPU.
+driver_env = flyte.TaskEnvironment(
+    name="rl-grpo-driver",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="2Gi"),
+)
+
+# Module globals — persist across calls *within a warm reusable replica*.
+_ENGINE = None  # the vLLM LLM, built once on first generate() call
+_ADAPTER_PATHS: dict[int, str] = {}  # adapter version -> local path (downloaded once per replica)
+
+
+# ----------------------------------------------------------------------------------------------------
+# 1. Rollout generation — warm in-process vLLM with per-request LoRA
+# ----------------------------------------------------------------------------------------------------
+@rollout_env.task
+async def generate(
+    base: flyte.io.Dir,
+    question: str,
+    answer: str,
+    adapter: flyte.io.Dir,
+    version: int,
+    group_id: int,
+) -> list[Rollout]:
+    """Generate a GROUP_SIZE group of completions for one prompt, using the current LoRA adapter.
+
+    The frozen base loads exactly once per replica (module-global ``_ENGINE``). Each new adapter
+    version is downloaded once and attached per request via ``LoRARequest`` — the base weights in GPU
+    memory are never touched.
+    """
+    global _ENGINE
+    from vllm import LLM, SamplingParams
+    from vllm.lora.request import LoRARequest
+
+    if _ENGINE is None:
+        local_base = await base.download()  # plain-HF base; vLLM loads it directly
+        logger.info("Building warm vLLM engine from %s", local_base)
+        _ENGINE = LLM(
+            model=local_base,
+            enable_lora=True,
+            max_lora_rank=LORA_RANK,
+            max_loras=1,
+            trust_remote_code=True,
+            gpu_memory_utilization=0.85,
+            max_model_len=2048,
+            enforce_eager=True,  # skip CUDA-graph capture → faster cold start for an MVP
+        )
+
+    if version not in _ADAPTER_PATHS:
+        _ADAPTER_PATHS[version] = await adapter.download()  # tiny LoRA dir, cached per version
+
+    # lora_int_id must be >= 1 and unique per adapter; version starts at 0 so shift by 1.
+    lora = LoRARequest(f"policy-v{version}", version + 1, _ADAPTER_PATHS[version])
+
+    sampling = SamplingParams(
+        n=GROUP_SIZE,
+        temperature=SAMPLING_TEMPERATURE,
+        top_p=1.0,
+        max_tokens=MAX_NEW_TOKENS,
+    )
+
+    prompt = build_prompt(question)
+    # vLLM's generate() is blocking; run it off the event loop so the reusable replica stays async-friendly.
+    outputs = await asyncio.to_thread(_ENGINE.generate, [prompt], sampling, lora_request=lora)
+    completions = [o.text for o in outputs[0].outputs]
+    logger.info("group %s: generated %d completions (adapter v%d)", group_id, len(completions), version)
+    return [
+        Rollout(group_id=group_id, question=question, completion=c, answer=answer) for c in completions
+    ]
+
+
+# ----------------------------------------------------------------------------------------------------
+# 2. Reward — rule-based / verifiable
+# ----------------------------------------------------------------------------------------------------
+def _extract_answer(text: str) -> str | None:
+    """Pull the integer following the last '####' marker; fall back to the last integer in the text."""
+    import re
+
+    if "####" in text:
+        tail = text.rsplit("####", 1)[1]
+        m = re.search(r"-?\d+", tail)
+        if m:
+            return m.group(0)
+    nums = re.findall(r"-?\d+", text)
+    return nums[-1] if nums else None
+
+
+@reward_env.task
+async def score(rollout: Rollout) -> float:
+    """Verifiable reward: 1.0 for the correct answer, +0.2 format bonus for emitting the '####' marker."""
+    reward = 0.0
+    if "####" in rollout.completion:
+        reward += 0.2
+    predicted = _extract_answer(rollout.completion)
+    if predicted is not None and predicted == rollout.answer:
+        reward += 1.0
+    return reward
+
+
+# ----------------------------------------------------------------------------------------------------
+# 3. Trainer — one GRPO step on the PEFT LoRA adapter (base frozen)
+# ----------------------------------------------------------------------------------------------------
+@train_env.task
+async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
+    """Create a fresh (untrained) LoRA adapter so iteration 0 already has an adapter to attach."""
+    import torch
+    from peft import LoraConfig, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    local_base = await base.download()
+    model = AutoModelForCausalLM.from_pretrained(
+        local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
+    )
+    lora_config = LoraConfig(
+        r=LORA_RANK,
+        lora_alpha=LORA_ALPHA,
+        lora_dropout=0.0,
+        bias="none",
+        task_type="CAUSAL_LM",
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+    )
+    model = get_peft_model(model, lora_config)
+
+    out_dir = tempfile.mkdtemp(prefix="adapter-v0-")
+    model.save_pretrained(out_dir)  # writes adapter_config.json + adapter_model.safetensors only
+    logger.info("Initialized fresh LoRA adapter at %s", out_dir)
+    return await flyte.io.Dir.from_local(out_dir)
+
+
+def _group_normalized_advantages(rollouts: list[Rollout], rewards: list[float]) -> list[float]:
+    """GRPO advantage: within each prompt group, ``(r - mean) / (std + eps)``."""
+    import statistics
+    from collections import defaultdict
+
+    by_group: dict[int, list[int]] = defaultdict(list)
+    for i, r in enumerate(rollouts):
+        by_group[r.group_id].append(i)
+
+    advantages = [0.0] * len(rollouts)
+    for idxs in by_group.values():
+        group_rewards = [rewards[i] for i in idxs]
+        mean = statistics.fmean(group_rewards)
+        std = statistics.pstdev(group_rewards) if len(group_rewards) > 1 else 0.0
+        for i in idxs:
+            advantages[i] = (rewards[i] - mean) / (std + 1e-4)
+    return advantages
+
+
+@train_env.task
+async def train_step(
+    base: flyte.io.Dir,
+    rollouts: list[Rollout],
+    rewards: list[float],
+    adapter: flyte.io.Dir,
+    version: int,
+) -> tuple[flyte.io.Dir, float, int]:
+    """One GRPO policy-gradient step over externally-generated rollouts; trains the LoRA adapter only.
+
+    Resumes from the previous adapter (``PeftModel.from_pretrained(..., is_trainable=True)``), takes a
+    single optimizer step on the group-normalized policy-gradient loss, and ``save_pretrained()``s the
+    new adapter as a ``flyte.io.Dir``. See module docstring for why this is hand-rolled rather than TRL.
+
+    Returns ``(new_adapter, mean_loss, contributing)`` so the driver can chart loss in the report.
+    """
+    import torch
+    import torch.nn.functional as F
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    local_base = await base.download()
+    local_adapter = await adapter.download()
+
+    tokenizer = AutoTokenizer.from_pretrained(local_base, trust_remote_code=True)
+    base_model = AutoModelForCausalLM.from_pretrained(
+        local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
+    ).to(device)
+    # Resume the trainable adapter from the previous version (frozen base, only A/B train).
+    model = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True).to(device)
+    model.train()
+
+    advantages = _group_normalized_advantages(rollouts, rewards)
+    optimizer = torch.optim.AdamW((p for p in model.parameters() if p.requires_grad), lr=LEARNING_RATE)
+    optimizer.zero_grad()
+
+    total_loss = 0.0
+    contributing = 0
+    for rollout, advantage in zip(rollouts, advantages):
+        if advantage == 0.0:
+            continue  # no learning signal (whole group scored identically)
+
+        prompt_text = build_prompt(rollout.question)
+        prompt_ids = tokenizer(prompt_text, return_tensors="pt").input_ids
+        full_ids = tokenizer(prompt_text + rollout.completion, return_tensors="pt").input_ids.to(device)
+
+        prompt_len = prompt_ids.shape[1]
+        if full_ids.shape[1] <= prompt_len:
+            continue  # empty completion after tokenization
+
+        logits = model(full_ids).logits  # (1, seq, vocab)
+        # log p(token_t | token_<t): align logits[:-1] with targets full_ids[1:]
+        log_probs = F.log_softmax(logits[:, :-1, :], dim=-1)
+        targets = full_ids[:, 1:]
+        token_log_probs = log_probs.gather(-1, targets.unsqueeze(-1)).squeeze(-1)  # (1, seq-1)
+
+        # Mask to the completion tokens only (targets at positions >= prompt_len-1 in the shifted view).
+        completion_mask = torch.zeros_like(token_log_probs)
+        completion_mask[:, prompt_len - 1 :] = 1.0
+        seq_log_prob = (token_log_probs * completion_mask).sum() / completion_mask.sum().clamp(min=1.0)
+
+        loss = -advantage * seq_log_prob
+        loss.backward()  # accumulate gradients across the batch, single optimizer step below
+        total_loss += float(loss.item())
+        contributing += 1
+
+    if contributing > 0:
+        torch.nn.utils.clip_grad_norm_((p for p in model.parameters() if p.requires_grad), 1.0)
+        optimizer.step()
+        logger.info(
+            "GRPO step v%d: %d/%d rollouts contributed, mean loss %.4f",
+            version,
+            contributing,
+            len(rollouts),
+            total_loss / contributing,
+        )
+    else:
+        logger.info("GRPO step v%d: no contributing rollouts (flat rewards); adapter unchanged", version)
+
+    out_dir = tempfile.mkdtemp(prefix=f"adapter-v{version}-")
+    model.save_pretrained(out_dir)
+    mean_loss = total_loss / contributing if contributing > 0 else 0.0
+    new_adapter = await flyte.io.Dir.from_local(out_dir)
+    return new_adapter, mean_loss, contributing
+
+
+# ----------------------------------------------------------------------------------------------------
+# 4. Driver — the RL loop (replaces Ray)
+# ----------------------------------------------------------------------------------------------------
+def _sample_prompts(iteration: int) -> list[tuple[str, str]]:
+    """Deterministically rotate through the dataset so each iteration sees a different slice."""
+    start = (iteration * PROMPTS_PER_ITER) % len(DATASET)
+    return [DATASET[(start + i) % len(DATASET)] for i in range(PROMPTS_PER_ITER)]
+
+
+def _report_config() -> dict:
+    """Static run config surfaced in the report header."""
+    return dict(
+        base_model=BASE_MODEL_REPO,
+        num_iterations=NUM_ITERATIONS,
+        group_size=GROUP_SIZE,
+        prompts_per_iter=PROMPTS_PER_ITER,
+        lora_rank=LORA_RANK,
+        learning_rate=LEARNING_RATE,
+    )
+
+
+async def _publish_report(history: list[IterationMetrics], status: str) -> None:
+    """Re-render and flush the live GRPO progress report to the driver task's report tab."""
+    await flyte.report.replace.aio(
+        render_report(history, status=status, **_report_config()),
+        do_flush=True,
+    )
+
+
+@driver_env.task(report=True)
+async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> flyte.io.Dir:
+    """Own the GRPO loop: fan out rollouts, score as they finish, take one GRPO step, repeat.
+
+    Loop state (iteration, current adapter, and the report history) is checkpointed each iteration so a
+    preempted driver resumes mid-run — including the accumulated report rows — instead of restarting.
+    Progress is published to a live HTML report (``report=True``) after every iteration.
+    """
+    ctx = flyte.ctx()
+    cp = ctx.checkpoint if ctx is not None else None
+
+    start_iter = 0
+    adapter: flyte.io.Dir | None = None
+    adapter_version = 0
+    history: list[IterationMetrics] = []
+
+    # Resume from a prior driver attempt, if any.
+    if cp is not None:
+        prev = await cp.load()
+        if prev is not None:
+            state = json.loads(prev.read_text())
+            start_iter = state["iteration"] + 1
+            adapter_version = state["adapter_version"]
+            adapter = flyte.io.Dir.from_existing_remote(state["adapter_path"])
+            history = [IterationMetrics(**row) for row in state.get("history", [])]
+            logger.info("Resumed from checkpoint at iteration %d (adapter v%d)", start_iter, adapter_version)
+
+    # Cold start: mint a fresh LoRA adapter (version 0).
+    if adapter is None:
+        adapter = await init_adapter(base)
+        adapter_version = 0
+
+    await _publish_report(history, status="running")
+
+    for it in range(start_iter, num_iterations):
+        with flyte.group(f"iter-{it}"):
+            prompts = _sample_prompts(it)
+
+            # Launch every rollout group at once on the warm replicas.
+            rollout_futs = [
+                asyncio.create_task(generate(base, q, a, adapter, adapter_version, group_id=gid))
+                for gid, (q, a) in enumerate(prompts)
+            ]
+
+            # Score each rollout the instant its group finishes — reward overlaps in-flight rollouts.
+            flat_rollouts: list[Rollout] = []
+            reward_futs: list[asyncio.Task[float]] = []
+            for fut in asyncio.as_completed(rollout_futs):
+                group = await fut
+                for r in group:
+                    flat_rollouts.append(r)
+                    reward_futs.append(asyncio.create_task(score(r)))
+
+            rewards = await asyncio.gather(*reward_futs)  # aligned with flat_rollouts (same order)
+            mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
+            logger.info("iter %d: %d rollouts, mean reward %.3f", it, len(rewards), mean_reward)
+
+            # One GRPO step → next adapter version.
+            new_version = adapter_version + 1
+            adapter, mean_loss, contributing = await train_step(
+                base, flat_rollouts, rewards, adapter, new_version
+            )
+            adapter_version = new_version
+
+            # Record metrics for the report (accuracy/format derived directly from the rollouts).
+            n = len(flat_rollouts)
+            correct = sum(1 for r in flat_rollouts if _extract_answer(r.completion) == r.answer)
+            formatted = sum(1 for r in flat_rollouts if "####" in r.completion)
+            best_idx = max(range(n), key=lambda i: rewards[i]) if n else None
+            history.append(
+                IterationMetrics(
+                    iteration=it,
+                    adapter_version=adapter_version,
+                    num_rollouts=n,
+                    mean_reward=mean_reward,
+                    max_reward=max(rewards) if rewards else 0.0,
+                    accuracy=correct / n if n else 0.0,
+                    format_rate=formatted / n if n else 0.0,
+                    mean_loss=mean_loss,
+                    contributing=contributing,
+                    sample_question=flat_rollouts[best_idx].question if best_idx is not None else "",
+                    sample_completion=flat_rollouts[best_idx].completion if best_idx is not None else "",
+                    sample_reward=rewards[best_idx] if best_idx is not None else 0.0,
+                )
+            )
+            await _publish_report(history, status="running")
+
+            # Persist loop state so a preempted driver resumes here (with its report history).
+            if cp is not None:
+                state = {
+                    "iteration": it,
+                    "adapter_version": adapter_version,
+                    "adapter_path": adapter.path,
+                    "history": [vars(m) for m in history],
+                }
+                await cp.save(json.dumps(state).encode())
+
+    await _publish_report(history, status="complete")
+    assert adapter is not None
+    return adapter
+
+
+# ----------------------------------------------------------------------------------------------------
+# Entry point
+# ----------------------------------------------------------------------------------------------------
+if __name__ == "__main__":
+    import flyte.prefetch
+
+    flyte.init_from_config()
+
+    # Prefetch the base ONCE into the Flyte object store as plain HF weights (see module docstring for
+    # why we do not vLLM-shard for this single-GPU MVP). hf_model returns a Run; its sole output is the
+    # model Dir, which we pass straight into the driver task as a flyte.io.Dir.
+    run = flyte.prefetch.hf_model(repo=BASE_MODEL_REPO, hf_token_key="HF_TOKEN")
+    run.wait()
+    print(f"Prefetched base model: {run.url}")
+    base_dir = asyncio.run(run.outputs())[0]
+
+    rl_run = flyte.run(train_rl, base=base_dir, num_iterations=NUM_ITERATIONS)
+    print(rl_run.url)
+    rl_run.wait()

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -164,6 +164,7 @@ class Rollout(BaseModel):
 # recipe mirrors the proven examples/genai/vllm/vllm_app.py. torch comes transitively from vllm.
 # `unionai-reuse` provides the actor bridge required by the reusable rollout env. The module top level
 # only imports flyte + pydantic; torch/vllm/transformers/peft are imported lazily inside the GPU tasks.
+# {{docs-fragment image}}
 image = (
     flyte.Image.from_debian_base(name="rl-grpo-lora")
     .with_pip_packages("flashinfer-python", "flashinfer-cubin")
@@ -177,12 +178,14 @@ image = (
         "async-lru>=2.0.0",
     )
 )
+# {{/docs-fragment image}}
 
 HF_SECRET = flyte.Secret(key="hf-token", as_env_var="HF_TOKEN")
 
 # Rollout generator: warm, reusable vLLM. concurrency=1 because a single in-process vLLM engine
 # batches internally and is not safe to drive from several coroutines at once; the driver still
 # pipelines by fanning generate() calls across replicas.
+# {{docs-fragment rollout_env}}
 rollout_env = flyte.TaskEnvironment(
     name="rl-grpo-rollout",
     image=image,
@@ -191,30 +194,37 @@ rollout_env = flyte.TaskEnvironment(
     secrets=[HF_SECRET],
     env_vars={"VLLM_USE_V1": "1"},
 )
+# {{/docs-fragment rollout_env}}
 
 # Reward: cheap, rule-based, CPU only.
+# {{docs-fragment reward_env}}
 reward_env = flyte.TaskEnvironment(
     name="rl-grpo-reward",
     image=image,
     resources=flyte.Resources(cpu=1, memory="2Gi"),
 )
+# {{/docs-fragment reward_env}}
 
 # Trainer: single node, one GPU is plenty for a 0.6B base + LoRA.
+# {{docs-fragment train_env}}
 train_env = flyte.TaskEnvironment(
     name="rl-grpo-train",
     image=image,
     resources=flyte.Resources(cpu=4, memory="24Gi", gpu=flyte.GPU("L4", 1), shm="auto"),
     secrets=[HF_SECRET],
 )
+# {{/docs-fragment train_env}}
 
 # Driver: plain async orchestration, no GPU. It invokes tasks in the rollout/reward/train envs, so it
 # must declare them via depends_on so their images/environments are registered alongside the driver's.
+# {{docs-fragment driver_env}}
 driver_env = flyte.TaskEnvironment(
     name="rl-grpo-driver",
     image=image,
     resources=flyte.Resources(cpu=1, memory="2Gi"),
     depends_on=[rollout_env, reward_env, train_env],
 )
+# {{/docs-fragment driver_env}}
 
 # ----------------------------------------------------------------------------------------------------
 # 1. Rollout generation — warm in-process vLLM with per-request LoRA
@@ -224,6 +234,7 @@ driver_env = flyte.TaskEnvironment(
 # rather than the flyte.io.Dir object. Returns are typed Any because vLLM is imported lazily.
 
 
+# {{docs-fragment engine_cache}}
 @alru_cache(maxsize=1)
 async def _load_engine(base_uri: str) -> Any:
     """Build the vLLM engine once per warm replica (cached); the frozen base stays resident in GPU."""
@@ -247,8 +258,10 @@ async def _load_engine(base_uri: str) -> Any:
 async def _adapter_local_path(adapter_uri: str) -> str:
     """Download a LoRA adapter once per warm replica (cached by its remote URI → one download/version)."""
     return await flyte.io.Dir.from_existing_remote(adapter_uri).download()
+# {{/docs-fragment engine_cache}}
 
 
+# {{docs-fragment generate}}
 @rollout_env.task
 async def generate(
     base: flyte.io.Dir,
@@ -291,11 +304,13 @@ async def generate(
     return [
         Rollout(group_id=group_id, question=question, completion=c, answer=answer) for c in completions
     ]
+# {{/docs-fragment generate}}
 
 
 # ----------------------------------------------------------------------------------------------------
 # 2. Reward — rule-based / verifiable
 # ----------------------------------------------------------------------------------------------------
+# {{docs-fragment reward}}
 def _extract_answer(text: str) -> str | None:
     """Pull the integer following the last '####' marker; fall back to the last integer in the text."""
     import re
@@ -318,8 +333,10 @@ def _reward(rollout: Rollout) -> float:
     if predicted is not None and predicted == rollout.answer:
         reward += 1.0
     return reward
+# {{/docs-fragment reward}}
 
 
+# {{docs-fragment score_group}}
 @reward_env.task
 async def score_group(rollouts: list[Rollout]) -> list[float]:
     """Score a whole prompt group in one task — one reward task per group, not per rollout.
@@ -329,11 +346,13 @@ async def score_group(rollouts: list[Rollout]) -> list[float]:
     already returns) keeps reward an observable, pipelined task while cutting the pod count ~GROUP_SIZE×.
     """
     return [_reward(r) for r in rollouts]
+# {{/docs-fragment score_group}}
 
 
 # ----------------------------------------------------------------------------------------------------
 # 3. Trainer — one GRPO step on the PEFT LoRA adapter (base frozen)
 # ----------------------------------------------------------------------------------------------------
+# {{docs-fragment init_adapter}}
 @train_env.task
 async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
     """Create a fresh (untrained) LoRA adapter so iteration 0 already has an adapter to attach."""
@@ -359,8 +378,10 @@ async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
     model.save_pretrained(out_dir)  # writes adapter_config.json + adapter_model.safetensors only
     logger.info("Initialized fresh LoRA adapter at %s", out_dir)
     return await flyte.io.Dir.from_local(out_dir)
+# {{/docs-fragment init_adapter}}
 
 
+# {{docs-fragment advantages}}
 def _group_normalized_advantages(rollouts: list[Rollout], rewards: list[float]) -> list[float]:
     """GRPO advantage: within each prompt group, ``(r - mean) / (std + eps)``."""
     import statistics
@@ -378,8 +399,10 @@ def _group_normalized_advantages(rollouts: list[Rollout], rewards: list[float]) 
         for i in idxs:
             advantages[i] = (rewards[i] - mean) / (std + 1e-4)
     return advantages
+# {{/docs-fragment advantages}}
 
 
+# {{docs-fragment train_step}}
 @train_env.task
 async def train_step(
     base: flyte.io.Dir,
@@ -465,11 +488,13 @@ async def train_step(
     mean_loss = total_loss / contributing if contributing > 0 else 0.0
     new_adapter = await flyte.io.Dir.from_local(out_dir)
     return new_adapter, mean_loss, contributing
+# {{/docs-fragment train_step}}
 
 
 # ----------------------------------------------------------------------------------------------------
 # 4. Driver — the RL loop (replaces Ray)
 # ----------------------------------------------------------------------------------------------------
+# {{docs-fragment driver_helpers}}
 def _sample_prompts(iteration: int) -> list[tuple[str, str]]:
     """Deterministically rotate through the dataset so each iteration sees a different slice."""
     start = (iteration * PROMPTS_PER_ITER) % len(DATASET)
@@ -494,8 +519,10 @@ async def _publish_report(history: list[IterationMetrics], status: str) -> None:
         render_report(history, status=status, **_report_config()),
         do_flush=True,
     )
+# {{/docs-fragment driver_helpers}}
 
 
+# {{docs-fragment train_rl}}
 @driver_env.task(report=True)
 async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> flyte.io.Dir:
     """Own the GRPO loop: fan out rollouts, score as they finish, take one GRPO step, repeat.
@@ -597,11 +624,13 @@ async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> 
     await _publish_report(history, status="complete")
     assert adapter is not None
     return adapter
+# {{/docs-fragment train_rl}}
 
 
 # ----------------------------------------------------------------------------------------------------
 # Entry point
 # ----------------------------------------------------------------------------------------------------
+# {{docs-fragment entrypoint}}
 if __name__ == "__main__":
     import flyte.prefetch
 
@@ -625,3 +654,4 @@ if __name__ == "__main__":
     rl_run = flyte.run(train_rl, base=base_dir, num_iterations=NUM_ITERATIONS)
     print(rl_run.url)
     rl_run.wait()
+# {{/docs-fragment entrypoint}}

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -13,17 +13,20 @@
 # params = ""
 # ///
 """
-GRPO-style RL for LLMs on Union with flyte-sdk
-==============================================
+GRPO + LoRA reinforcement learning for LLMs on Union with flyte-sdk
+==================================================================
 
-A runnable, MVP reinforcement-learning loop for LLMs (GRPO with LoRA), orchestrated *natively* by
-Flyte async tasks — **no Ray, no external scheduler**. The design doc is the sibling ``README.md``;
-read it first. The loop has the standard shape::
+A runnable reinforcement-learning loop for LLMs (GRPO with LoRA), orchestrated by ordinary Flyte async
+tasks. The sibling ``README.md`` is a step-by-step tutorial that explains the concepts; this module is
+the implementation. The loop has the standard RL-for-LLMs shape::
 
     sample prompts -> generate rollouts (vLLM) -> score (reward) -> policy update (LoRA) -> refresh adapter -> repeat
 
-The only genuinely new piece versus a normal training job is *keeping vLLM warm in a reusable
-container and swapping the LoRA adapter each iteration*. Everything else is ordinary Flyte tasks.
+Flyte fits this well: each stage runs in its own right-sized environment (GPU rollouts and trainer,
+CPU reward and driver), the driver is just an ``async`` ``for`` loop, the run is resumable via
+``flyte.Checkpoint``, and progress streams to a live ``flyte.report``. The one technique unique to
+RL-for-LLMs is *keeping vLLM warm in a reusable container and swapping the LoRA adapter each
+iteration* — everything else is ordinary Flyte.
 
 What runs where
 ---------------
@@ -40,27 +43,26 @@ What runs where
                    Resumes loop state from ``flyte.Checkpoint`` and wraps each iteration in
                    ``flyte.group(f"iter-{it}")``.
 
-Two deliberate deviations from the README (both documented inline where they bite):
+Two implementation choices worth knowing (also explained in the README):
 
-1. **Hand-rolled GRPO step instead of TRL ``GRPOTrainer``.** The README's data flow passes
-   *externally generated* rollouts + rewards into ``train_step``. TRL's ``GRPOTrainer`` owns
-   generation *and* reward computation internally (it takes ``reward_funcs`` + a prompt dataset and
-   generates completions itself), so it cannot consume pre-computed rollouts — using it would bypass
-   the warm vLLM rollout env, which is the entire point of this architecture. The GRPO loss here is
+1. **A custom GRPO step rather than a library trainer (e.g. TRL ``GRPOTrainer``).** Library trainers
+   own the whole loop — they generate completions *and* call the reward function internally — so they
+   can't consume the rollouts+rewards we produce in separate tasks, and would bypass the warm vLLM
+   pool and the as-completed pipelining that are the point of running this on Flyte. The loss here is
    the standard group-normalized policy gradient (advantage = ``(r - mean_group)/(std_group + eps)``),
    trained through the PEFT LoRA params only. See ``train_step``.
 
-2. **Plain-HF prefetch instead of ``ShardConfig(engine="vllm")``.** vLLM's pre-sharded layout
+2. **Plain-HF prefetch rather than vLLM-sharded weights.** vLLM's pre-sharded layout
    (``model-rank-*-part-*.safetensors``) is *not* readable by the HF/PEFT trainer, and for
    ``tensor_parallel_size=1`` + a small model vLLM loads plain HF weights directly with no benefit
-   lost. vLLM pre-sharding only pays off for TP>1 rollout replicas, which would then need a *separate*
-   HF copy of the base for the trainer. For the single-GPU MVP one plain-HF ``Dir`` feeds both.
+   lost. Pre-sharding only pays off for TP>1 rollout replicas, which would then need a *separate* HF
+   copy of the base for the trainer. Here one plain-HF ``Dir`` feeds both generator and trainer.
 
 API verification
 ----------------
 Signatures below were checked against source, not assumed:
 - ``flyte`` (src/flyte): ``TaskEnvironment``, ``ReusePolicy(replicas, idle_ttl, concurrency,
-  scaledown_ttl)``, ``Resources``, ``GPU``, ``Secret(key, as_env_var)``, ``Image.from_uv_script``,
+  scaledown_ttl)``, ``Resources``, ``GPU``, ``Secret(key, as_env_var)``, ``Image.from_debian_base``,
   ``Checkpoint`` (``await load()/save(bytes|path)``), ``group``, ``io.Dir`` (``download``,
   ``from_local``, ``from_existing_remote``), ``prefetch.hf_model`` (returns a ``Run``; the output
   ``Dir`` is ``(await run.outputs())[0]``).

--- a/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/rl_grpo_lora/rl_grpo_lora.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #    "flyte>=2.4.0",
 #    "unionai-reuse>=0.1.3",
+#    "async-lru>=2.0.0",
 #    "torch>=2.5.0",
 #    "transformers>=4.51.0",
 #    "peft>=0.13.0",
@@ -33,7 +34,8 @@ What runs where
 - ``generate``   — **reusable, warm** ``TaskEnvironment`` (``ReusePolicy``). Holds an in-process vLLM
                    ``LLM(enable_lora=True)`` engine as a module global so the frozen base never
                    reloads; the per-iteration LoRA adapter is attached per request via ``LoRARequest``.
-- ``score``      — plain CPU ``@task``, rule-based / verifiable reward (exact-match + format).
+- ``score_group``— plain CPU ``@task``, rule-based / verifiable reward (exact-match + format). Scores a
+                   whole prompt group per call (one reward task per group, not per rollout).
 - ``init_adapter`` / ``train_step`` — single-node GPU ``@task``; one GRPO step over the
                    externally-generated rollouts, training only the PEFT LoRA adapter (base frozen),
                    returning the new adapter as a ``flyte.io.Dir`` (a few MB).
@@ -89,7 +91,9 @@ import json
 import logging
 import os
 import tempfile
+from typing import Any
 
+from async_lru import alru_cache
 from pydantic import BaseModel
 
 import flyte
@@ -170,6 +174,7 @@ image = (
         "peft>=0.13.0",
         "accelerate>=0.34.0",
         "unionai-reuse>=0.1.3",
+        "async-lru>=2.0.0",
     )
 )
 
@@ -211,14 +216,39 @@ driver_env = flyte.TaskEnvironment(
     depends_on=[rollout_env, reward_env, train_env],
 )
 
-# Module globals — persist across calls *within a warm reusable replica*.
-_ENGINE = None  # the vLLM LLM, built once on first generate() call
-_ADAPTER_PATHS: dict[int, str] = {}  # adapter version -> local path (downloaded once per replica)
-
-
 # ----------------------------------------------------------------------------------------------------
 # 1. Rollout generation — warm in-process vLLM with per-request LoRA
 # ----------------------------------------------------------------------------------------------------
+# The expensive per-replica work is cached with @alru_cache, so it happens once and is reused across
+# every generate() call a warm replica handles. We key the caches on the remote URI string (hashable)
+# rather than the flyte.io.Dir object. Returns are typed Any because vLLM is imported lazily.
+
+
+@alru_cache(maxsize=1)
+async def _load_engine(base_uri: str) -> Any:
+    """Build the vLLM engine once per warm replica (cached); the frozen base stays resident in GPU."""
+    from vllm import LLM
+
+    local_base: str = await flyte.io.Dir.from_existing_remote(base_uri).download()  # plain-HF base
+    logger.info("Building warm vLLM engine from %s", local_base)
+    return LLM(
+        model=local_base,
+        enable_lora=True,
+        max_lora_rank=LORA_RANK,
+        max_loras=1,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.85,
+        max_model_len=2048,
+        enforce_eager=True,  # skip CUDA-graph capture → faster cold start for an MVP
+    )
+
+
+@alru_cache(maxsize=None)
+async def _adapter_local_path(adapter_uri: str) -> str:
+    """Download a LoRA adapter once per warm replica (cached by its remote URI → one download/version)."""
+    return await flyte.io.Dir.from_existing_remote(adapter_uri).download()
+
+
 @rollout_env.task
 async def generate(
     base: flyte.io.Dir,
@@ -230,45 +260,33 @@ async def generate(
 ) -> list[Rollout]:
     """Generate a GROUP_SIZE group of completions for one prompt, using the current LoRA adapter.
 
-    The frozen base loads exactly once per replica (module-global ``_ENGINE``). Each new adapter
-    version is downloaded once and attached per request via ``LoRARequest`` — the base weights in GPU
-    memory are never touched.
+    The frozen base loads exactly once per replica (cached ``_load_engine``); each adapter version is
+    downloaded once (cached ``_adapter_local_path``) and attached per request via ``LoRARequest`` — the
+    base weights in GPU memory are never touched.
     """
-    global _ENGINE
-    from vllm import LLM, SamplingParams
+    from vllm import SamplingParams
     from vllm.lora.request import LoRARequest
 
-    if _ENGINE is None:
-        local_base = await base.download()  # plain-HF base; vLLM loads it directly
-        logger.info("Building warm vLLM engine from %s", local_base)
-        _ENGINE = LLM(
-            model=local_base,
-            enable_lora=True,
-            max_lora_rank=LORA_RANK,
-            max_loras=1,
-            trust_remote_code=True,
-            gpu_memory_utilization=0.85,
-            max_model_len=2048,
-            enforce_eager=True,  # skip CUDA-graph capture → faster cold start for an MVP
-        )
-
-    if version not in _ADAPTER_PATHS:
-        _ADAPTER_PATHS[version] = await adapter.download()  # tiny LoRA dir, cached per version
+    engine: Any = await _load_engine(base.path)
+    adapter_path: str = await _adapter_local_path(adapter.path)
 
     # lora_int_id must be >= 1 and unique per adapter; version starts at 0 so shift by 1.
-    lora = LoRARequest(f"policy-v{version}", version + 1, _ADAPTER_PATHS[version])
-
-    sampling = SamplingParams(
+    lora: LoRARequest = LoRARequest(f"policy-v{version}", version + 1, adapter_path)
+    sampling: SamplingParams = SamplingParams(
         n=GROUP_SIZE,
         temperature=SAMPLING_TEMPERATURE,
         top_p=1.0,
         max_tokens=MAX_NEW_TOKENS,
     )
 
-    prompt = build_prompt(question)
-    # vLLM's generate() is blocking; run it off the event loop so the reusable replica stays async-friendly.
-    outputs = await asyncio.to_thread(_ENGINE.generate, [prompt], sampling, lora_request=lora)
-    completions = [o.text for o in outputs[0].outputs]
+    prompt: str = build_prompt(question)
+    # vLLM's generate() is a blocking call, so we run it via asyncio.to_thread to keep it off the event
+    # loop — that lets the reusable replica's background actor heartbeat stay responsive while the GPU
+    # is busy. (We deliberately do not use flyte.extras.DynamicBatcher here: it batches many concurrent
+    # producers, whereas this env runs concurrency=1 and each call already submits a full group of
+    # GROUP_SIZE sequences as one vLLM batch.)
+    outputs: Any = await asyncio.to_thread(engine.generate, [prompt], sampling, lora_request=lora)
+    completions: list[str] = [o.text for o in outputs[0].outputs]
     logger.info("group %s: generated %d completions (adapter v%d)", group_id, len(completions), version)
     return [
         Rollout(group_id=group_id, question=question, completion=c, answer=answer) for c in completions
@@ -291,8 +309,7 @@ def _extract_answer(text: str) -> str | None:
     return nums[-1] if nums else None
 
 
-@reward_env.task
-async def score(rollout: Rollout) -> float:
+def _reward(rollout: Rollout) -> float:
     """Verifiable reward: 1.0 for the correct answer, +0.2 format bonus for emitting the '####' marker."""
     reward = 0.0
     if "####" in rollout.completion:
@@ -301,6 +318,17 @@ async def score(rollout: Rollout) -> float:
     if predicted is not None and predicted == rollout.answer:
         reward += 1.0
     return reward
+
+
+@reward_env.task
+async def score_group(rollouts: list[Rollout]) -> list[float]:
+    """Score a whole prompt group in one task — one reward task per group, not per rollout.
+
+    The rule-based reward is microseconds of pure-Python work, so a task *per rollout* would pay pod
+    startup over and over for trivial compute. Scoring at the group granularity (the unit `generate`
+    already returns) keeps reward an observable, pipelined task while cutting the pod count ~GROUP_SIZE×.
+    """
+    return [_reward(r) for r in rollouts]
 
 
 # ----------------------------------------------------------------------------------------------------
@@ -313,11 +341,11 @@ async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
     from peft import LoraConfig, get_peft_model
     from transformers import AutoModelForCausalLM
 
-    local_base = await base.download()
-    model = AutoModelForCausalLM.from_pretrained(
+    local_base: str = await base.download()
+    model: Any = AutoModelForCausalLM.from_pretrained(
         local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
     )
-    lora_config = LoraConfig(
+    lora_config: Any = LoraConfig(
         r=LORA_RANK,
         lora_alpha=LORA_ALPHA,
         lora_dropout=0.0,
@@ -327,7 +355,7 @@ async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
     )
     model = get_peft_model(model, lora_config)
 
-    out_dir = tempfile.mkdtemp(prefix="adapter-v0-")
+    out_dir: str = tempfile.mkdtemp(prefix="adapter-v0-")
     model.save_pretrained(out_dir)  # writes adapter_config.json + adapter_model.safetensors only
     logger.info("Initialized fresh LoRA adapter at %s", out_dir)
     return await flyte.io.Dir.from_local(out_dir)
@@ -373,24 +401,24 @@ async def train_step(
     from peft import PeftModel
     from transformers import AutoModelForCausalLM, AutoTokenizer
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    local_base = await base.download()
-    local_adapter = await adapter.download()
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    local_base: str = await base.download()
+    local_adapter: str = await adapter.download()
 
-    tokenizer = AutoTokenizer.from_pretrained(local_base, trust_remote_code=True)
-    base_model = AutoModelForCausalLM.from_pretrained(
+    tokenizer: Any = AutoTokenizer.from_pretrained(local_base, trust_remote_code=True)
+    base_model: Any = AutoModelForCausalLM.from_pretrained(
         local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
     ).to(device)
     # Resume the trainable adapter from the previous version (frozen base, only A/B train).
-    model = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True).to(device)
+    model: Any = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True).to(device)
     model.train()
 
-    advantages = _group_normalized_advantages(rollouts, rewards)
-    optimizer = torch.optim.AdamW((p for p in model.parameters() if p.requires_grad), lr=LEARNING_RATE)
+    advantages: list[float] = _group_normalized_advantages(rollouts, rewards)
+    optimizer: Any = torch.optim.AdamW((p for p in model.parameters() if p.requires_grad), lr=LEARNING_RATE)
     optimizer.zero_grad()
 
-    total_loss = 0.0
-    contributing = 0
+    total_loss: float = 0.0
+    contributing: int = 0
     for rollout, advantage in zip(rollouts, advantages):
         if advantage == 0.0:
             continue  # no learning signal (whole group scored identically)
@@ -448,7 +476,7 @@ def _sample_prompts(iteration: int) -> list[tuple[str, str]]:
     return [DATASET[(start + i) % len(DATASET)] for i in range(PROMPTS_PER_ITER)]
 
 
-def _report_config() -> dict:
+def _report_config() -> dict[str, Any]:
     """Static run config surfaced in the report header."""
     return dict(
         base_model=BASE_MODEL_REPO,
@@ -512,16 +540,17 @@ async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> 
                 for gid, (q, a) in enumerate(prompts)
             ]
 
-            # Score each rollout the instant its group finishes — reward overlaps in-flight rollouts.
+            # Score each group the instant its rollout finishes — reward overlaps in-flight rollouts.
+            # One reward task per group (not per rollout): see score_group.
             flat_rollouts: list[Rollout] = []
-            reward_futs: list[asyncio.Task[float]] = []
+            reward_futs: list[asyncio.Task[list[float]]] = []
             for fut in asyncio.as_completed(rollout_futs):
                 group = await fut
-                for r in group:
-                    flat_rollouts.append(r)
-                    reward_futs.append(asyncio.create_task(score(r)))
+                flat_rollouts.extend(group)
+                reward_futs.append(asyncio.create_task(score_group(group)))
 
-            rewards = await asyncio.gather(*reward_futs)  # aligned with flat_rollouts (same order)
+            group_rewards = await asyncio.gather(*reward_futs)  # aligned with append order
+            rewards = [r for gr in group_rewards for r in gr]  # flatten → aligned with flat_rollouts
             mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
             logger.info("iter %d: %d rollouts, mean reward %.3f", it, len(rewards), mean_reward)
 


### PR DESCRIPTION
## What

An educational, runnable tutorial for **reinforcement learning of LLMs (GRPO + LoRA)** — the same loop shape used to train reasoning models — orchestrated entirely by Flyte async tasks on Union. No Ray, no external scheduler: the driver is a plain `async` `for` loop, and Flyte applies tricks like reusable-container warm pools to keep it fast. Lives in `v2/tutorials/rl_grpo_lora/`.

Loop shape: `sample prompts → generate rollouts (vLLM) → score (reward) → GRPO update (LoRA) → refresh adapter → repeat`

## Files

- **`rl_grpo_lora.py`** — the full example:
  - `generate` — **warm, reusable** vLLM rollout env (`ReusePolicy`, autoscales 1→4). The engine and each LoRA adapter are cached per replica with `@alru_cache`; adapters attach per request via `LoRARequest` (base never reloads).
  - `score_group` — CPU reward task, rule-based / verifiable, scored **one task per prompt group** (not per rollout) to keep pod count low.
  - `init_adapter` / `train_step` — single-node GPU; one hand-rolled GRPO step (group-normalized advantages) training only the PEFT LoRA adapter, returned as a `flyte.io.Dir`.
  - `train_rl` — async driver: fan out with `asyncio.create_task`, score via `as_completed`, then `train_step`; resumes via `flyte.Checkpoint`, groups iterations with `flyte.group`, streams a live `flyte.report`.
- **`report_helpers.py`** — dependency-free HTML/SVG report toolkit.
- **`README.md`** — the tutorial: GRPO/LoRA primer, concept-by-concept walkthrough, warm-pool topology (Mermaid), a "Why Flyte with Union is a great fit for RL" section, and a Ray/RLlib bridge.

## Key techniques shown

- **Warm vLLM pool** via `ReusePolicy` + `@alru_cache` — load the frozen base once, reuse across all iterations; only the few-MB adapter moves each step.
- **Rollout→reward pipelining** with `asyncio.as_completed` (no map barrier) — reward overlaps in-flight generation, at group granularity.
- **Hand-rolled GRPO step** so generation/reward/update stay separate, observable Flyte tasks (a library trainer would own the loop and bypass the warm pool).
- **Resumability + observability** — `flyte.Checkpoint`, `flyte.group`, live `report=True`.

## Validated end-to-end on a Union demo cluster

Qwen3-0.6B, L4 GPUs, 3 GRPO iterations — run **SUCCEEDED** with **1 init_adapter + 12 generate + 12 score_group + 3 train_step**, final LoRA adapter (`v3`) returned as a `flyte.io.Dir`, live report published each iteration, rollouts running as warm `actor` replicas. (Small model + toy dataset proves the machinery, not convergence.)

Runtime issues found and fixed during validation: `depends_on` on the driver env; `unionai-reuse` in the image (actor bridge); precompiled flashinfer cubin wheels (avoids runtime `nvcc`); `hf-token` secret name; sync `run.outputs()` handling.

## API verification

Checked against source, not assumed — flyte-sdk (`TaskEnvironment`, `ReusePolicy`, `GPU`, `Secret`, `Checkpoint`, `io.Dir`, `prefetch.hf_model`, `report`) and vLLM 0.11.0 (`LLM(enable_lora=True)`, `generate(..., lora_request=...)`, `LoRARequest`). The deferred GRPO refinements (PPO clip, KL term) are noted in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
