### PR TITLE
Enable passthrough authentication in agent chat UI

### DIFF
--- a/v2/user-guide/build-agent/agent-chat-ui/agent_chat_ui.py
+++ b/v2/user-guide/build-agent/agent-chat-ui/agent_chat_ui.py
@@ -86,6 +86,7 @@ env = AgentChatAppEnvironment(
     image=flyte.Image.from_debian_base().with_pip_packages("litellm", "fastapi", "uvicorn"),
     resources=flyte.Resources(cpu=2, memory="2Gi"),
     secrets=flyte.Secret("internal-anthropic-api-key", as_env_var="ANTHROPIC_API_KEY"),
+    passthrough_auth=True,
 )
 # {{/docs-fragment all}}
 


### PR DESCRIPTION
<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes
Setting `passthrough_auth=True` because the agent ui example is failing with 
```Filtered traceback (most recent call last):
  File "/path/deploy.py", line 24, in <module>
    from agent.agent import agent_env
  File "/path/agent/agent.py", line 64, in <module>
    agent_env = AgentChatAppEnvironment(
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 35, in __init__
  File "/path/venv/lib/python3.12/site-packages/flyte/ai/chat/app.py", line 319, in __post_init__
    raise ValueError(
ValueError: task_entrypoint requires passthrough_auth=True so the app can run tasks with caller credentials.
```

## Checklist

- [ ] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [ ] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
