### PR TITLE
name the lance benchmark's metric for what it measures

### DIFF
--- a/v2/integrations/flyte-plugins/lance/parquet_vs_lance.py
+++ b/v2/integrations/flyte-plugins/lance/parquet_vs_lance.py
@@ -82,6 +82,10 @@ async def compare(parquet_df: DataFrame, lance_ds: lance.LanceDataset, n_random_
     indices = random.Random(7).sample(range(n), k=min(n_random_rows, n))
     columns = ["id", "x", "payload"]
 
+    # `nbytes` is the decoded size of the result, not bytes moved off storage.
+    # That is the comparison: how much each side has to build in memory to
+    # answer a 1,000-row request.
+    #
     # Lance: fetch exactly the requested rows off the open handle.
     lance_bytes = lance_ds.take(indices, columns=columns).nbytes
     lance_seconds = _best_of(lambda: lance_ds.take(indices, columns=columns))
@@ -103,9 +107,9 @@ async def compare(parquet_df: DataFrame, lance_ds: lance.LanceDataset, n_random_
     return {
         "rows_in_dataset": n,
         "rows_requested": len(indices),
-        "parquet_mb_read": round(parquet_bytes / 1e6, 1),
-        "lance_mb_read": round(lance_bytes / 1e6, 2),
-        "less_data_read_x": round(parquet_bytes / lance_bytes, 1),
+        "parquet_mb_materialized": round(parquet_bytes / 1e6, 1),
+        "lance_mb_materialized": round(lance_bytes / 1e6, 2),
+        "less_data_x": round(parquet_bytes / lance_bytes, 1),
         "parquet_ms": round(parquet_seconds * 1e3, 1),
         "lance_ms": round(lance_seconds * 1e3, 1),
         "faster_x": round(parquet_seconds / lance_seconds, 1),


### PR DESCRIPTION
Follow-up to review feedback on [unionai-docs#1419](https://github.com/unionai/unionai-docs/pull/1419).

`compare()` reports `pa.Table.nbytes`, which is the decoded size of the result rather than bytes moved off storage. The keys named it as I/O:

```
parquet_mb_read   →  parquet_mb_materialized
lance_mb_read     →  lance_mb_materialized
less_data_read_x  →  less_data_x
```

The measurement itself is fine and the comparison still holds — Flyte's Parquet decoder materializes the whole table to answer a 1,000-row request, while Lance materializes just those rows. Only the naming claimed something the code doesn't measure. These keys render on the docs page through the `compare` fragment, so they sat directly under prose that now says "materializes".

Also added a comment at the measurement site, since the distinction is easy to miss when reading the code.

## Verification

Values are unchanged:

```
rows_in_dataset: 100000, rows_requested: 1000,
parquet_mb_materialized: 53.6, lance_mb_materialized: 0.54, less_data_x: 100.0
```

`make test-local FILE=v2/integrations/flyte-plugins/lance/parquet_vs_lance.py` passes; ruff clean.

`_render` is deliberately untouched, so the report screenshot committed to the docs PR still matches the code. Its chart heading still reads "Data read", which is the same imprecision one level down — fixing that properly means retaking the screenshot on a cluster, so it's left for whenever that image is next regenerated.

## Note for the docs PR

unionai-docs#1419 will need a submodule re-bump after this merges; the pointer it carries now (`6e19fe3`) predates this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)