### PR TITLE
add domain to app

### DIFF
--- a/v2/tutorials/auto_train/app.py
+++ b/v2/tutorials/auto_train/app.py
@@ -29,6 +29,7 @@ from starlette import status
 
 import flyte
 import flyte.remote
+from flyte.app import Domain
 from flyte.app.extras import FastAPIAppEnvironment
 from flyte.models import ActionPhase
 
@@ -136,6 +137,33 @@ _SUBMIT_ERRORS: dict[str, str] = {}
 # App environment
 # ---------------------------------------------------------------------------
 
+# The Union-hosted demo cluster.
+_HOSTED_ENDPOINT_MARKER = "demo.hosted"
+
+
+def _app_domain() -> Optional[Domain]:
+    """Subdomain policy for the deployed app.
+
+    Default: None — the platform assigns a generated hostname. On the
+    Union-hosted demo cluster (demo.hosted) we pin a stable, human-friendly
+    hostname ``autotrain-<flyte-domain>`` (e.g. ``autotrain-production``) so
+    the URL is predictable across redeploys.
+
+    Resolved from the flyte config that ``flyte serve`` initializes before
+    importing this module. When flyte isn't initialized yet (e.g. the local
+    ``python app.py`` dev server) there's no cluster to pin to, so this
+    returns None.
+    """
+    from flyte._initialize import _get_init_config
+
+    cfg = _get_init_config()
+    if cfg is None or cfg.client is None or cfg.domain is None:
+        return None
+    if _HOSTED_ENDPOINT_MARKER in (cfg.client.endpoint or ""):
+        return Domain(subdomain=f"autotrain-{cfg.domain}")
+    return None
+
+
 automl_webapp = FastAPIAppEnvironment(
     name="automl-webapp",
     app=app,
@@ -143,6 +171,7 @@ automl_webapp = FastAPIAppEnvironment(
     resources=flyte.Resources(cpu="1", memory="2Gi"),
     port=8080,
     requires_auth=False,
+    domain=_app_domain(),
     env_vars=({"WEBHOOK_API_KEY": WEBHOOK_API_KEY} if WEBHOOK_API_KEY else {}),
 )
 


### PR DESCRIPTION
<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes

<!-- Briefly describe the example/tutorial added or updated, and the docs page it
     supports (if any). -->

## Checklist

- [ ] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [ ] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
