### PR TITLE
Add Flyte 1 → Flyte 2 migration examples

### DIFF
--- a/v2/user-guide/build-apps/fastapi/ml_model_serving.py
+++ b/v2/user-guide/build-apps/fastapi/ml_model_serving.py
@@ -80,7 +80,7 @@ env = FastAPIAppEnvironment(
     parameters=[
         flyte.app.Parameter(
             name="model_file",
-            value=flyte.io.File("s3://bucket/models/model.joblib"),
+            value=flyte.io.File.from_existing_remote("s3://bucket/models/model.joblib"),
             mount="/app/models",
             env_var="MODEL_PATH",
         ),

--- a/v2/user-guide/migration/flyte-2/batch_inference_v1.py
+++ b/v2/user-guide/migration/flyte-2/batch_inference_v1.py
@@ -1,0 +1,40 @@
+import os
+from functools import partial
+
+import joblib
+from flytekit import task, workflow, map_task, ImageSpec, current_context
+from flytekit.types.file import FlyteFile
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+
+image = ImageSpec(name="inference-image", packages=["scikit-learn", "joblib"])
+
+
+@task(container_image=image)
+def train_model() -> FlyteFile:
+    data = load_iris()
+    model = RandomForestClassifier().fit(data.data, data.target)
+    model_path = os.path.join(current_context().working_directory, "model.joblib")
+    joblib.dump(model, model_path)
+    return FlyteFile(path=model_path)
+
+
+@task(container_image=image)
+def get_batches() -> list[list[list[float]]]:
+    data = load_iris()
+    rows = data.data.tolist()
+    # Split the rows into batches of 30.
+    return [rows[i : i + 30] for i in range(0, len(rows), 30)]
+
+
+@task(container_image=image)
+def score_batch(model_file: FlyteFile, batch: list[list[float]]) -> list[int]:
+    model = joblib.load(model_file.download())
+    return [int(p) for p in model.predict(batch)]
+
+
+@workflow
+def main() -> list[list[int]]:
+    model = train_model()
+    batches = get_batches()
+    return map_task(partial(score_batch, model_file=model))(batch=batches)

--- a/v2/user-guide/migration/flyte-2/batch_inference_v2.py
+++ b/v2/user-guide/migration/flyte-2/batch_inference_v2.py
@@ -1,0 +1,60 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "scikit-learn",
+#    "joblib",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import asyncio
+import os
+
+import joblib
+import flyte
+from flyte.io import File
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+
+env = flyte.TaskEnvironment(
+    name="batch_inference",
+    image=flyte.Image.from_debian_base().with_pip_packages("scikit-learn", "joblib"),
+)
+
+
+@env.task
+async def train_model() -> File:
+    data = load_iris()
+    model = RandomForestClassifier().fit(data.data, data.target)
+    model_path = os.path.join(os.getcwd(), "model.joblib")
+    joblib.dump(model, model_path)
+    return await File.from_local(model_path)
+
+
+@env.task
+async def score_batch(model_file: File, batch: list[list[float]]) -> list[int]:
+    local_path = await model_file.download()
+    model = joblib.load(local_path)
+    return [int(p) for p in model.predict(batch)]
+
+
+@env.task
+async def main() -> list[list[int]]:
+    model = await train_model()
+    rows = load_iris().data.tolist()
+    batches = [rows[i : i + 30] for i in range(0, len(rows), 30)]
+    # Score every batch in parallel, reusing the same model reference.
+    coros = [score_batch(model, batch) for batch in batches]
+    return list(await asyncio.gather(*coros))
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/chained_tasks_v1.py
+++ b/v2/user-guide/migration/flyte-2/chained_tasks_v1.py
@@ -2,23 +2,29 @@ from flytekit import task, workflow
 
 
 @task
-def download_dataset() -> str:
-    return "s3://datasets/train.parquet"
+def clear_staging_table() -> None:
+    # Side effect only: truncate the staging table.
+    print("cleared staging table")
 
 
 @task
-def validate_dataset(uri: str) -> str:
-    # e.g. check schema and row counts
-    return f"validated {uri}"
+def load_into_staging() -> None:
+    # Side effect only: load fresh rows into staging.
+    print("loaded staging table")
 
 
 @task
-def register_dataset(uri: str) -> str:
-    return f"registered {uri}"
+def publish_to_prod() -> None:
+    # Side effect only: swap staging into the production table.
+    print("published to prod")
 
 
 @workflow
-def main() -> str:
-    uri = download_dataset()
-    validated = validate_dataset(uri=uri)
-    return register_dataset(uri=validated)
+def main() -> None:
+    clear = clear_staging_table()
+    load = load_into_staging()
+    publish = publish_to_prod()
+
+    # These tasks pass no data between them, so use the >> operator to force
+    # ordering: clear must finish before load, which must finish before publish.
+    clear >> load >> publish

--- a/v2/user-guide/migration/flyte-2/chained_tasks_v1.py
+++ b/v2/user-guide/migration/flyte-2/chained_tasks_v1.py
@@ -1,0 +1,24 @@
+from flytekit import task, workflow
+
+
+@task
+def download_dataset() -> str:
+    return "s3://datasets/train.parquet"
+
+
+@task
+def validate_dataset(uri: str) -> str:
+    # e.g. check schema and row counts
+    return f"validated {uri}"
+
+
+@task
+def register_dataset(uri: str) -> str:
+    return f"registered {uri}"
+
+
+@workflow
+def main() -> str:
+    uri = download_dataset()
+    validated = validate_dataset(uri=uri)
+    return register_dataset(uri=validated)

--- a/v2/user-guide/migration/flyte-2/chained_tasks_v2.py
+++ b/v2/user-guide/migration/flyte-2/chained_tasks_v2.py
@@ -10,32 +10,31 @@
 # {{docs-fragment all}}
 import flyte
 
-env = flyte.TaskEnvironment(name="dataset_lifecycle")
+env = flyte.TaskEnvironment(name="staging_publish")
 
 
 @env.task
-def download_dataset() -> str:
-    return "s3://datasets/train.parquet"
+def clear_staging_table() -> None:
+    print("cleared staging table")
 
 
 @env.task
-def validate_dataset(uri: str) -> str:
-    # e.g. check schema and row counts
-    return f"validated {uri}"
+def load_into_staging() -> None:
+    print("loaded staging table")
 
 
 @env.task
-def register_dataset(uri: str) -> str:
-    return f"registered {uri}"
+def publish_to_prod() -> None:
+    print("published to prod")
 
 
-# Sequential calls are naturally ordered: each line runs after the previous one
-# returns. The Flyte 1 `>>` ordering operator is gone.
+# Sequential (synchronous) calls run in the order they're written, even when no
+# data flows between them. The Flyte 1 `>>` ordering operator is gone.
 @env.task
-def main() -> str:
-    uri = download_dataset()
-    validated = validate_dataset(uri)
-    return register_dataset(validated)
+def main() -> None:
+    clear_staging_table()
+    load_into_staging()
+    publish_to_prod()
 # {{/docs-fragment all}}
 
 

--- a/v2/user-guide/migration/flyte-2/chained_tasks_v2.py
+++ b/v2/user-guide/migration/flyte-2/chained_tasks_v2.py
@@ -1,0 +1,47 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="dataset_lifecycle")
+
+
+@env.task
+def download_dataset() -> str:
+    return "s3://datasets/train.parquet"
+
+
+@env.task
+def validate_dataset(uri: str) -> str:
+    # e.g. check schema and row counts
+    return f"validated {uri}"
+
+
+@env.task
+def register_dataset(uri: str) -> str:
+    return f"registered {uri}"
+
+
+# Sequential calls are naturally ordered: each line runs after the previous one
+# returns. The Flyte 1 `>>` ordering operator is gone.
+@env.task
+def main() -> str:
+    uri = download_dataset()
+    validated = validate_dataset(uri)
+    return register_dataset(validated)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/conditional_v1.py
+++ b/v2/user-guide/migration/flyte-2/conditional_v1.py
@@ -1,0 +1,23 @@
+from flytekit import task, workflow, conditional
+
+
+@task
+def train_gradient_boosting(n_rows: int) -> str:
+    return f"trained gradient boosting on {n_rows} rows"
+
+
+@task
+def train_logistic_regression(n_rows: int) -> str:
+    return f"trained logistic regression on {n_rows} rows"
+
+
+@workflow
+def main(n_rows: int) -> str:
+    # Pick the model based on dataset size.
+    return (
+        conditional("model_choice")
+        .if_(n_rows > 10_000)
+        .then(train_gradient_boosting(n_rows=n_rows))
+        .else_()
+        .then(train_logistic_regression(n_rows=n_rows))
+    )

--- a/v2/user-guide/migration/flyte-2/conditional_v2.py
+++ b/v2/user-guide/migration/flyte-2/conditional_v2.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "n_rows=50000"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="conditional")
+
+
+@env.task
+def train_gradient_boosting(n_rows: int) -> str:
+    return f"trained gradient boosting on {n_rows} rows"
+
+
+@env.task
+def train_logistic_regression(n_rows: int) -> str:
+    return f"trained logistic regression on {n_rows} rows"
+
+
+# Branching is now ordinary Python control flow -- no conditional() DSL.
+@env.task
+def main(n_rows: int) -> str:
+    if n_rows > 10_000:
+        return train_gradient_boosting(n_rows)
+    return train_logistic_regression(n_rows)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, n_rows=50000)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/data_backfill_v1.py
+++ b/v2/user-guide/migration/flyte-2/data_backfill_v1.py
@@ -1,0 +1,25 @@
+from datetime import date, timedelta
+
+from flytekit import task, workflow, dynamic
+
+
+@task
+def process_day(day: str) -> int:
+    # Reprocess a single day's partition; return the row count.
+    return len(day)
+
+
+# @dynamic is needed because the number of days is only known at runtime.
+@dynamic
+def backfill(start: str, days: int) -> list[int]:
+    base = date.fromisoformat(start)
+    results = []
+    for i in range(days):
+        day = (base + timedelta(days=i)).isoformat()
+        results.append(process_day(day=day))
+    return results
+
+
+@workflow
+def main(start: str, days: int) -> list[int]:
+    return backfill(start=start, days=days)

--- a/v2/user-guide/migration/flyte-2/data_backfill_v2.py
+++ b/v2/user-guide/migration/flyte-2/data_backfill_v2.py
@@ -1,0 +1,43 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "start=2024-01-01 days=3"
+# ///
+
+# {{docs-fragment all}}
+import asyncio
+from datetime import date, timedelta
+
+import flyte
+
+env = flyte.TaskEnvironment(name="data_backfill")
+
+
+@env.task
+async def process_day(day: str) -> int:
+    # Reprocess a single day's partition; return the row count.
+    return len(day)
+
+
+# A plain task builds the date range at runtime and fans the days out in
+# parallel with asyncio.gather -- no @dynamic and no map_task needed.
+@env.task
+async def main(start: str, days: int) -> list[int]:
+    base = date.fromisoformat(start)
+    coros = [
+        process_day((base + timedelta(days=i)).isoformat())
+        for i in range(days)
+    ]
+    return list(await asyncio.gather(*coros))
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, start="2024-01-01", days=3)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/data_etl_v1.py
+++ b/v2/user-guide/migration/flyte-2/data_etl_v1.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from flytekit import task, workflow
+from flytekit.types.structured import StructuredDataset
+
+
+@task
+def extract() -> pd.DataFrame:
+    # Read raw transaction records (stand-in for a real source).
+    return pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 3, 3, 3],
+            "amount": [10.0, 5.0, 20.0, 7.5, 2.5, 1.0],
+        }
+    )
+
+
+@task
+def transform(df: pd.DataFrame) -> StructuredDataset:
+    # Clean and aggregate into a per-user feature table.
+    df = df[df["amount"] > 0]
+    agg = df.groupby("user_id", as_index=False)["amount"].sum()
+    return StructuredDataset(dataframe=agg)
+
+
+@task
+def load(sd: StructuredDataset) -> int:
+    df = sd.open(pd.DataFrame).all()
+    return len(df)
+
+
+@workflow
+def main() -> int:
+    raw = extract()
+    features = transform(df=raw)
+    return load(sd=features)

--- a/v2/user-guide/migration/flyte-2/data_etl_v2.py
+++ b/v2/user-guide/migration/flyte-2/data_etl_v2.py
@@ -1,0 +1,62 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "pandas",
+#    "pyarrow",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import pandas as pd
+import flyte
+import flyte.io
+
+env = flyte.TaskEnvironment(
+    name="data_etl",
+    image=flyte.Image.from_debian_base().with_pip_packages("pandas", "pyarrow"),
+)
+
+
+@env.task
+async def extract() -> pd.DataFrame:
+    # Read raw transaction records (stand-in for a real source).
+    return pd.DataFrame(
+        {
+            "user_id": [1, 1, 2, 3, 3, 3],
+            "amount": [10.0, 5.0, 20.0, 7.5, 2.5, 1.0],
+        }
+    )
+
+
+@env.task
+async def transform(df: pd.DataFrame) -> flyte.io.DataFrame:
+    # Clean and aggregate into a per-user feature table.
+    df = df[df["amount"] > 0]
+    agg = df.groupby("user_id", as_index=False)["amount"].sum()
+    # StructuredDataset becomes flyte.io.DataFrame.
+    return flyte.io.DataFrame.from_df(agg)
+
+
+@env.task
+async def load(sd: flyte.io.DataFrame) -> int:
+    df = await sd.open(pd.DataFrame).all()
+    return len(df)
+
+
+@env.task
+async def main() -> int:
+    raw = await extract()
+    features = await transform(raw)
+    return await load(features)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/dataclasses_v1.py
+++ b/v2/user-guide/migration/flyte-2/dataclasses_v1.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+from flytekit import task, workflow
+
+
+@dataclass_json
+@dataclass
+class TrainingConfig:
+    learning_rate: float
+    n_estimators: int
+    max_depth: int = 6
+
+
+@task
+def make_config(learning_rate: float, n_estimators: int) -> TrainingConfig:
+    return TrainingConfig(learning_rate=learning_rate, n_estimators=n_estimators)
+
+
+@task
+def train(config: TrainingConfig) -> str:
+    return (
+        f"trained with lr={config.learning_rate}, "
+        f"n_estimators={config.n_estimators}, max_depth={config.max_depth}"
+    )
+
+
+@workflow
+def main(learning_rate: float, n_estimators: int) -> str:
+    config = make_config(learning_rate=learning_rate, n_estimators=n_estimators)
+    return train(config=config)

--- a/v2/user-guide/migration/flyte-2/dataclasses_v2.py
+++ b/v2/user-guide/migration/flyte-2/dataclasses_v2.py
@@ -1,0 +1,52 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "learning_rate=0.1 n_estimators=100"
+# ///
+
+# {{docs-fragment all}}
+from dataclasses import dataclass
+
+import flyte
+
+env = flyte.TaskEnvironment(name="dataclasses")
+
+
+# Plain dataclasses work directly as task I/O -- no @dataclass_json mixin needed.
+# Pydantic BaseModels work the same way.
+@dataclass
+class TrainingConfig:
+    learning_rate: float
+    n_estimators: int
+    max_depth: int = 6
+
+
+@env.task
+def make_config(learning_rate: float, n_estimators: int) -> TrainingConfig:
+    return TrainingConfig(learning_rate=learning_rate, n_estimators=n_estimators)
+
+
+@env.task
+def train(config: TrainingConfig) -> str:
+    return (
+        f"trained with lr={config.learning_rate}, "
+        f"n_estimators={config.n_estimators}, max_depth={config.max_depth}"
+    )
+
+
+@env.task
+def main(learning_rate: float, n_estimators: int) -> str:
+    config = make_config(learning_rate, n_estimators)
+    return train(config)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, learning_rate=0.1, n_estimators=100)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/dataframe_v1.py
+++ b/v2/user-guide/migration/flyte-2/dataframe_v1.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from flytekit import task, workflow
+from flytekit.types.structured import StructuredDataset
+
+
+@task
+def make_df() -> StructuredDataset:
+    df = pd.DataFrame({"employee_id": [1, 2, 3], "salary": [50000, 60000, 70000]})
+    return StructuredDataset(dataframe=df)
+
+
+@task
+def total_payroll(sd: StructuredDataset) -> float:
+    df = sd.open(pd.DataFrame).all()
+    return float(df["salary"].sum())
+
+
+@workflow
+def main() -> float:
+    return total_payroll(sd=make_df())

--- a/v2/user-guide/migration/flyte-2/dataframe_v2.py
+++ b/v2/user-guide/migration/flyte-2/dataframe_v2.py
@@ -1,0 +1,47 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "pandas",
+#    "pyarrow",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import pandas as pd
+import flyte
+import flyte.io
+
+env = flyte.TaskEnvironment(
+    name="dataframe",
+    image=flyte.Image.from_debian_base().with_pip_packages("pandas", "pyarrow"),
+)
+
+
+@env.task
+async def make_df() -> flyte.io.DataFrame:
+    df = pd.DataFrame({"employee_id": [1, 2, 3], "salary": [50000, 60000, 70000]})
+    # StructuredDataset becomes flyte.io.DataFrame.
+    return flyte.io.DataFrame.from_df(df)
+
+
+@env.task
+async def total_payroll(sd: flyte.io.DataFrame) -> float:
+    df = await sd.open(pd.DataFrame).all()
+    return float(df["salary"].sum())
+
+
+@env.task
+async def main() -> float:
+    return await total_payroll(await make_df())
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/dataframe_v2.py
+++ b/v2/user-guide/migration/flyte-2/dataframe_v2.py
@@ -28,8 +28,8 @@ async def make_df() -> flyte.io.DataFrame:
 
 
 @env.task
-async def total_payroll(sd: flyte.io.DataFrame) -> float:
-    df = await sd.open(pd.DataFrame).all()
+async def total_payroll(fdf: flyte.io.DataFrame) -> float:
+    df = await fdf.open(pd.DataFrame).all()
     return float(df["salary"].sum())
 
 

--- a/v2/user-guide/migration/flyte-2/dynamic_v1.py
+++ b/v2/user-guide/migration/flyte-2/dynamic_v1.py
@@ -1,0 +1,26 @@
+from flytekit import task, workflow, dynamic
+
+
+@task
+def list_partitions(n: int) -> list[int]:
+    return list(range(n))
+
+
+@task
+def process_partition(partition_id: int) -> int:
+    # Aggregate one data partition.
+    return partition_id * 2
+
+
+@dynamic
+def process_all(partitions: list[int]) -> list[int]:
+    results = []
+    for partition_id in partitions:
+        results.append(process_partition(partition_id=partition_id))
+    return results
+
+
+@workflow
+def main(n: int) -> list[int]:
+    partitions = list_partitions(n=n)
+    return process_all(partitions=partitions)

--- a/v2/user-guide/migration/flyte-2/dynamic_v2.py
+++ b/v2/user-guide/migration/flyte-2/dynamic_v2.py
@@ -1,0 +1,35 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "n=5"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="dynamic")
+
+
+@env.task
+def process_partition(partition_id: int) -> int:
+    # Aggregate one data partition.
+    return partition_id * 2
+
+
+# No @dynamic decorator needed: a plain task can loop over runtime data (e.g. a
+# variable number of partitions discovered at runtime) and call other tasks.
+@env.task
+def main(n: int) -> list[int]:
+    return [process_partition(partition_id) for partition_id in range(n)]
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, n=5)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/error_handling_v1.py
+++ b/v2/user-guide/migration/flyte-2/error_handling_v1.py
@@ -1,0 +1,21 @@
+from flytekit import task, workflow
+
+
+@task
+def train_fold(max_depth: int) -> float:
+    if max_depth <= 0:
+        raise ValueError("max_depth must be positive")
+    # Return validation accuracy for this hyperparameter.
+    return 0.90 + 0.001 * max_depth
+
+
+@task
+def notify_failure() -> None:
+    print("training run failed -- sending alert")
+
+
+# The on_failure handler runs if any node in the workflow fails. There is no
+# try/except inside a Flyte 1 workflow.
+@workflow(on_failure=notify_failure)
+def main(max_depth: int) -> float:
+    return train_fold(max_depth=max_depth)

--- a/v2/user-guide/migration/flyte-2/error_handling_v2.py
+++ b/v2/user-guide/migration/flyte-2/error_handling_v2.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "max_depth=0"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="error_handling")
+
+
+@env.task
+async def train_fold(max_depth: int) -> float:
+    if max_depth <= 0:
+        raise ValueError("max_depth must be positive")
+    return 0.90 + 0.001 * max_depth
+
+
+# Failure handling is ordinary Python try/except -- no on_failure handler.
+@env.task
+async def main(max_depth: int) -> float:
+    try:
+        return await train_fold(max_depth)
+    except ValueError as e:
+        print(f"invalid hyperparameter ({e}); falling back to a safe default")
+        # Recover with a safe default instead of failing the whole run.
+        return await train_fold(max_depth=6)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, max_depth=0)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/files_v1.py
+++ b/v2/user-guide/migration/flyte-2/files_v1.py
@@ -1,0 +1,24 @@
+import os
+
+from flytekit import task, workflow, current_context
+from flytekit.types.file import FlyteFile
+
+
+@task
+def write_file(content: str) -> FlyteFile:
+    path = os.path.join(current_context().working_directory, "out.txt")
+    with open(path, "w") as f:
+        f.write(content)
+    return FlyteFile(path=path)
+
+
+@task
+def read_file(f: FlyteFile) -> str:
+    with open(f.download()) as fh:
+        return fh.read()
+
+
+@workflow
+def main(content: str) -> str:
+    f = write_file(content=content)
+    return read_file(f=f)

--- a/v2/user-guide/migration/flyte-2/files_v2.py
+++ b/v2/user-guide/migration/flyte-2/files_v2.py
@@ -1,0 +1,44 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "content=hello"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+from flyte.io import File
+
+env = flyte.TaskEnvironment(name="files")
+
+
+@env.task
+async def write_file(content: str) -> File:
+    with open("out.txt", "w") as f:
+        f.write(content)
+    # File.from_local uploads the file to blob storage and returns a reference
+    # (a lightweight pointer, not the materialized bytes).
+    return await File.from_local("out.txt")
+
+
+@env.task
+async def read_file(f: File) -> str:
+    async with f.open("rb") as fh:
+        return (await fh.read()).decode("utf-8")
+
+
+@env.task
+async def main(content: str) -> str:
+    f = await write_file(content)
+    return await read_file(f)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, content="hello")
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/hello_world_v1.py
+++ b/v2/user-guide/migration/flyte-2/hello_world_v1.py
@@ -1,0 +1,17 @@
+import flytekit
+
+
+@flytekit.task
+def say_hello(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@flytekit.task
+def to_upper(greeting: str) -> str:
+    return greeting.upper()
+
+
+@flytekit.workflow
+def main(name: str) -> str:
+    greeting = say_hello(name=name)
+    return to_upper(greeting=greeting)

--- a/v2/user-guide/migration/flyte-2/hello_world_v2.py
+++ b/v2/user-guide/migration/flyte-2/hello_world_v2.py
@@ -1,0 +1,39 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "name=World"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="hello_world")
+
+
+@env.task
+def say_hello(name: str) -> str:
+    return f"Hello, {name}!"
+
+
+@env.task
+def to_upper(greeting: str) -> str:
+    return greeting.upper()
+
+
+# The "workflow" is now just a task that calls other tasks.
+@env.task
+def main(name: str) -> str:
+    greeting = say_hello(name)
+    return to_upper(greeting)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, name="World")
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/hpo_v1.py
+++ b/v2/user-guide/migration/flyte-2/hpo_v1.py
@@ -1,0 +1,30 @@
+from flytekit import task, workflow, map_task
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+
+@task
+def get_grid() -> list[int]:
+    return [2, 4, 8, 16]
+
+
+@task
+def train_eval(max_depth: int) -> float:
+    data = load_iris()
+    model = RandomForestClassifier(max_depth=max_depth, random_state=42)
+    scores = cross_val_score(model, data.data, data.target, cv=3)
+    return float(scores.mean())
+
+
+@task
+def best_score(scores: list[float]) -> float:
+    return max(scores)
+
+
+@workflow
+def main() -> float:
+    grid = get_grid()
+    # Fan out one training run per hyperparameter value.
+    scores = map_task(train_eval)(max_depth=grid)
+    return best_score(scores=scores)

--- a/v2/user-guide/migration/flyte-2/hpo_v2.py
+++ b/v2/user-guide/migration/flyte-2/hpo_v2.py
@@ -1,0 +1,49 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "scikit-learn",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import asyncio
+
+import flyte
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+env = flyte.TaskEnvironment(
+    name="hpo",
+    image=flyte.Image.from_debian_base().with_pip_packages("scikit-learn"),
+)
+
+
+@env.task
+async def train_eval(max_depth: int) -> float:
+    data = load_iris()
+    model = RandomForestClassifier(max_depth=max_depth, random_state=42)
+    scores = cross_val_score(model, data.data, data.target, cv=3)
+    return float(scores.mean())
+
+
+@env.task
+async def main() -> dict:
+    grid = [2, 4, 8, 16]
+    # Fan out one training run per hyperparameter value...
+    scores = await asyncio.gather(*[train_eval(d) for d in grid])
+    # ...then pick the best in plain Python (impossible in a Flyte 1 workflow).
+    best_idx = max(range(len(scores)), key=lambda i: scores[i])
+    return {"best_max_depth": grid[best_idx], "best_score": scores[best_idx]}
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/map_task_v1.py
+++ b/v2/user-guide/migration/flyte-2/map_task_v1.py
@@ -1,0 +1,23 @@
+from functools import partial
+
+from flytekit import task, workflow, map_task
+
+
+@task
+def get_shards(n: int) -> list[int]:
+    return list(range(n))
+
+
+@task
+def score_shard(shard_id: int, model_version: int) -> int:
+    # Score one shard of records with the given model version.
+    return shard_id * model_version
+
+
+@workflow
+def main(n: int, model_version: int) -> list[int]:
+    shards = get_shards(n=n)
+    return map_task(
+        partial(score_shard, model_version=model_version),
+        concurrency=10,
+    )(shard_id=shards)

--- a/v2/user-guide/migration/flyte-2/map_task_v2.py
+++ b/v2/user-guide/migration/flyte-2/map_task_v2.py
@@ -1,0 +1,52 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "n=5 model_version=3"
+# ///
+import asyncio
+from functools import partial
+
+import flyte
+
+env = flyte.TaskEnvironment(name="batch_scoring")
+
+
+# {{docs-fragment sync}}
+@env.task
+def score_shard(shard_id: int, model_version: int) -> int:
+    # Score one shard of records with the given model version.
+    return shard_id * model_version
+
+
+@env.task
+def main(n: int, model_version: int) -> list[int]:
+    bound = partial(score_shard, model_version=model_version)
+    # flyte.map is a drop-in for map_task, but it returns a generator, so wrap
+    # it in list() to materialize the results.
+    return list(flyte.map(bound, range(n), concurrency=10))
+# {{/docs-fragment sync}}
+
+
+# {{docs-fragment async}}
+@env.task
+async def score_shard_async(shard_id: int, model_version: int) -> int:
+    return shard_id * model_version
+
+
+@env.task
+async def main_async(n: int, model_version: int) -> list[int]:
+    # asyncio.gather is the idiomatic Flyte 2 way to fan out.
+    coros = [score_shard_async(i, model_version) for i in range(n)]
+    return list(await asyncio.gather(*coros))
+# {{/docs-fragment async}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, n=5, model_version=3)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/ml_pipeline_v1.py
+++ b/v2/user-guide/migration/flyte-2/ml_pipeline_v1.py
@@ -1,0 +1,53 @@
+import os
+
+import joblib
+import pandas as pd
+from flytekit import task, workflow, ImageSpec, Resources, current_context
+from flytekit.types.file import FlyteFile
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+
+image = ImageSpec(
+    name="ml-image",
+    packages=["pandas", "scikit-learn", "joblib"],
+)
+
+
+@task(
+    container_image=image,
+    requests=Resources(cpu="2", mem="4Gi"),
+    cache=True,
+    cache_version="1.0",
+)
+def load_data() -> pd.DataFrame:
+    data = load_iris(as_frame=True)
+    df = data.frame
+    df["species"] = data.target
+    return df
+
+
+@task(container_image=image)
+def train_model(data: pd.DataFrame) -> FlyteFile:
+    model = RandomForestClassifier()
+    X = data.drop("species", axis=1)
+    y = data["species"]
+    model.fit(X, y)
+
+    model_path = os.path.join(current_context().working_directory, "model.joblib")
+    joblib.dump(model, model_path)
+    return FlyteFile(path=model_path)
+
+
+@task(container_image=image)
+def evaluate(model_file: FlyteFile, data: pd.DataFrame) -> float:
+    model = joblib.load(model_file.download())
+    X = data.drop("species", axis=1)
+    y = data["species"]
+    return float(model.score(X, y))
+
+
+@workflow
+def main() -> float:
+    data = load_data()
+    model = train_model(data=data)
+    return evaluate(model_file=model, data=data)

--- a/v2/user-guide/migration/flyte-2/ml_pipeline_v2.py
+++ b/v2/user-guide/migration/flyte-2/ml_pipeline_v2.py
@@ -1,0 +1,77 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "pandas",
+#    "scikit-learn",
+#    "joblib",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import os
+
+import joblib
+import pandas as pd
+import flyte
+from flyte.io import File
+from sklearn.datasets import load_iris
+from sklearn.ensemble import RandomForestClassifier
+
+# Image, resources, and cache are set once on the TaskEnvironment.
+env = flyte.TaskEnvironment(
+    name="ml_pipeline",
+    image=flyte.Image.from_debian_base().with_pip_packages(
+        "pandas", "scikit-learn", "joblib"
+    ),
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
+    cache="auto",
+)
+
+
+@env.task
+async def load_data() -> pd.DataFrame:
+    data = load_iris(as_frame=True)
+    df = data.frame
+    df["species"] = data.target
+    return df
+
+
+@env.task
+async def train_model(data: pd.DataFrame) -> File:
+    model = RandomForestClassifier()
+    X = data.drop("species", axis=1)
+    y = data["species"]
+    model.fit(X, y)
+
+    model_path = os.path.join(os.getcwd(), "model.joblib")
+    joblib.dump(model, model_path)
+    return await File.from_local(model_path)
+
+
+@env.task
+async def evaluate(model_file: File, data: pd.DataFrame) -> float:
+    local_path = await model_file.download()
+    model = joblib.load(local_path)
+    X = data.drop("species", axis=1)
+    y = data["species"]
+    return float(model.score(X, y))
+
+
+# The "workflow" is just an orchestrating task.
+@env.task
+async def main() -> float:
+    data = await load_data()
+    model = await train_model(data)
+    return await evaluate(model, data)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/scheduling_v1.py
+++ b/v2/user-guide/migration/flyte-2/scheduling_v1.py
@@ -1,0 +1,22 @@
+from flytekit import task, workflow, LaunchPlan, CronSchedule
+
+
+@task
+def retrain(kickoff_time: str) -> str:
+    return f"retrained model at {kickoff_time}"
+
+
+@workflow
+def main(kickoff_time: str) -> str:
+    return retrain(kickoff_time=kickoff_time)
+
+
+# A LaunchPlan attaches a schedule (and default inputs) to a workflow.
+nightly_retrain = LaunchPlan.get_or_create(
+    workflow=main,
+    name="nightly_retrain",
+    schedule=CronSchedule(
+        schedule="0 2 * * *",  # 2 AM daily
+        kickoff_time_input_arg="kickoff_time",
+    ),
+)

--- a/v2/user-guide/migration/flyte-2/scheduling_v2.py
+++ b/v2/user-guide/migration/flyte-2/scheduling_v2.py
@@ -1,0 +1,39 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+from datetime import datetime
+
+import flyte
+
+env = flyte.TaskEnvironment(name="scheduling")
+
+# A Trigger replaces LaunchPlan + CronSchedule. It is attached directly to the
+# task and deployed with it (flyte deploy). flyte.TriggerTime binds the
+# scheduled fire time to a task input.
+nightly_retrain = flyte.Trigger(
+    name="nightly_retrain",
+    automation=flyte.Cron("0 2 * * *"),  # 2 AM daily
+    inputs={"trigger_time": flyte.TriggerTime},
+    auto_activate=True,
+)
+
+
+@env.task(triggers=nightly_retrain)
+def main(trigger_time: datetime = datetime(2024, 1, 1, 2, 0)) -> str:
+    return f"retrained model at {trigger_time.isoformat()}"
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/secrets_v1.py
+++ b/v2/user-guide/migration/flyte-2/secrets_v1.py
@@ -1,0 +1,12 @@
+from flytekit import task, workflow, Secret, current_context
+
+
+@task(secret_requests=[Secret(group="openai", key="api_key")])
+def call_api() -> str:
+    token = current_context().secrets.get(group="openai", key="api_key")
+    return f"token has {len(token)} chars"
+
+
+@workflow
+def main() -> str:
+    return call_api()

--- a/v2/user-guide/migration/flyte-2/secrets_v2.py
+++ b/v2/user-guide/migration/flyte-2/secrets_v2.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment all}}
+import os
+
+import flyte
+
+# Secrets are declared on the TaskEnvironment and injected as environment
+# variables (instead of read through current_context().secrets).
+env = flyte.TaskEnvironment(
+    name="secrets",
+    secrets=[flyte.Secret(key="openai_api_key", as_env_var="OPENAI_API_KEY")],
+)
+
+
+@env.task
+def call_api() -> str:
+    token = os.getenv("OPENAI_API_KEY", "")
+    return f"token has {len(token)} chars"
+
+
+@env.task
+def main() -> str:
+    return call_api()
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/subworkflow_v1.py
+++ b/v2/user-guide/migration/flyte-2/subworkflow_v1.py
@@ -1,0 +1,23 @@
+from flytekit import task, workflow
+
+
+@task
+def impute(value: float) -> float:
+    # Replace missing/negative sentinel values with 0.
+    return value if value >= 0 else 0.0
+
+
+@task
+def scale(value: float) -> float:
+    return value / 100.0
+
+
+@workflow
+def preprocess(value: float) -> float:
+    imputed = impute(value=value)
+    return scale(value=imputed)
+
+
+@workflow
+def main(raw_value: float) -> float:
+    return preprocess(value=raw_value)

--- a/v2/user-guide/migration/flyte-2/subworkflow_v2.py
+++ b/v2/user-guide/migration/flyte-2/subworkflow_v2.py
@@ -1,0 +1,45 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "raw_value=42.0"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+
+env = flyte.TaskEnvironment(name="subworkflow")
+
+
+@env.task
+def impute(value: float) -> float:
+    # Replace missing/negative sentinel values with 0.
+    return value if value >= 0 else 0.0
+
+
+@env.task
+def scale(value: float) -> float:
+    return value / 100.0
+
+
+# A preprocessing "subworkflow" is just a task that calls other tasks.
+@env.task
+def preprocess(value: float) -> float:
+    imputed = impute(value)
+    return scale(imputed)
+
+
+@env.task
+def main(raw_value: float) -> float:
+    return preprocess(raw_value)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, raw_value=42.0)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/task_config_v1.py
+++ b/v2/user-guide/migration/flyte-2/task_config_v1.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+import flytekit
+from flytekit import Resources
+
+image = flytekit.ImageSpec(
+    name="training-image",
+    packages=["scikit-learn", "pandas"],
+)
+
+
+@flytekit.task(
+    container_image=image,
+    requests=Resources(cpu="2", mem="4Gi"),
+    limits=Resources(cpu="4", mem="8Gi"),
+    cache=True,
+    cache_version="1.0",
+    retries=3,
+    timeout=timedelta(minutes=30),
+)
+def train_epoch(step: int) -> float:
+    # A stand-in for a training step that returns the current loss.
+    return 1.0 / (step + 1)
+
+
+@flytekit.workflow
+def main(step: int) -> float:
+    return train_epoch(step=step)

--- a/v2/user-guide/migration/flyte-2/task_config_v2.py
+++ b/v2/user-guide/migration/flyte-2/task_config_v2.py
@@ -1,0 +1,43 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "main"
+# params = "step=1"
+# ///
+
+# {{docs-fragment all}}
+from datetime import timedelta
+
+import flyte
+
+# Image, resources, and caching move to the TaskEnvironment, so they are declared
+# once and shared by every task in the environment.
+env = flyte.TaskEnvironment(
+    name="training",
+    image=flyte.Image.from_debian_base().with_pip_packages("scikit-learn", "pandas"),
+    resources=flyte.Resources(cpu="2", memory="4Gi"),  # "memory", not "mem"
+    cache="auto",
+)
+
+
+# retries and timeout stay on the task decorator.
+@env.task(retries=3, timeout=timedelta(minutes=30))
+def train_epoch(step: int) -> float:
+    # A stand-in for a training step that returns the current loss.
+    return 1.0 / (step + 1)
+
+
+@env.task
+def main(step: int) -> float:
+    return train_epoch(step)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, step=1)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/train_deep_learning_v1.py
+++ b/v2/user-guide/migration/flyte-2/train_deep_learning_v1.py
@@ -1,0 +1,37 @@
+from flytekit import task, workflow, ImageSpec, Resources
+from flytekit.extras.accelerators import T4
+import torch
+import torch.nn as nn
+
+image = ImageSpec(
+    name="dl-image",
+    packages=["torch"],
+)
+
+
+@task(
+    container_image=image,
+    requests=Resources(cpu="4", mem="16Gi", gpu="1"),
+    accelerator=T4,
+)
+def train(epochs: int) -> float:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = nn.Linear(10, 1).to(device)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+
+    X = torch.randn(128, 10, device=device)
+    y = torch.randn(128, 1, device=device)
+
+    loss = torch.tensor(0.0)
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        loss = loss_fn(model(X), y)
+        loss.backward()
+        optimizer.step()
+    return float(loss.item())
+
+
+@workflow
+def main(epochs: int) -> float:
+    return train(epochs=epochs)

--- a/v2/user-guide/migration/flyte-2/train_deep_learning_v2.py
+++ b/v2/user-guide/migration/flyte-2/train_deep_learning_v2.py
@@ -1,0 +1,55 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "torch",
+# ]
+# main = "main"
+# params = "epochs=5"
+# ///
+
+# {{docs-fragment all}}
+import flyte
+import torch
+import torch.nn as nn
+
+# GPU type and count go in a single "T4:1"-style string. For multi-node
+# distributed training, wrap the training task with the torch elastic plugin.
+env = flyte.TaskEnvironment(
+    name="train_deep_learning",
+    image=flyte.Image.from_debian_base().with_pip_packages("torch"),
+    resources=flyte.Resources(cpu="4", memory="16Gi", gpu="T4:1"),
+)
+
+
+@env.task
+async def train(epochs: int) -> float:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = nn.Linear(10, 1).to(device)
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    loss_fn = nn.MSELoss()
+
+    X = torch.randn(128, 10, device=device)
+    y = torch.randn(128, 1, device=device)
+
+    loss = torch.tensor(0.0)
+    for _ in range(epochs):
+        optimizer.zero_grad()
+        loss = loss_fn(model(X), y)
+        loss.backward()
+        optimizer.step()
+    return float(loss.item())
+
+
+@env.task
+async def main(epochs: int) -> float:
+    return await train(epochs)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, epochs=5)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/migration/flyte-2/train_xgboost_v1.py
+++ b/v2/user-guide/migration/flyte-2/train_xgboost_v1.py
@@ -1,0 +1,39 @@
+import os
+
+import joblib
+from flytekit import task, workflow, ImageSpec, Resources, current_context
+from flytekit.types.file import FlyteFile
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+image = ImageSpec(
+    name="xgb-image",
+    packages=["xgboost", "scikit-learn", "joblib"],
+)
+
+
+@task(container_image=image, requests=Resources(cpu="2", mem="4Gi"))
+def train_model(n_estimators: int, max_depth: int) -> FlyteFile:
+    data = load_breast_cancer()
+    X_train, _, y_train, _ = train_test_split(data.data, data.target, random_state=42)
+    model = XGBClassifier(n_estimators=n_estimators, max_depth=max_depth)
+    model.fit(X_train, y_train)
+
+    model_path = os.path.join(current_context().working_directory, "model.json")
+    joblib.dump(model, model_path)
+    return FlyteFile(path=model_path)
+
+
+@task(container_image=image)
+def evaluate(model_file: FlyteFile) -> float:
+    model = joblib.load(model_file.download())
+    data = load_breast_cancer()
+    _, X_test, _, y_test = train_test_split(data.data, data.target, random_state=42)
+    return float(model.score(X_test, y_test))
+
+
+@workflow
+def main(n_estimators: int, max_depth: int) -> float:
+    model = train_model(n_estimators=n_estimators, max_depth=max_depth)
+    return evaluate(model_file=model)

--- a/v2/user-guide/migration/flyte-2/train_xgboost_v2.py
+++ b/v2/user-guide/migration/flyte-2/train_xgboost_v2.py
@@ -1,0 +1,65 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+#    "xgboost",
+#    "scikit-learn",
+#    "joblib",
+# ]
+# main = "main"
+# params = "n_estimators=50 max_depth=3"
+# ///
+
+# {{docs-fragment all}}
+import os
+
+import joblib
+import flyte
+from flyte.io import File
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+env = flyte.TaskEnvironment(
+    name="train_xgboost",
+    image=flyte.Image.from_debian_base().with_pip_packages(
+        "xgboost", "scikit-learn", "joblib"
+    ),
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
+)
+
+
+@env.task
+async def train_model(n_estimators: int, max_depth: int) -> File:
+    data = load_breast_cancer()
+    X_train, _, y_train, _ = train_test_split(data.data, data.target, random_state=42)
+    model = XGBClassifier(n_estimators=n_estimators, max_depth=max_depth)
+    model.fit(X_train, y_train)
+
+    model_path = os.path.join(os.getcwd(), "model.json")
+    joblib.dump(model, model_path)
+    return await File.from_local(model_path)
+
+
+@env.task
+async def evaluate(model_file: File) -> float:
+    local_path = await model_file.download()
+    model = joblib.load(local_path)
+    data = load_breast_cancer()
+    _, X_test, _, y_test = train_test_split(data.data, data.target, random_state=42)
+    return float(model.score(X_test, y_test))
+
+
+@env.task
+async def main(n_estimators: int, max_depth: int) -> float:
+    model = await train_model(n_estimators, max_depth)
+    return await evaluate(model)
+# {{/docs-fragment all}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    r = flyte.run(main, n_estimators=50, max_depth=3)
+    print(r.name)
+    print(r.url)
+    r.wait()

--- a/v2/user-guide/sandboxing/code_sandbox.py
+++ b/v2/user-guide/sandboxing/code_sandbox.py
@@ -6,6 +6,7 @@ import flyte.sandbox
 from flyte.io import File
 from flyte.sandbox import sandbox_environment
 
+# {{docs-fragment create}}
 # sandbox_environment provides the base runtime for code sandboxes.
 # Include it in depends_on so the sandbox runtime is available when tasks execute.
 env = flyte.TaskEnvironment(
@@ -14,13 +15,15 @@ env = flyte.TaskEnvironment(
     depends_on=[sandbox_environment],
 )
 
-# Auto-IO mode: pure computation
+# Auto-IO mode: pure computation. The code string runs in an isolated sandbox;
+# only the declared inputs go in and only the declared outputs come back.
 sum_sandbox = flyte.sandbox.create(
     name="sum-to-n",
     code="total = sum(range(n + 1)) if conditional else 0",
     inputs={"n": int, "conditional": bool},
     outputs={"total": int},
 )
+# {{/docs-fragment create}}
 
 # Auto-IO mode with packages
 _stats_code = """\


### PR DESCRIPTION
## Summary

Adds side-by-side **Flyte 1 → Flyte 2 migration examples** referenced by the migration user guide in `unionai-docs` (`content/user-guide/migration/flyte-2/migration.md`).

New directory: `v2/user-guide/migration/flyte-2/` with **20 workload patterns** as `{pattern}_v1.py` / `{pattern}_v2.py` pairs (40 files):

- **Core patterns:** `hello_world`, `task_config`, `chained_tasks`, `subworkflow`, `conditional`, `dynamic`, `map_task`, `error_handling`, `dataclasses`, `files`, `dataframe`, `secrets`, `scheduling`
- **Data & ML workloads:** `data_etl`, `data_backfill`, `train_xgboost`, `hpo`, `train_deep_learning`, `batch_inference`, `ml_pipeline`

The `_v1.py` files are display-only `flytekit` snippets; the `_v2.py` files use the PEP 723 script header + `docs-fragment` markers and are written to run under `flyte run --local` (small/synthetic data, `os.getenv` for secrets, error paths that recover).

Also adds a `docs-fragment` marker to `v2/user-guide/sandboxing/code_sandbox.py` so the migration doc's "new in Flyte 2" feature-discovery section can embed a concise sandbox snippet.

## Notes

- Examples are grounded in existing repo patterns (`flyte.io.File`/`DataFrame`, `flyte.errors`, `flyte.Trigger`, `asyncio.gather`, etc.).
- The deep-learning (`torch`) and XGBoost examples pull heavier deps; training is kept tiny so `flyte run --local` stays fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)