### PR TITLE
Add intra-task checkpoint examples for the user guide

### DIFF
--- a/v2/user-guide/task-programming/intra-task-checkpoints/generic_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/generic_checkpoint.py
@@ -1,0 +1,42 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+# ]
+# main = "use_checkpoint"
+# params = "n_iterations=10"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="checkpoint_generic")
+
+RETRIES = 3
+
+
+@env.task(retries=RETRIES)
+async def use_checkpoint(n_iterations: int = 10) -> int:
+    checkpoint = flyte.ctx().checkpoint
+
+    # Load the previous attempt's checkpoint, if any.
+    # On the first attempt there is none, so load() returns None.
+    path = await checkpoint.load()
+    start = int(path.read_bytes()) if path else 0
+
+    failure_interval = n_iterations // RETRIES
+    index = start
+    for index in range(start, n_iterations):
+        if index > start and index % failure_interval == 0:
+            # Simulate a failure so the next attempt resumes from the checkpoint
+            raise RuntimeError(f"Simulated failure at iteration {index}")
+        # Persist progress to object storage.
+        await checkpoint.save(f"{index + 1}".encode())
+    return index
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(use_checkpoint, n_iterations=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/generic_checkpoint_sync.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/generic_checkpoint_sync.py
@@ -1,0 +1,42 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+# ]
+# main = "use_checkpoint"
+# params = "n_iterations=10"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="checkpoint_generic_sync")
+
+RETRIES = 3
+
+
+@env.task(retries=RETRIES)
+def use_checkpoint(n_iterations: int = 10) -> int:
+    checkpoint = flyte.ctx().checkpoint
+
+    # Load the previous attempt's checkpoint, if any.
+    # On the first attempt there is none, so load_sync() returns None.
+    path = checkpoint.load_sync()
+    start = int(path.read_bytes()) if path else 0
+
+    failure_interval = n_iterations // RETRIES
+    index = start
+    for index in range(start, n_iterations):
+        if index > start and index % failure_interval == 0:
+            # Simulate a failure so the next attempt resumes from the checkpoint
+            raise RuntimeError(f"Simulated failure at iteration {index}")
+        # Persist progress to object storage.
+        checkpoint.save_sync(f"{index + 1}".encode())
+    return index
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(use_checkpoint, n_iterations=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/huggingface_trainer_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/huggingface_trainer_checkpoint.py
@@ -1,0 +1,139 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+#    "torch>=2.0",
+#    "transformers>=4.38",
+#    "accelerate>=1.1.0",
+# ]
+# main = "train_transformers"
+# params = "max_epochs=10"
+# ///
+
+"""Resume Hugging Face `transformers.Trainer` training across task retries.
+
+The `Trainer` already writes `checkpoint-<step>` directories under `output_dir`;
+this example mirrors `output_dir` to the Flyte checkpoint after each epoch and
+resumes with `resume_from_checkpoint` on retry.
+"""
+
+import pathlib
+
+import torch
+from torch.utils.data import Dataset
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    DataCollatorWithPadding,
+    Trainer,
+    TrainerCallback,
+    TrainingArguments,
+)
+from transformers.trainer_utils import get_last_checkpoint
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="checkpoint_hf_trainer",
+    image=flyte.Image.from_debian_base().with_pip_packages("transformers[torch]"),
+)
+
+MODEL_ID = "hf-internal-testing/tiny-random-bert"
+RETRIES = 3
+
+
+class ToyTextDataset(Dataset):
+    """Synthetic binary classification examples."""
+
+    def __init__(self, tokenizer, n: int = 64, max_length: int = 32):
+        self._tokenizer = tokenizer
+        self._max_length = max_length
+        self._texts = [f"classification example {i} with enough tokens" for i in range(n)]
+        self._labels = [i % 2 for i in range(n)]
+
+    def __len__(self) -> int:
+        return len(self._texts)
+
+    def __getitem__(self, idx: int) -> dict:
+        enc = self._tokenizer(
+            self._texts[idx],
+            truncation=True,
+            max_length=self._max_length,
+            padding="max_length",
+        )
+        enc["labels"] = self._labels[idx]
+        return enc
+
+
+# {{docs-fragment callback}}
+class FlyteTrainerCheckpointCallback(TrainerCallback):
+    """Mirror the Trainer's `output_dir` to the Flyte checkpoint after each epoch."""
+
+    def __init__(self, checkpoint: flyte.Checkpoint, output_dir: pathlib.Path) -> None:
+        self._checkpoint = checkpoint
+        self._output_dir = output_dir
+
+    def on_epoch_end(self, args, state, control, **kwargs) -> None:
+        # Trainer callbacks are synchronous, so use save_sync
+        self._checkpoint.save_sync(self._output_dir)
+# {{/docs-fragment callback}}
+
+
+# {{docs-fragment task}}
+@env.task(retries=RETRIES)
+def train_transformers(max_epochs: int = 10) -> float:
+    checkpoint = flyte.ctx().checkpoint
+
+    ckpt_dir = pathlib.Path("hf_trainer")
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # Restore the previous attempt's checkpoint tree and find the last HF checkpoint.
+    hf_resume = None
+    prev = checkpoint.load_sync()
+    if prev:
+        hf_resume = get_last_checkpoint(str(prev))
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
+    model = AutoModelForSequenceClassification.from_pretrained(MODEL_ID, num_labels=2)
+
+    args = TrainingArguments(
+        output_dir=str(ckpt_dir),
+        num_train_epochs=max_epochs,
+        per_device_train_batch_size=4,
+        save_strategy="epoch",
+        save_total_limit=2,
+        logging_steps=1,
+        report_to="none",
+        seed=42,
+        use_cpu=True,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=ToyTextDataset(tokenizer),
+        data_collator=DataCollatorWithPadding(tokenizer),
+        callbacks=[FlyteTrainerCheckpointCallback(checkpoint, ckpt_dir)],
+    )
+    trainer.train(resume_from_checkpoint=hf_resume)
+
+    model.eval()
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        batch = tokenizer(
+            "classification example for inference",
+            return_tensors="pt",
+            truncation=True,
+            max_length=32,
+            padding="max_length",
+        )
+        batch = {k: v.to(device) for k, v in batch.items()}
+        logits = model(**batch).logits
+        return float(logits[0, 1].item())
+# {{/docs-fragment task}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_transformers, max_epochs=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/pytorch_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/pytorch_checkpoint.py
@@ -1,0 +1,79 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+#    "torch>=2.0",
+# ]
+# main = "train_linear"
+# params = "epochs=10"
+# ///
+
+"""Resume a PyTorch training loop across task retries with `flyte.Checkpoint`."""
+
+# {{docs-fragment env}}
+import pathlib
+
+import torch
+import torch.nn as nn
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="checkpoint_pytorch",
+    image=flyte.Image.from_debian_base().with_pip_packages("torch"),
+)
+
+RETRIES = 3
+# {{/docs-fragment env}}
+
+
+# {{docs-fragment task}}
+@env.task(retries=RETRIES)
+async def train_linear(epochs: int = 10) -> float:
+    checkpoint = flyte.ctx().checkpoint
+
+    model = nn.Linear(4, 1)
+    opt = torch.optim.SGD(model.parameters(), lr=0.01)
+
+    # Resume model, optimizer, and epoch from the previous attempt, if any.
+    prev = await checkpoint.load()
+    if prev:
+        blob = torch.load(prev, map_location="cpu", weights_only=False)
+        model.load_state_dict(blob["model"])
+        opt.load_state_dict(blob["opt"])
+        start = int(blob["epoch"]) + 1
+    else:
+        start = 0
+
+    wpath = pathlib.Path("pytorch_linear") / "training.pt"
+    wpath.parent.mkdir(parents=True, exist_ok=True)
+
+    failure_interval = epochs // RETRIES
+    for epoch in range(start, epochs):
+        x = torch.randn(8, 4)
+        y = torch.randn(8, 1)
+        loss = torch.nn.functional.mse_loss(model(x), y)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+        if epoch > start and epoch % failure_interval == 0:
+            # Simulate a failure so the next attempt resumes from the checkpoint
+            raise RuntimeError(f"Simulated failure at epoch {epoch}")
+
+        # Save model, optimizer, and epoch state to object storage.
+        torch.save(
+            {"model": model.state_dict(), "opt": opt.state_dict(), "epoch": epoch},
+            wpath,
+        )
+        await checkpoint.save(wpath)
+
+    with torch.no_grad():
+        return float(model(torch.ones(1, 4)).squeeze().item())
+# {{/docs-fragment task}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_linear, epochs=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/pytorch_lightning_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/pytorch_lightning_checkpoint.py
@@ -1,0 +1,126 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+#    "torch>=2.0",
+#    "lightning>=2.0",
+# ]
+# main = "train_lightning"
+# params = "max_epochs=10"
+# ///
+
+"""Resume PyTorch Lightning training across task retries with `flyte.Checkpoint`.
+
+Lightning already writes `last.ckpt` to a local directory via `ModelCheckpoint`;
+this example mirrors that directory to the Flyte checkpoint after each epoch and
+resumes from the newest `last.ckpt` on retry.
+"""
+
+import pathlib
+
+import lightning as L
+import torch
+import torch.nn as nn
+from lightning.pytorch.callbacks import ModelCheckpoint
+from torch.utils.data import DataLoader, TensorDataset
+from typing_extensions import override
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="checkpoint_lightning",
+    image=flyte.Image.from_debian_base().with_pip_packages("lightning"),
+)
+
+FEATURES = 16
+RETRIES = 3
+
+
+# {{docs-fragment callback}}
+class FlyteLightningCheckpointCallback(ModelCheckpoint):
+    """A `ModelCheckpoint` that mirrors `dirpath` to the Flyte checkpoint after each epoch."""
+
+    def __init__(self, flyte_checkpoint: flyte.Checkpoint, *, dirpath: str | pathlib.Path, **kwargs) -> None:
+        super().__init__(dirpath=str(dirpath), **kwargs)
+        self._flyte_checkpoint = flyte_checkpoint
+
+    @override
+    def on_train_epoch_end(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
+        super().on_train_epoch_end(trainer, pl_module)
+        if self.dirpath:
+            # Lightning callbacks are synchronous, so use save_sync
+            self._flyte_checkpoint.save_sync(pathlib.Path(self.dirpath))
+# {{/docs-fragment callback}}
+
+
+class TinyModule(L.LightningModule):
+    def __init__(self, lr: float = 0.02):
+        super().__init__()
+        self.save_hyperparameters()
+        self.net = nn.Sequential(nn.Linear(FEATURES, 32), nn.ReLU(), nn.Linear(32, 1))
+        self.loss = nn.MSELoss()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        x, y = batch
+        loss = self.loss(self(x), y)
+        self.log("train_loss", loss, prog_bar=True)
+        return loss
+
+    def configure_optimizers(self):
+        return torch.optim.SGD(self.parameters(), lr=self.hparams.lr)
+
+
+def make_loader(batch: int = 32, batches: int = 8) -> DataLoader:
+    g = torch.Generator().manual_seed(42)
+    x = torch.randn(batches * batch, FEATURES, generator=g)
+    y = torch.randn(batches * batch, 1, generator=g)
+    return DataLoader(TensorDataset(x, y), batch_size=batch, shuffle=True)
+
+
+# {{docs-fragment task}}
+@env.task(retries=RETRIES)
+def train_lightning(max_epochs: int = 10) -> float:
+    checkpoint = flyte.ctx().checkpoint
+
+    ckpt_dir = pathlib.Path("pl_checkpoints")
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # Restore the previous attempt's checkpoint tree and find the newest last.ckpt.
+    resume_ckpt = None
+    prev = checkpoint.load_sync()
+    if prev:
+        last = flyte.latest_checkpoint(prev)
+        if last:
+            resume_ckpt = str(last)
+
+    model = TinyModule()
+    mc = FlyteLightningCheckpointCallback(
+        checkpoint,
+        dirpath=ckpt_dir,
+        filename="last",
+        save_last=True,
+        save_top_k=1,
+    )
+    trainer = L.Trainer(
+        max_epochs=max_epochs,
+        enable_checkpointing=True,
+        callbacks=[mc],
+        enable_progress_bar=True,
+        logger=False,
+        accelerator="cpu",
+        devices=1,
+    )
+    trainer.fit(model, make_loader(), ckpt_path=resume_ckpt)
+
+    with torch.no_grad():
+        return float(model(torch.ones(1, FEATURES)).squeeze().item())
+# {{/docs-fragment task}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_lightning, max_epochs=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/sklearn_partial_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/sklearn_partial_checkpoint.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+#    "scikit-learn",
+#    "numpy",
+# ]
+# main = "incremental_sgd"
+# params = "chunks=10"
+# ///
+
+"""Resume scikit-learn incremental training (`partial_fit`) across task retries.
+
+The estimator and the number of chunks already trained are pickled together
+after each chunk, so a retry unpickles them and continues from the next chunk.
+"""
+
+# {{docs-fragment env}}
+import pathlib
+import pickle
+
+import numpy as np
+from sklearn.linear_model import SGDClassifier
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="checkpoint_sklearn_partial",
+    image=flyte.Image.from_debian_base().with_pip_packages("scikit-learn"),
+    resources=flyte.Resources(cpu="2", memory="1Gi"),
+)
+
+RETRIES = 3
+# {{/docs-fragment env}}
+
+
+# {{docs-fragment task}}
+@env.task(retries=RETRIES)
+async def incremental_sgd(chunks: int = 10) -> float:
+    checkpoint = flyte.ctx().checkpoint
+
+    # Resume the estimator and progress from the previous attempt, if any.
+    prev = await checkpoint.load()
+    if prev:
+        bundle = pickle.loads(prev.read_bytes())
+        start = bundle["chunks_done"]
+        clf = bundle["clf"]
+    else:
+        start = 0
+        clf = SGDClassifier(max_iter=1, tol=None, random_state=0)
+
+    bundle_path = pathlib.Path("sklearn_partial") / "sgd_bundle.pkl"
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(0)
+    classes = np.array([0, 1])
+
+    failure_interval = chunks // RETRIES
+    for i in range(start, chunks):
+        x = rng.standard_normal((32, 8))
+        y = (x[:, 0] + x[:, 1] > 0).astype(int)
+        clf.partial_fit(x, y, classes=classes)
+
+        if i > start and i % failure_interval == 0:
+            # Simulate a failure so the next attempt resumes from the checkpoint
+            raise RuntimeError(f"Simulated failure at chunk {i}")
+
+        # Pickle the estimator plus progress and save it to object storage.
+        bundle_path.write_bytes(pickle.dumps({"clf": clf, "chunks_done": i + 1}))
+        await checkpoint.save(bundle_path)
+
+    x_test = rng.standard_normal((64, 8))
+    y_test = (x_test[:, 0] + x_test[:, 1] > 0).astype(int)
+    return float(clf.score(x_test, y_test))
+# {{/docs-fragment task}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(incremental_sgd, chunks=10)
+    print(run.url)

--- a/v2/user-guide/task-programming/intra-task-checkpoints/unsloth_sft_checkpoint.py
+++ b/v2/user-guide/task-programming/intra-task-checkpoints/unsloth_sft_checkpoint.py
@@ -1,0 +1,156 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.5.0",
+#    "torch>=2.0",
+#    "unsloth",
+#    "trl",
+#    "datasets",
+#    "transformers",
+#    "accelerate",
+# ]
+# main = "train_unsloth_sft"
+# params = "max_epochs=10"
+# ///
+
+"""Resume Unsloth LoRA fine-tuning (`trl.SFTTrainer`) across task retries.
+
+Same pattern as the Hugging Face `Trainer` example: mirror `output_dir` to the
+Flyte checkpoint after each epoch and resume with `resume_from_checkpoint`.
+Unsloth requires an NVIDIA, AMD, or Intel GPU, so the task requests one.
+"""
+
+import pathlib
+
+try:
+    import unsloth  # noqa: F401
+except NotImplementedError:
+    # Unsloth raises on unsupported hardware at import time (e.g. Apple Silicon);
+    # the task itself runs on a GPU worker.
+    pass
+
+import torch
+from transformers import TrainerCallback
+from transformers.trainer_utils import get_last_checkpoint
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="checkpoint_unsloth_sft",
+    image=flyte.Image.from_debian_base().with_pip_packages("unsloth"),
+    resources=flyte.Resources(cpu=2, memory="8Gi", gpu="L4:1"),
+)
+
+MODEL_NAME = "unsloth/Llama-3.2-1B-bnb-4bit"
+RETRIES = 3
+
+
+class FlyteTrainerCheckpointCallback(TrainerCallback):
+    """Mirror the Trainer's `output_dir` to the Flyte checkpoint after each epoch."""
+
+    def __init__(self, checkpoint: flyte.Checkpoint, output_dir: pathlib.Path) -> None:
+        self._checkpoint = checkpoint
+        self._output_dir = output_dir
+
+    def on_epoch_end(self, args, state, control, **kwargs) -> None:
+        # Trainer callbacks are synchronous, so use save_sync
+        self._checkpoint.save_sync(self._output_dir)
+
+
+def tiny_instruction_dataset():
+    from datasets import Dataset
+
+    rows = [
+        "### Instruction:\nSay hello.\n\n### Response:\nHello!",
+        "### Instruction:\nWhat is 1+1?\n\n### Response:\n2",
+        "### Instruction:\nName a color.\n\n### Response:\nBlue",
+    ] * 6
+    return Dataset.from_dict({"text": rows})
+
+
+# {{docs-fragment task}}
+@env.task(retries=RETRIES)
+def train_unsloth_sft(max_epochs: int = 10) -> float:
+    from trl import SFTConfig, SFTTrainer
+    from unsloth import FastLanguageModel
+
+    checkpoint = flyte.ctx().checkpoint
+
+    ckpt_dir = pathlib.Path("unsloth_sft")
+    ckpt_dir.mkdir(parents=True, exist_ok=True)
+
+    # Restore the previous attempt's checkpoint tree and find the last HF checkpoint.
+    hf_resume = None
+    prev = checkpoint.load_sync()
+    if prev:
+        hf_resume = get_last_checkpoint(str(prev))
+
+    max_seq_length = 512
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=MODEL_NAME,
+        max_seq_length=max_seq_length,
+        dtype=None,
+        load_in_4bit=True,
+    )
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=16,
+        target_modules=[
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        lora_alpha=16,
+        lora_dropout=0.0,
+        bias="none",
+        use_gradient_checkpointing="unsloth",
+        random_state=42,
+    )
+
+    args = SFTConfig(
+        output_dir=str(ckpt_dir),
+        num_train_epochs=max_epochs,
+        per_device_train_batch_size=1,
+        gradient_accumulation_steps=1,
+        save_strategy="epoch",
+        save_total_limit=2,
+        logging_steps=1,
+        report_to="none",
+        seed=42,
+        dataset_text_field="text",
+        max_length=max_seq_length,
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        args=args,
+        train_dataset=tiny_instruction_dataset(),
+        processing_class=tokenizer,
+        callbacks=[FlyteTrainerCheckpointCallback(checkpoint, ckpt_dir)],
+    )
+    trainer.train(resume_from_checkpoint=hf_resume)
+
+    model.eval()
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        batch = tokenizer(
+            "classification example for inference",
+            return_tensors="pt",
+            truncation=True,
+            max_length=32,
+            padding="max_length",
+        )
+        batch = {k: v.to(device) for k, v in batch.items()}
+        logits = model(**batch).logits
+        return float(logits[0, 1].mean().item())
+# {{/docs-fragment task}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(train_unsloth_sft, max_epochs=10)
+    print(run.url)


### PR DESCRIPTION
## Summary

Adds `v2/user-guide/task-programming/intra-task-checkpoints/` with seven runnable examples of `flyte.Checkpoint` (intra-task checkpointing across retries), adapted from [flyteorg/flyte-sdk `examples/checkpoint`](https://github.com/flyteorg/flyte-sdk/tree/8f22ea784347efe6489477535ecce3c4e2674a41/examples/checkpoint):

- `generic_checkpoint.py` / `generic_checkpoint_sync.py` — raw-bytes counter with simulated failures (async and sync APIs)
- `pytorch_checkpoint.py` — save/restore model + optimizer + epoch with `torch.save`/`torch.load`
- `pytorch_lightning_checkpoint.py` — `ModelCheckpoint` subclass that mirrors `dirpath` to the Flyte checkpoint; resumes via `flyte.latest_checkpoint`
- `huggingface_trainer_checkpoint.py` — `TrainerCallback` mirroring `output_dir`; resumes via `get_last_checkpoint`
- `sklearn_partial_checkpoint.py` — pickled estimator + progress bundle around `partial_fit`
- `unsloth_sft_checkpoint.py` — LoRA fine-tuning with `trl.SFTTrainer` on an L4 GPU

Adaptations from the upstream examples: dropped the failure-injection callback classes from the framework examples (kept inline simulated failures in the generic/PyTorch/sklearn ones), removed type-narrowing asserts, and added `{{docs-fragment}}` markers for the new "Intra-task checkpoints" user-guide page in unionai-docs, which references these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)