### PR TITLE
update migration examples

### DIFF
--- a/v2/user-guide/migration/flyte-2/error_handling_v1.py
+++ b/v2/user-guide/migration/flyte-2/error_handling_v1.py
@@ -1,7 +1,8 @@
+import flytekit
 from flytekit import task, workflow
 
 
-@task
+@task(resources=flytekit.Resources(cpu=1, mem="250Mi"))
 def train_fold(max_depth: int) -> float:
     if max_depth <= 0:
         raise ValueError("max_depth must be positive")

--- a/v2/user-guide/migration/flyte-2/error_handling_v2.py
+++ b/v2/user-guide/migration/flyte-2/error_handling_v2.py
@@ -9,8 +9,9 @@
 
 # {{docs-fragment all}}
 import flyte
+import flyte.errors
 
-env = flyte.TaskEnvironment(name="error_handling")
+env = flyte.TaskEnvironment(name="error_handling", resources=flyte.Resources(cpu=1, memory="250Mi"))
 
 
 @env.task
@@ -30,6 +31,27 @@ async def main(max_depth: int) -> float:
         # Recover with a safe default instead of failing the whole run.
         return await train_fold(max_depth=6)
 # {{/docs-fragment all}}
+
+
+# Infrastructure failures are catchable too: recover from an out-of-memory
+# kill by retrying the same task with a larger memory request.
+# {{docs-fragment oom}}
+@env.task
+async def oomer(x: int) -> float:
+    large_list = [x] * 100000000
+    return sum(large_list) / len(large_list)
+
+
+@env.task
+async def main_with_oom_retry(x: int) -> float:
+    try:
+        return await oomer(x)
+    except flyte.errors.OOMError:
+        # Retry the same task with a larger memory request.
+        return await oomer.override(
+            resources=flyte.Resources(memory="16Gi")
+        )(x)
+# {{/docs-fragment oom}}
 
 
 if __name__ == "__main__":

--- a/v2/user-guide/migration/flyte-2/hello_world_v1.py
+++ b/v2/user-guide/migration/flyte-2/hello_world_v1.py
@@ -1,17 +1,25 @@
-import flytekit
+import flyte
 
 
-@flytekit.task
+env = flyte.TaskEnvironment(
+    name="hello_world",
+)
+
+
+@env.task
 def say_hello(name: str) -> str:
     return f"Hello, {name}!"
 
 
-@flytekit.task
+@env.task
 def to_upper(greeting: str) -> str:
     return greeting.upper()
 
 
-@flytekit.workflow
+@env.task
 def main(name: str) -> str:
     greeting = say_hello(name=name)
+    greeting = f"{greeting}, welcome to Flyte!"
+    if len(name) < 1:
+        return "No greeting for you!"
     return to_upper(greeting=greeting)

--- a/v2/user-guide/migration/flyte-2/ml_pipeline_v2.py
+++ b/v2/user-guide/migration/flyte-2/ml_pipeline_v2.py
@@ -24,7 +24,7 @@ from sklearn.ensemble import RandomForestClassifier
 env = flyte.TaskEnvironment(
     name="ml_pipeline",
     image=flyte.Image.from_debian_base().with_pip_packages(
-        "pandas", "scikit-learn", "joblib"
+        "pandas", "scikit-learn", "joblib", "pyarrow",
     ),
     resources=flyte.Resources(cpu="2", memory="4Gi"),
     cache="auto",

--- a/v2/user-guide/migration/flyte-2/scheduling_v2.py
+++ b/v2/user-guide/migration/flyte-2/scheduling_v2.py
@@ -17,9 +17,8 @@ env = flyte.TaskEnvironment(name="scheduling")
 # A Trigger replaces LaunchPlan + CronSchedule. It is attached directly to the
 # task and deployed with it (flyte deploy). flyte.TriggerTime binds the
 # scheduled fire time to a task input.
-nightly_retrain = flyte.Trigger(
+nightly_retrain = flyte.Trigger.minutely(
     name="nightly_retrain",
-    automation=flyte.Cron("0 2 * * *"),  # 2 AM daily
     inputs={"trigger_time": flyte.TriggerTime},
     auto_activate=True,
 )

--- a/v2/user-guide/migration/flyte-2/train_deep_learning_v1.py
+++ b/v2/user-guide/migration/flyte-2/train_deep_learning_v1.py
@@ -1,5 +1,5 @@
 from flytekit import task, workflow, ImageSpec, Resources
-from flytekit.extras.accelerators import T4
+import flytekit
 import torch
 import torch.nn as nn
 
@@ -11,8 +11,8 @@ image = ImageSpec(
 
 @task(
     container_image=image,
-    requests=Resources(cpu="4", mem="16Gi", gpu="1"),
-    accelerator=T4,
+    requests=Resources(cpu="2", mem="4Gi"),
+    enable_deck=True,
 )
 def train(epochs: int) -> float:
     device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -29,6 +29,9 @@ def train(epochs: int) -> float:
         loss = loss_fn(model(X), y)
         loss.backward()
         optimizer.step()
+        flytekit.current_context().default_deck.append(f"loss: {float(loss.item())}")
+        flytekit.Deck.publish()
+
     return float(loss.item())
 
 

--- a/v2/user-guide/migration/flyte-2/train_deep_learning_v2.py
+++ b/v2/user-guide/migration/flyte-2/train_deep_learning_v2.py
@@ -10,6 +10,7 @@
 
 # {{docs-fragment all}}
 import flyte
+import flyte.report
 import torch
 import torch.nn as nn
 
@@ -18,11 +19,11 @@ import torch.nn as nn
 env = flyte.TaskEnvironment(
     name="train_deep_learning",
     image=flyte.Image.from_debian_base().with_pip_packages("torch"),
-    resources=flyte.Resources(cpu="4", memory="16Gi", gpu="T4:1"),
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
 )
 
 
-@env.task
+@env.task(report=True)
 async def train(epochs: int) -> float:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = nn.Linear(10, 1).to(device)
@@ -38,6 +39,8 @@ async def train(epochs: int) -> float:
         loss = loss_fn(model(X), y)
         loss.backward()
         optimizer.step()
+        flyte.report.log(f"loss: {float(loss.item())}<br>")
+        flyte.report.flush()
     return float(loss.item())
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes

<!-- Briefly describe the example/tutorial added or updated, and the docs page it
     supports (if any). -->

## Checklist

- [x] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [x] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [x] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [x] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [x] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [x] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
