### PR TITLE
fix lance multimodal example to read real image bytes

### DIFF
--- a/v2/integrations/flyte-plugins/lance/multimodal_streaming.py
+++ b/v2/integrations/flyte-plugins/lance/multimodal_streaming.py
@@ -81,18 +81,27 @@ async def train_one_epoch(df: DataFrame, batch_size: int = 128, seed: int = 0) -
     random.Random(seed).shuffle(order)
 
     seen = 0
+    image_bytes = 0
     label_counts: dict[int, int] = {}
     for i in range(0, len(order), batch_size):
-        # Reads only these rows, only these columns. Memory stays proportional to
-        # the batch, not to the dataset.
-        batch = ds.take(order[i : i + batch_size], columns=["image", "label"])
-        for image, label in zip(batch.column("image").to_pylist(), batch.column("label").to_pylist()):
-            _ = len(image)  # stand-in for decoding and augmenting the image
+        rows = order[i : i + batch_size]
+
+        # Structured columns come back inline. A blob column does not: `take` and
+        # `scanner` hand you a {position, size} descriptor rather than the value,
+        # so the bytes are read through `take_blobs`, which opens each one as a
+        # file object. Either way only these rows are touched, so memory stays
+        # proportional to the batch and not to the dataset.
+        labels = ds.take(rows, columns=["label"]).column("label").to_pylist()
+
+        for blob, label in zip(ds.take_blobs("image", indices=rows), labels):
+            with blob as f:
+                image_bytes += len(f.readall())  # stand-in for decode + augment
             label_counts[label] = label_counts.get(label, 0) + 1
             seen += 1
 
     return {
         "rows_streamed": seen,
+        "image_bytes_read": image_bytes,
         # Map keys are stringified so the run UI renders them as text.
         "labels": {str(k): v for k, v in sorted(label_counts.items())},
     }


### PR DESCRIPTION
take() and scanner() do not return a blob value. They return a {position, size} descriptor, so the training loop was calling len() on a dict and never touching an image. Read the bytes through take_blobs() instead, and return a byte count so the claim is checkable.

<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes

<!-- Briefly describe the example/tutorial added or updated, and the docs page it
     supports (if any). -->

## Checklist

- [ ] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [ ] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
