### PR TITLE
docs: link You.com key signup from the agent tutorial setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To run the cloud tests from your local machine you need to set the environment v
 
 ### API Key Secrets for Examples
 
-Some examples require additional API keys (e.g., OpenAI, Tavily, Together.ai, and Finnhub). These can be created as Flyte secrets referenced in the example scripts.
+Some examples require additional API keys (e.g., OpenAI, Tavily, Together.ai, and Finnhub). The You.com agent tutorials under `v2/tutorials/` need a [You.com API key](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) (new accounts start with free credits, no credit card required) and an [Anthropic API key](https://console.anthropic.com/settings/keys). These can be created as Flyte secrets referenced in the example scripts.
 
 The script `test/create_secrets.sh` can be used to create these secrets in the Flyte backend that is used for testing environment. Make sure to set the corresponding environment variables before running the script.
 

--- a/v2/tutorials/competitive_intelligence_agent/README.md
+++ b/v2/tutorials/competitive_intelligence_agent/README.md
@@ -52,6 +52,17 @@ agent feeds those into an LLM that emits structured, source-cited deltas.
 | `youdotcom-api-key` | `YDC_API_KEY` | You.com Search API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
+Get a You.com API key at
+[you.com/platform](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) —
+new accounts start with free credits, no credit card required — and an Anthropic
+API key at [console.anthropic.com](https://console.anthropic.com/settings/keys).
+Then create both as Flyte secrets:
+
+```bash
+flyte create secret youdotcom-api-key
+flyte create secret internal-anthropic-api-key
+```
+
 ## Run it
 
 ```bash

--- a/v2/tutorials/compliance_monitoring_agent/README.md
+++ b/v2/tutorials/compliance_monitoring_agent/README.md
@@ -53,6 +53,17 @@ a story no SERP scraper or LLM-only stack can credibly tell.
 | `youdotcom-api-key` | `YDC_API_KEY` | You.com Research API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
+Get a You.com API key at
+[you.com/platform](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) —
+new accounts start with free credits, no credit card required — and an Anthropic
+API key at [console.anthropic.com](https://console.anthropic.com/settings/keys).
+Then create both as Flyte secrets:
+
+```bash
+flyte create secret youdotcom-api-key
+flyte create secret internal-anthropic-api-key
+```
+
 ## Run it
 
 ```bash

--- a/v2/tutorials/field_data_enrichment_agent/README.md
+++ b/v2/tutorials/field_data_enrichment_agent/README.md
@@ -49,6 +49,17 @@ information without building and maintaining a per-customer crawler.
 | `youdotcom-api-key` | `YDC_API_KEY` | You.com Search API |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
+Get a You.com API key at
+[you.com/platform](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) —
+new accounts start with free credits, no credit card required — and an Anthropic
+API key at [console.anthropic.com](https://console.anthropic.com/settings/keys).
+Then create both as Flyte secrets:
+
+```bash
+flyte create secret youdotcom-api-key
+flyte create secret internal-anthropic-api-key
+```
+
 ## Run it
 
 ```bash

--- a/v2/tutorials/financial_research_agent/README.md
+++ b/v2/tutorials/financial_research_agent/README.md
@@ -46,6 +46,17 @@ task environment. Flyte caching further cuts duplicate spend when runs converge.
 | `youdotcom-api-key` | `YDC_API_KEY` | You.com Research + Search APIs |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
+Get a You.com API key at
+[you.com/platform](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) —
+new accounts start with free credits, no credit card required — and an Anthropic
+API key at [console.anthropic.com](https://console.anthropic.com/settings/keys).
+Then create both as Flyte secrets:
+
+```bash
+flyte create secret youdotcom-api-key
+flyte create secret internal-anthropic-api-key
+```
+
 ## Run it
 
 ```bash

--- a/v2/tutorials/support_resolution_agent/README.md
+++ b/v2/tutorials/support_resolution_agent/README.md
@@ -47,6 +47,17 @@ for real-time, human-in-the-loop support flows — not just batch.
 | `youdotcom-api-key` | `YDC_API_KEY` | You.com Research + Search APIs |
 | `internal-anthropic-api-key` | `ANTHROPIC_API_KEY` | Claude via LiteLLM |
 
+Get a You.com API key at
+[you.com/platform](https://you.com/platform?utm_source=unionai-unionai-examples&utm_medium=oss_integration&utm_campaign=2026-08-oss-integrations&utm_content=readme) —
+new accounts start with free credits, no credit card required — and an Anthropic
+API key at [console.anthropic.com](https://console.anthropic.com/settings/keys).
+Then create both as Flyte secrets:
+
+```bash
+flyte create secret youdotcom-api-key
+flyte create secret internal-anthropic-api-key
+```
+
 ## Run it
 
 ```bash


### PR DESCRIPTION
## What this changes

Docs only — a tutorial-completion fix for the five You.com agent tutorials under `v2/tutorials/`.

Each of these READMEs has a `## Secrets` table naming `youdotcom-api-key` / `YDC_API_KEY`, but nothing says where to get the key. A reader who has cloned the repo and started the devbox reaches the setup step and has to leave the tutorial to go hunting — so this adds the missing step rather than any new content.

For each tutorial, a short trailer on the existing Secrets section:

- where to get the You.com key (`you.com/platform` — new accounts start with free credits, no credit card),
- where to get the Anthropic key the same tutorials require,
- the two `flyte create secret` commands that come next.

This matches the shape of `templates/tutorial/README.md`, which already closes its Secrets section with a create-secrets line, and mirrors the `flyte create secret` block in Union's own write-up of these agents. The `## Prerequisites` list in `v2/tutorials/cognee_memory_store/README.md` is the existing precedent for linking a signup page from a tutorial.

Same one-sentence addition to the root README's **API Key Secrets for Examples** section, which currently lists OpenAI/Tavily/Together.ai/Finnhub but not these two.

Tutorials touched: `competitive_intelligence_agent`, `compliance_monitoring_agent`, `field_data_enrichment_agent`, `support_resolution_agent`, `financial_research_agent`.

Disclosure: I work at You.com, so the You.com link is ours. Happy to drop the tracking parameters on it, shorten the wording, or cut the Anthropic half if you'd rather keep third-party links out of the READMEs — the part that matters to the reader is that the setup step names a destination.

Two things I noticed but deliberately left alone, as separate concerns:

- `test/create_secrets.sh` doesn't create `youdotcom-api-key` or `internal-anthropic-api-key`, so these five tutorials can't pass a cloud (`make test`) run on a fresh backend. Happy to add them in a follow-up if that's wanted.
- The tutorials call `https://ydc-index.io/v1/search`; `https://api.you.com/v1/search` is the current host. Also a follow-up, since it touches tutorial code.

## Checklist

- [x] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it). — n/a, no code changes
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct. — n/a, no code changes
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered. — n/a, README-only; no `.py` file is added or modified, so test discovery is unchanged
- [x] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged. — no file renamed or moved and no fragment markers touched; if any docs page on `docs.union.ai` renders these README bodies rather than linking to them, the added lines will surface there too, which seems desirable but flagging it
- [x] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
