### PR TITLE
Canonicalize YDC_API_KEY with YOU_API_KEY fallback and improve You.com search params

### DIFF
--- a/v2/tutorials/competitive_intelligence_agent/README.md
+++ b/v2/tutorials/competitive_intelligence_agent/README.md
@@ -49,7 +49,7 @@ agent feeds those into an LLM that emits structured, source-cited deltas.
 
 | Secret key | Env var | Purpose |
 | --- | --- | --- |
-| `youdotcom-api-key` | `YOU_API_KEY` | You.com Search API |
+| `youdotcom-api-key` | `YDC_API_KEY` | You.com Search API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
 ## Run it

--- a/v2/tutorials/competitive_intelligence_agent/main.py
+++ b/v2/tutorials/competitive_intelligence_agent/main.py
@@ -28,7 +28,7 @@ MODEL = "anthropic/claude-haiku-4-5"
 env = flyte.TaskEnvironment(
     name="competitive-intelligence",
     secrets=[
-        flyte.Secret(key="youdotcom-api-key", as_env_var="YOU_API_KEY"),
+        flyte.Secret(key="youdotcom-api-key", as_env_var="YDC_API_KEY"),
         flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(__file__, name="competitive-intelligence", pre=True),
@@ -92,7 +92,8 @@ async def _you_get(url: str, params: dict, timeout: float = 60.0) -> dict:
 
     import httpx
 
-    headers = {"X-API-Key": os.environ["YOU_API_KEY"]}
+    # YDC_API_KEY is canonical; YOU_API_KEY accepted as a backwards-compatible fallback.
+    headers = {"X-API-Key": os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"]}
     async with httpx.AsyncClient(timeout=timeout) as client:
         for attempt in range(7):
             resp = await client.get(url, headers=headers, params=params)
@@ -122,9 +123,23 @@ def _favicon(item: dict, url: str) -> str:
 
 
 @flyte.trace
-async def you_search(query: str, count: int = 8, freshness: str = "week") -> list[SearchHit]:
-    """Call the You.com Search API and return unified web + news hits."""
-    params = {"query": query, "count": count, "freshness": freshness}
+async def you_search(
+    query: str,
+    count: int = 10,
+    freshness: str = "week",
+    boost_domains: str = "",
+) -> list[SearchHit]:
+    """Call the You.com Search API and return unified web + news hits.
+
+    ``boost_domains`` (comma-separated) gives a ranking boost to authoritative
+    sources without restricting results to only those domains — useful for
+    competitive intelligence where credible third-party reporting should
+    surface above noise, but primary sources (e.g. a company's own blog)
+    must still be reachable.
+    """
+    params: dict = {"query": query, "count": count, "freshness": freshness}
+    if boost_domains:
+        params["boost_domains"] = boost_domains
     data = await _you_get(YOU_SEARCH_URL, params)
 
     results = data.get("results", {})
@@ -194,6 +209,12 @@ If there are no clear changes, return {"deltas": []}."""
 
 
 # {{docs-fragment watch_competitor}}
+# Domains that consistently break AI-industry news (funding, product, leadership).
+# boost_domains lifts these in ranking without excluding other sources, so a
+# competitor's own blog or niche coverage still surfaces when relevant.
+CI_BOOST_DOMAINS = "techcrunch.com,reuters.com,bloomberg.com,theinformation.com,venturebeat.com"
+
+
 @env.task(retries=3)
 async def watch_competitor(
     competitor: str,
@@ -206,7 +227,9 @@ async def watch_competitor(
         + " OR ".join(categories)
         + " announcement OR news OR update"
     )
-    hits = await you_search(query, count=8, freshness=freshness)
+    hits = await you_search(
+        query, count=10, freshness=freshness, boost_domains=CI_BOOST_DOMAINS
+    )
     if not hits:
         return CompetitorWatch(competitor=competitor)
 

--- a/v2/tutorials/compliance_monitoring_agent/README.md
+++ b/v2/tutorials/compliance_monitoring_agent/README.md
@@ -50,7 +50,7 @@ a story no SERP scraper or LLM-only stack can credibly tell.
 
 | Secret key | Env var | Purpose |
 | --- | --- | --- |
-| `youdotcom-api-key` | `YOU_API_KEY` | You.com Research API |
+| `youdotcom-api-key` | `YDC_API_KEY` | You.com Research API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
 ## Run it

--- a/v2/tutorials/compliance_monitoring_agent/main.py
+++ b/v2/tutorials/compliance_monitoring_agent/main.py
@@ -29,7 +29,7 @@ MODEL = "anthropic/claude-haiku-4-5"
 env = flyte.TaskEnvironment(
     name="compliance-monitoring",
     secrets=[
-        flyte.Secret(key="youdotcom-api-key", as_env_var="YOU_API_KEY"),
+        flyte.Secret(key="youdotcom-api-key", as_env_var="YDC_API_KEY"),
         flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(__file__, name="compliance-monitoring", pre=True),
@@ -120,8 +120,9 @@ async def _you_post(url: str, body: dict, timeout: float = 300.0) -> dict:
 
     import httpx
 
+    # YDC_API_KEY is canonical; YOU_API_KEY accepted as a backwards-compatible fallback.
     headers = {
-        "X-API-Key": os.environ["YOU_API_KEY"],
+        "X-API-Key": os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"],
         "Content-Type": "application/json",
     }
     async with httpx.AsyncClient(timeout=timeout) as client:

--- a/v2/tutorials/field_data_enrichment_agent/README.md
+++ b/v2/tutorials/field_data_enrichment_agent/README.md
@@ -46,7 +46,7 @@ information without building and maintaining a per-customer crawler.
 
 | Secret key | Env var | Purpose |
 | --- | --- | --- |
-| `youdotcom-api-key` | `YOU_API_KEY` | You.com Search API |
+| `youdotcom-api-key` | `YDC_API_KEY` | You.com Search API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
 ## Run it

--- a/v2/tutorials/field_data_enrichment_agent/main.py
+++ b/v2/tutorials/field_data_enrichment_agent/main.py
@@ -29,7 +29,7 @@ MODEL = "anthropic/claude-haiku-4-5"
 env = flyte.TaskEnvironment(
     name="field-data-enrichment",
     secrets=[
-        flyte.Secret(key="youdotcom-api-key", as_env_var="YOU_API_KEY"),
+        flyte.Secret(key="youdotcom-api-key", as_env_var="YDC_API_KEY"),
         flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(__file__, name="field-data-enrichment", pre=True),
@@ -113,7 +113,8 @@ async def _you_get(url: str, params: dict, timeout: float = 60.0) -> dict:
 
     import httpx
 
-    headers = {"X-API-Key": os.environ["YOU_API_KEY"]}
+    # YDC_API_KEY is canonical; YOU_API_KEY accepted as a backwards-compatible fallback.
+    headers = {"X-API-Key": os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"]}
     async with httpx.AsyncClient(timeout=timeout) as client:
         for attempt in range(7):
             resp = await client.get(url, headers=headers, params=params)

--- a/v2/tutorials/financial_research_agent/README.md
+++ b/v2/tutorials/financial_research_agent/README.md
@@ -43,7 +43,7 @@ task environment. Flyte caching further cuts duplicate spend when runs converge.
 
 | Secret key | Env var | Purpose |
 | --- | --- | --- |
-| `youdotcom-api-key` | `YOU_API_KEY` | You.com Research + Search APIs |
+| `youdotcom-api-key` | `YDC_API_KEY` | You.com Research + Search APIs |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
 ## Run it

--- a/v2/tutorials/financial_research_agent/main.py
+++ b/v2/tutorials/financial_research_agent/main.py
@@ -29,7 +29,7 @@ MODEL = "anthropic/claude-haiku-4-5"
 env = flyte.TaskEnvironment(
     name="financial-research",
     secrets=[
-        flyte.Secret(key="youdotcom-api-key", as_env_var="YOU_API_KEY"),
+        flyte.Secret(key="youdotcom-api-key", as_env_var="YDC_API_KEY"),
         flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(__file__, name="financial-research", pre=True),
@@ -96,7 +96,8 @@ async def _you_request(method: str, url: str, timeout: float, **kwargs) -> dict:
 
     import httpx
 
-    headers = {"X-API-Key": os.environ["YOU_API_KEY"]}
+    # YDC_API_KEY is canonical; YOU_API_KEY accepted as a backwards-compatible fallback.
+    headers = {"X-API-Key": os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"]}
     if method == "POST":
         headers["Content-Type"] = "application/json"
 
@@ -125,9 +126,21 @@ async def you_research(question: str, research_effort: str, freshness: str) -> d
 
 
 @flyte.trace
-async def you_news(query: str, count: int = 6, freshness: str = "week") -> list[dict]:
-    """Fresh news headlines for a company."""
-    params = {"query": query, "count": count, "freshness": freshness}
+async def you_news(
+    query: str,
+    count: int = 10,
+    freshness: str = "week",
+    boost_domains: str = "",
+) -> list[dict]:
+    """Fresh news headlines for a company.
+
+    ``boost_domains`` (comma-separated) lifts authoritative financial outlets
+    in ranking without restricting results to only those domains, so company
+    press releases and niche coverage still surface when relevant.
+    """
+    params: dict = {"query": query, "count": count, "freshness": freshness}
+    if boost_domains:
+        params["boost_domains"] = boost_domains
     data = await _you_request("GET", YOU_SEARCH_URL, 60.0, params=params)
 
     results = data.get("results", {})
@@ -194,6 +207,13 @@ def _parse_json(text: str) -> dict | list:
 
 
 # {{docs-fragment research_company}}
+# Tier-1 financial outlets that consistently break earnings, M&A, and
+# analyst-moving news. boost_domains lifts these in ranking without excluding
+# other sources, so company press releases and trade-press coverage still
+# surface when relevant.
+FINANCE_BOOST_DOMAINS = "reuters.com,bloomberg.com,wsj.com,marketwatch.com,cnbc.com,ft.com"
+
+
 @env.task(retries=3)
 async def research_company(
     company: str,
@@ -209,7 +229,11 @@ async def research_company(
     )
     research_result, news = await asyncio.gather(
         you_research(question, research_effort, freshness),
-        you_news(f"{company} earnings news", freshness=freshness),
+        you_news(
+            f"{company} earnings news",
+            freshness=freshness,
+            boost_domains=FINANCE_BOOST_DOMAINS,
+        ),
     )
 
     output = research_result.get("output", {})

--- a/v2/tutorials/support_resolution_agent/README.md
+++ b/v2/tutorials/support_resolution_agent/README.md
@@ -44,7 +44,7 @@ for real-time, human-in-the-loop support flows — not just batch.
 
 | Secret key | Env var | Purpose |
 | --- | --- | --- |
-| `youdotcom-api-key` | `YOU_API_KEY` | You.com Research + Search APIs |
+| `youdotcom-api-key` | `YDC_API_KEY` | You.com Research + Search APIs |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
 ## Run it

--- a/v2/tutorials/support_resolution_agent/main.py
+++ b/v2/tutorials/support_resolution_agent/main.py
@@ -29,7 +29,7 @@ MODEL = "anthropic/claude-haiku-4-5"
 env = flyte.TaskEnvironment(
     name="support-resolution",
     secrets=[
-        flyte.Secret(key="youdotcom-api-key", as_env_var="YOU_API_KEY"),
+        flyte.Secret(key="youdotcom-api-key", as_env_var="YDC_API_KEY"),
         flyte.Secret(key="internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
     ],
     image=flyte.Image.from_uv_script(__file__, name="support-resolution", pre=True),
@@ -99,8 +99,9 @@ async def _you_post(url: str, body: dict, timeout: float = 120.0) -> dict:
 
     import httpx
 
+    # YDC_API_KEY is canonical; YOU_API_KEY accepted as a backwards-compatible fallback.
     headers = {
-        "X-API-Key": os.environ["YOU_API_KEY"],
+        "X-API-Key": os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"],
         "Content-Type": "application/json",
     }
     async with httpx.AsyncClient(timeout=timeout) as client:


### PR DESCRIPTION
## Summary

Across all 5 You.com tutorial agents, switch the canonical env var from `YOU_API_KEY` to `YDC_API_KEY` so existing developers can onboard onto new tools with a consistent key name. `YOU_API_KEY` is kept as a backwards-compatible fallback via `os.environ.get("YDC_API_KEY") or os.environ["YOU_API_KEY"]`, so no one breaks on upgrade.

Also improve You.com Search API usage in two agents where parameter tuning materially helps:

- **competitive_intelligence_agent**: `count` 8 → 10 (more signal surface for delta extraction), `boost_domains` for authoritative tech/business news (techcrunch, reuters, bloomberg, theinformation, venturebeat) — lifts credible third-party reporting in ranking without excluding primary sources.
- **financial_research_agent**: `count` 6 → 10 (more news for briefing synthesis), `boost_domains` for tier-1 financial outlets (reuters, bloomberg, wsj, marketwatch, cnbc, ft).

### What was NOT changed (and why)
- **field_data_enrichment_agent**: already well-tuned (`country` for geofencing, `freshness=day` for real-time ops). `boost_domains` doesn't apply since authoritative local sources vary by country/event.
- **compliance_monitoring_agent / support_resolution_agent**: use the Research API (not Search API), already appropriately configured.
- `livecrawl`, `country`, `include_domains`, `exclude_domains` — not applicable to these use cases.

## Files changed
- 5 `main.py` files: env var canonicalization + fallback pattern
- 5 `README.md` files: documented env var updated to `YDC_API_KEY`
- `competitive_intelligence_agent/main.py`: search params (count, boost_domains)
- `financial_research_agent/main.py`: search params (count, boost_domains)