### PR TITLE
add lance examples

### DIFF
--- a/v2/integrations/flyte-plugins/lance/lance_example.py
+++ b/v2/integrations/flyte-plugins/lance/lance_example.py
@@ -1,0 +1,200 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-lance",
+#    "pandas",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment setup}}
+import flyte
+
+image = flyte.Image.from_debian_base(name="lance").with_pip_packages("flyteplugins-lance")
+
+env = flyte.TaskEnvironment(
+    name="lance_env",
+    image=image,
+    resources=flyte.Resources(cpu="1", memory="2Gi"),
+)
+# {{/docs-fragment setup}}
+
+
+# {{docs-fragment stream}}
+import tempfile
+
+import lance
+import pyarrow as pa
+
+
+@env.task
+async def build_dataset(n: int = 10_000) -> lance.LanceDataset:
+    uri = f"{tempfile.mkdtemp()}/points.lance"
+    lance.write_dataset(pa.table({"id": list(range(n)), "value": [i * i for i in range(n)]}), uri)
+    return lance.dataset(uri)
+
+
+@env.task
+async def summarize(ds: lance.LanceDataset) -> dict:
+    # `ds` is a live handle. Stream it in batches; nothing is materialized whole.
+    total = 0
+    for batch in ds.scanner(columns=["value"], batch_size=1024).to_batches():
+        total += sum(batch.column("value").to_pylist())
+    return {"rows": ds.count_rows(), "sum_of_values": total}
+# {{/docs-fragment stream}}
+
+
+# {{docs-fragment projection}}
+@env.task
+async def sample_rows(ds: lance.LanceDataset) -> dict:
+    # Random access: read only these rows, only these columns.
+    rows = ds.take([0, 500, 9_999], columns=["id", "value"]).to_pylist()
+
+    # Predicate pushdown: the filter runs inside Lance, so unmatched rows are
+    # never decoded or sent over the wire.
+    matched = ds.scanner(columns=["id"], filter="value > 98000000").to_table().num_rows
+
+    return {"sample": rows, "matched": matched}
+# {{/docs-fragment projection}}
+
+
+# {{docs-fragment arrow}}
+from collections import OrderedDict
+from typing import Annotated
+
+from flyte.io import DataFrame
+
+
+@env.task
+async def build_table() -> Annotated[DataFrame, "lance"]:
+    # A bare `DataFrame` or `pa.Table` would be stored as Parquet. The "lance"
+    # annotation is what selects this plugin's encoder.
+    table = pa.table(
+        {
+            "city": ["NYC", "SF", "LA", "SEA"],
+            "temp_c": [7, 15, 20, 11],
+            "humidity": [55, 70, 40, 80],
+        }
+    )
+    return DataFrame.wrap_df(table)
+
+
+@env.task
+async def read_as_dataset(ds: lance.LanceDataset) -> int:
+    # The same stored bytes, opened lazily as a streaming handle.
+    return ds.count_rows()
+
+
+@env.task
+async def read_as_table(table: Annotated[pa.Table, OrderedDict(city=str, temp_c=int)]) -> dict:
+    # Decoded eagerly into memory, narrowed to the two annotated columns.
+    return {"columns": table.column_names, "rows": table.num_rows}
+# {{/docs-fragment arrow}}
+
+
+# {{docs-fragment interop}}
+# `to_pandas()` is a pyarrow method, but it still needs pandas installed in the
+# task image: .with_pip_packages("flyteplugins-lance", "pandas")
+
+
+@env.task
+async def as_pandas(table: pa.Table) -> int:
+    """Convert inside the task. Declaring `pd.DataFrame` directly would fail:
+    the plugin registers no lance-to-pandas handler."""
+    df = table.to_pandas()
+    return len(df)
+
+
+@env.task
+async def as_pandas_streaming(ds: lance.LanceDataset) -> int:
+    """Convert per batch instead, so the dataset is never held whole."""
+    rows = 0
+    for batch in ds.scanner(columns=["id"], batch_size=1024).to_batches():
+        rows += len(batch.to_pandas())
+    return rows
+# {{/docs-fragment interop}}
+
+
+# {{docs-fragment reference}}
+import os
+
+
+@env.task
+async def convert(n: int = 10_000, chunk: int = 2_000) -> DataFrame:
+    """Write a Lance dataset in bounded chunks, then hand it off by reference."""
+    uri = os.path.join(tempfile.mkdtemp(), "dataset.lance")
+    mode = "create"
+    for start in range(0, n, chunk):
+        rows = list(range(start, min(start + chunk, n)))
+        lance.write_dataset(pa.table({"id": rows}), uri, mode=mode)
+        mode = "append"
+
+    # Flyte uploads the .lance directory verbatim: no re-read, no re-encode.
+    return DataFrame(uri=uri, format="lance")
+
+
+@env.task
+async def inspect(ds: lance.LanceDataset) -> dict:
+    # The consumer still takes the raw Lance type; the "lance" format resolves
+    # the handoff regardless of which form the producer returned.
+    return {"rows": ds.count_rows(), "fragments": len(ds.get_fragments())}
+# {{/docs-fragment reference}}
+
+
+# {{docs-fragment fragments}}
+from functools import partial
+
+
+@env.task
+async def scan_fragment(df: DataFrame, fragment_id: int) -> int:
+    """Read exactly one fragment. Each worker touches a disjoint slice of files."""
+    ds = await df.open(lance.LanceDataset).all()
+    return ds.get_fragment(fragment_id).to_table(columns=["id"]).num_rows
+
+
+@env.task
+async def fan_out(df: DataFrame) -> int:
+    # Pass the dataset as a `DataFrame`, not a `lance.LanceDataset`: the reference
+    # form keeps the stored bytes (and therefore the fragment ids) identical for
+    # every worker. Returning a `lance.LanceDataset` would re-encode the dataset
+    # at the boundary and coalesce the fragments, invalidating these ids.
+    ds = await df.open(lance.LanceDataset).all()
+    fragment_ids = [f.fragment_id for f in ds.get_fragments()]
+
+    total = 0
+    async for count in flyte.map.aio(partial(scan_fragment, df), fragment_ids):
+        if isinstance(count, Exception):
+            raise count
+        total += count
+    return total
+# {{/docs-fragment fragments}}
+
+
+# {{docs-fragment main}}
+@env.task
+async def main(n: int = 10_000) -> dict:
+    ds = await build_dataset(n)
+
+    table_df = await build_table()
+
+    referenced = await convert(n)
+
+    return {
+        "summary": await summarize(ds),
+        "sampled": await sample_rows(ds),
+        "arrow_streaming_rows": await read_as_dataset(table_df),
+        "arrow_eager": await read_as_table(table_df),
+        "pandas_rows": await as_pandas(table_df),
+        "pandas_streaming_rows": await as_pandas_streaming(referenced),
+        "referenced": await inspect(referenced),
+        "fanned_out_rows": await fan_out(referenced),
+    }
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+# {{/docs-fragment main}}

--- a/v2/integrations/flyte-plugins/lance/multimodal_streaming.py
+++ b/v2/integrations/flyte-plugins/lance/multimodal_streaming.py
@@ -1,0 +1,143 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-lance",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment setup}}
+import os
+import random
+import tempfile
+
+import flyte
+import lance
+import pyarrow as pa
+from flyte.io import DataFrame
+
+image = flyte.Image.from_debian_base(name="lance-multimodal").with_pip_packages("flyteplugins-lance")
+
+env = flyte.TaskEnvironment(
+    name="lance_multimodal",
+    image=image,
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
+)
+
+# `lance-encoding:blob` keeps large values out of the regular column layout, so a
+# scan that doesn't ask for `image` never pays for the image bytes.
+SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.int32()),
+        pa.field("image", pa.large_binary(), metadata={"lance-encoding:blob": "true"}),
+        pa.field("label", pa.int32()),
+    ]
+)
+# {{/docs-fragment setup}}
+
+
+def _fake_image_bytes(i: int) -> bytes:
+    """Stand-in for encoded PNG/JPEG bytes, deliberately non-uniform in size."""
+    return f"IMG{i}".encode() * (i % 7 + 1) * 64
+
+
+# {{docs-fragment convert}}
+@env.task
+async def convert(n: int = 4_000, chunk: int = 512) -> DataFrame:
+    """Fold many small samples into one Lance dataset, a chunk at a time."""
+    uri = os.path.join(tempfile.mkdtemp(), "images.lance")
+
+    mode = "create"
+    for start in range(0, n, chunk):
+        rows = list(range(start, min(start + chunk, n)))
+        table = pa.table(
+            {
+                "id": rows,
+                "image": [_fake_image_bytes(i) for i in rows],
+                "label": [i % 10 for i in rows],
+            },
+            schema=SCHEMA,
+        )
+        lance.write_dataset(table, uri, mode=mode)
+        mode = "append"
+
+    # Hand off by reference. Returning a `lance.LanceDataset` here would re-encode
+    # the dataset through Arrow, which a blob-encoded column does not survive.
+    return DataFrame(uri=uri, format="lance")
+# {{/docs-fragment convert}}
+
+
+# {{docs-fragment train}}
+@env.task
+async def train_one_epoch(df: DataFrame, batch_size: int = 128, seed: int = 0) -> dict:
+    """Stream one shuffled epoch by random access. Nothing is downloaded whole."""
+    ds = await df.open(lance.LanceDataset).all()
+
+    order = list(range(ds.count_rows()))
+    random.Random(seed).shuffle(order)
+
+    seen = 0
+    label_counts: dict[int, int] = {}
+    for i in range(0, len(order), batch_size):
+        # Reads only these rows, only these columns. Memory stays proportional to
+        # the batch, not to the dataset.
+        batch = ds.take(order[i : i + batch_size], columns=["image", "label"])
+        for image, label in zip(batch.column("image").to_pylist(), batch.column("label").to_pylist()):
+            _ = len(image)  # stand-in for decoding and augmenting the image
+            label_counts[label] = label_counts.get(label, 0) + 1
+            seen += 1
+
+    return {
+        "rows_streamed": seen,
+        # Map keys are stringified so the run UI renders them as text.
+        "labels": {str(k): v for k, v in sorted(label_counts.items())},
+    }
+# {{/docs-fragment train}}
+
+
+# {{docs-fragment metadata-scan}}
+@env.task
+async def label_histogram(df: DataFrame) -> dict:
+    """Scan the structured columns only. The image bytes are never read."""
+    ds = await df.open(lance.LanceDataset).all()
+
+    counts: dict[int, int] = {}
+    for batch in ds.scanner(columns=["label"], batch_size=4_096).to_batches():
+        for label in batch.column("label").to_pylist():
+            counts[label] = counts.get(label, 0) + 1
+    return {str(k): v for k, v in sorted(counts.items())}
+# {{/docs-fragment metadata-scan}}
+
+
+# {{docs-fragment blob-file}}
+@env.task
+async def inspect_large_images(df: DataFrame, top_k: int = 3) -> list[int]:
+    """Open blobs as file-like objects instead of loading them into memory."""
+    ds = await df.open(lance.LanceDataset).all()
+
+    sizes = []
+    for blob in ds.take_blobs("image", indices=list(range(top_k))):
+        with blob as f:
+            sizes.append(len(f.readall()))
+    return sizes
+# {{/docs-fragment blob-file}}
+
+
+# {{docs-fragment main}}
+@env.task
+async def main(n: int = 4_000) -> dict:
+    dataset = await convert(n)
+    return {
+        "epoch": await train_one_epoch(dataset),
+        "labels": await label_histogram(dataset),
+        "blob_sizes": await inspect_large_images(dataset),
+    }
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+# {{/docs-fragment main}}

--- a/v2/integrations/flyte-plugins/lance/parquet_vs_lance.py
+++ b/v2/integrations/flyte-plugins/lance/parquet_vs_lance.py
@@ -1,0 +1,161 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-lance",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment setup}}
+import random
+import time
+from typing import Annotated
+
+import flyte
+import flyte.report
+import lance
+import pyarrow as pa
+from flyte.io import DataFrame
+
+image = flyte.Image.from_debian_base(name="lance-benchmark").with_pip_packages("flyteplugins-lance")
+
+env = flyte.TaskEnvironment(
+    name="lance_benchmark",
+    image=image,
+    resources=flyte.Resources(cpu="2", memory="8Gi"),
+)
+
+
+def build_table(n_rows: int, payload_bytes: int) -> pa.Table:
+    """An id, a float feature, and a binary payload standing in for an embedding."""
+    rng = random.Random(0)
+    return pa.table(
+        {
+            "id": pa.array(range(n_rows), type=pa.int64()),
+            "x": pa.array([rng.random() for _ in range(n_rows)], type=pa.float64()),
+            "payload": pa.array([rng.randbytes(payload_bytes) for _ in range(n_rows)], type=pa.large_binary()),
+        }
+    )
+# {{/docs-fragment setup}}
+
+
+# {{docs-fragment producers}}
+@env.task
+async def write_parquet(n_rows: int = 100_000, payload_bytes: int = 512) -> DataFrame:
+    """No format annotation, so this is stored as Parquet (Flyte's default)."""
+    return DataFrame.wrap_df(build_table(n_rows, payload_bytes))
+
+
+@env.task
+async def write_lance(n_rows: int = 100_000, payload_bytes: int = 512) -> Annotated[DataFrame, "lance"]:
+    """The same rows, stored as Lance by this plugin."""
+    return DataFrame.wrap_df(build_table(n_rows, payload_bytes))
+# {{/docs-fragment producers}}
+
+
+def _best_of(fn, repeats: int = 3) -> float:
+    best = float("inf")
+    for _ in range(repeats):
+        start = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+async def _best_of_async(fn, repeats: int = 3) -> float:
+    best = float("inf")
+    for _ in range(repeats):
+        start = time.perf_counter()
+        await fn()
+        best = min(best, time.perf_counter() - start)
+    return best
+
+
+# {{docs-fragment compare}}
+@env.task(report=True)
+async def compare(parquet_df: DataFrame, lance_ds: lance.LanceDataset, n_random_rows: int = 1_000) -> dict:
+    n = lance_ds.count_rows()
+    indices = random.Random(7).sample(range(n), k=min(n_random_rows, n))
+    columns = ["id", "x", "payload"]
+
+    # Lance: fetch exactly the requested rows off the open handle.
+    lance_bytes = lance_ds.take(indices, columns=columns).nbytes
+    lance_seconds = _best_of(lambda: lance_ds.take(indices, columns=columns))
+
+    # Parquet: the decoder is eager, so getting any subset means materializing
+    # the whole table first, then indexing into it in memory.
+    async def parquet_random():
+        table = await parquet_df.open(pa.Table).all()
+        table.take(indices)
+
+    parquet_bytes = (await parquet_df.open(pa.Table).all()).nbytes
+    parquet_seconds = await _best_of_async(parquet_random)
+
+    await flyte.report.replace.aio(
+        _render(n, len(indices), parquet_bytes, lance_bytes, parquet_seconds, lance_seconds),
+        do_flush=True,
+    )
+
+    return {
+        "rows_in_dataset": n,
+        "rows_requested": len(indices),
+        "parquet_mb_read": round(parquet_bytes / 1e6, 1),
+        "lance_mb_read": round(lance_bytes / 1e6, 2),
+        "less_data_read_x": round(parquet_bytes / lance_bytes, 1),
+        "parquet_ms": round(parquet_seconds * 1e3, 1),
+        "lance_ms": round(lance_seconds * 1e3, 1),
+        "faster_x": round(parquet_seconds / lance_seconds, 1),
+    }
+# {{/docs-fragment compare}}
+
+
+def _bar(label: str, value: float, largest: float, unit: str, color: str) -> str:
+    pct = 100 * value / largest if largest else 0
+    return (
+        '<div style="margin:10px 0">'
+        f'<div style="font-size:13px;margin-bottom:4px">{label} &mdash; <b>{value:,.1f}{unit}</b></div>'
+        '<div style="background:#e9ecef;border-radius:5px;overflow:hidden">'
+        f'<div style="width:{pct:.1f}%;background:{color};height:18px"></div></div></div>'
+    )
+
+
+def _render(n, k, parquet_bytes, lance_bytes, parquet_seconds, lance_seconds) -> str:
+    parquet_mb, lance_mb = parquet_bytes / 1e6, lance_bytes / 1e6
+    largest = max(parquet_mb, lance_mb)
+    return f"""
+    <div style="font-family:system-ui,sans-serif;max-width:720px">
+      <h2>Fetching {k:,} scattered rows from {n:,}</h2>
+      <p style="color:#444">Same columnar data, same <code>flyte.io.DataFrame</code> interface.
+      What differs is how much has to be read to answer the request.</p>
+      <div style="margin:14px 0;padding:12px 14px;background:#e6fcf5;border-radius:8px;color:#087f5b">
+        Parquet materialized <b>{parquet_mb:,.0f} MB</b> to return {k:,} rows.
+        Lance read <b>{lance_mb:,.1f} MB</b> &mdash;
+        <b>{parquet_bytes / lance_bytes:,.0f}x less data</b>.
+      </div>
+      <h3 style="margin:20px 0 2px">Data read (lower is better)</h3>
+      {_bar("Parquet", parquet_mb, largest, " MB", "#adb5bd")}
+      {_bar("Lance", lance_mb, largest, " MB", "#06d6a0")}
+      <p style="color:#666;font-size:13px;margin-top:16px">
+        Fetch time: Parquet {parquet_seconds * 1e3:,.0f} ms vs Lance {lance_seconds * 1e3:,.1f} ms.
+        The bytes-read ratio is the durable number &mdash; it is cache-independent, and it is what
+        turns into a latency gap once the data sits on object storage rather than local disk.
+      </p>
+    </div>
+    """
+
+
+# {{docs-fragment main}}
+@env.task
+async def main(n_rows: int = 100_000, payload_bytes: int = 512, n_random_rows: int = 1_000) -> dict:
+    parquet_df = await write_parquet(n_rows, payload_bytes)
+    lance_df = await write_lance(n_rows, payload_bytes)
+    return await compare(parquet_df, lance_df, n_random_rows)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+# {{/docs-fragment main}}


### PR DESCRIPTION
<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes

<!-- Briefly describe the example/tutorial added or updated, and the docs page it
     supports (if any). -->

## Checklist

- [x] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [x] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [x] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
