### PR TITLE
add hugging face plugin examples

### DIFF
--- a/v2/integrations/flyte-plugins/huggingface/hf_datasets.py
+++ b/v2/integrations/flyte-plugins/huggingface/hf_datasets.py
@@ -1,0 +1,179 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-huggingface",
+#    "datasets",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+# {{docs-fragment setup}}
+import flyte
+
+image = flyte.Image.from_debian_base(name="huggingface").with_pip_packages("flyteplugins-huggingface")
+
+env = flyte.TaskEnvironment(
+    name="huggingface_env",
+    image=image,
+    resources=flyte.Resources(cpu="2", memory="4Gi"),
+)
+# {{/docs-fragment setup}}
+
+# Point this at a bucket you can read and write to reuse downloads across runs.
+# A local path works too, so you can try `flyte run --local` before touching a bucket.
+CACHE_ROOT = "s3://my-bucket/flyte-hf-cache"
+
+
+# {{docs-fragment source}}
+import datasets
+
+from flyteplugins.huggingface.datasets import from_hf
+
+
+@env.task
+async def count_reviews(
+    ds: datasets.Dataset = from_hf("stanfordnlp/imdb", name="plain_text", split="train"),
+) -> int:
+    return len(ds)
+# {{/docs-fragment source}}
+
+
+# {{docs-fragment config}}
+@env.task
+async def count_mrpc(
+    ds: datasets.Dataset = from_hf("nyu-mll/glue", name="mrpc", split="train"),
+) -> int:
+    return len(ds)
+# {{/docs-fragment config}}
+
+
+# {{docs-fragment splits}}
+@env.task
+async def all_splits_combined(
+    ds: datasets.Dataset = from_hf("stanfordnlp/imdb", name="plain_text"),
+) -> str:
+    # 100,000 rows: train (25k), test (25k) and unsupervised (50k), concatenated.
+    # There is no column telling you which split a row came from.
+    return f"{len(ds)} rows, columns: {ds.column_names}"
+# {{/docs-fragment splits}}
+
+
+# {{docs-fragment cache}}
+@env.task
+async def count_reviews_cached(
+    ds: datasets.Dataset = from_hf(
+        "stanfordnlp/imdb",
+        name="plain_text",
+        split="train",
+        cache_root=CACHE_ROOT,
+    ),
+) -> int:
+    return len(ds)
+# {{/docs-fragment cache}}
+
+
+# {{docs-fragment projection}}
+from collections import OrderedDict
+from typing import Annotated
+
+
+@env.task
+async def first_reviews(
+    ds: Annotated[datasets.Dataset, OrderedDict(text=str)] = from_hf(
+        "stanfordnlp/imdb",
+        name="plain_text",
+        split="train",
+        cache_root=CACHE_ROOT,
+    ),
+) -> list[str]:
+    # `label` was never read off disk.
+    return ds["text"][:5]
+# {{/docs-fragment projection}}
+
+
+# {{docs-fragment iterable}}
+@env.task
+async def add_length(
+    ds: datasets.IterableDataset = from_hf(
+        "stanfordnlp/imdb",
+        name="plain_text",
+        split="train",
+        cache_root=CACHE_ROOT,
+    ),
+) -> datasets.IterableDataset:
+    def measure(batch):
+        batch["length"] = [len(text) for text in batch["text"]]
+        return batch
+
+    return ds.map(measure, batched=True)
+
+
+@env.task
+async def mean_length(ds: datasets.IterableDataset, sample: int = 1_000) -> float:
+    total = count = 0
+    for row in ds.take(sample):
+        total += row["length"]
+        count += 1
+    return total / count
+# {{/docs-fragment iterable}}
+
+
+# {{docs-fragment handoff}}
+@env.task
+async def build_dataset() -> datasets.Dataset:
+    return datasets.Dataset.from_dict(
+        {"text": ["hello", "world", "flyte"], "label": [0, 1, 0]}
+    )
+
+
+@env.task
+async def keep_positive(ds: datasets.Dataset) -> datasets.Dataset:
+    # flatten_indices() is required, not stylistic. filter() only records an
+    # index mapping over the original table, and the encoder serializes the
+    # underlying table, so without this the task returns every row it was given.
+    return ds.filter(lambda row: row["label"] == 1).flatten_indices()
+# {{/docs-fragment handoff}}
+
+
+# {{docs-fragment runtime-arg}}
+@env.task
+async def count_rows(ds: datasets.Dataset) -> int:
+    return len(ds)
+
+
+@env.task
+async def count_any_split(repo: str, split: str) -> int:
+    # The dataset is chosen when the parent runs, not when the task is defined.
+    return await count_rows(from_hf(repo, split=split, cache_root=CACHE_ROOT))
+# {{/docs-fragment runtime-arg}}
+
+
+# {{docs-fragment passthrough}}
+from flyte.io import DataFrame
+
+
+@env.task
+async def route(df: DataFrame) -> DataFrame:
+    # Typed as DataFrame, so nothing is downloaded here. The reference is
+    # forwarded untouched and resolved by whoever asks for a datasets.Dataset.
+    return df
+# {{/docs-fragment passthrough}}
+
+
+# {{docs-fragment main}}
+@env.task
+async def main() -> str:
+    n_train = await count_reviews_cached()
+    lengths = await add_length()
+    avg = await mean_length(lengths)
+    filtered = await keep_positive(await build_dataset())
+    return f"{n_train} train reviews, mean length {avg:.1f} chars, {len(filtered)} positive row(s)"
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+# {{/docs-fragment main}}

--- a/v2/integrations/flyte-plugins/huggingface/hf_datasets.py
+++ b/v2/integrations/flyte-plugins/huggingface/hf_datasets.py
@@ -1,7 +1,7 @@
 # /// script
-# requires-python = "==3.12"
+# requires-python = "==3.13"
 # dependencies = [
-#    "flyte",
+#    "flyte>=2.0.0b52",
 #    "flyteplugins-huggingface",
 #    "datasets",
 # ]
@@ -21,9 +21,13 @@ env = flyte.TaskEnvironment(
 )
 # {{/docs-fragment setup}}
 
-# Point this at a bucket you can read and write to reuse downloads across runs.
-# A local path works too, so you can try `flyte run --local` before touching a bucket.
-CACHE_ROOT = "s3://my-bucket/flyte-hf-cache"
+# Reuses downloads across runs. Set HF_CACHE_ROOT to object storage (s3://..., gs://...)
+# to share one copy across a team; it falls back to a local directory so the example
+# runs anywhere.
+import os
+import tempfile
+
+CACHE_ROOT = os.environ.get("HF_CACHE_ROOT", os.path.join(tempfile.gettempdir(), "flyte-hf-cache"))
 
 
 # {{docs-fragment source}}

--- a/v2/integrations/flyte-plugins/huggingface/imdb_sentiment.py
+++ b/v2/integrations/flyte-plugins/huggingface/imdb_sentiment.py
@@ -1,0 +1,224 @@
+# /// script
+# requires-python = "==3.12"
+# dependencies = [
+#    "flyte",
+#    "flyteplugins-huggingface",
+#    "datasets",
+#    "transformers",
+#    "torch",
+#    "scikit-learn",
+#    "accelerate",
+#    "numpy",
+# ]
+# main = "main"
+# params = ""
+# ///
+"""Fine-tune DistilBERT on IMDB, sourcing the dataset straight from the Hub.
+
+Every dataset that crosses a task boundary here is a `datasets.Dataset`. The
+plugin handles the Parquet on both sides, so no task writes a file by hand.
+"""
+
+# {{docs-fragment env}}
+import flyte
+
+image = flyte.Image.from_uv_script(__file__, name="imdb-sentiment", pre=True)
+
+cpu_env = flyte.TaskEnvironment(
+    name="imdb_sentiment_cpu",
+    image=image,
+    resources=flyte.Resources(cpu="4", memory="8Gi"),
+)
+
+gpu_env = flyte.TaskEnvironment(
+    name="imdb_sentiment_gpu",
+    image=image,
+    resources=flyte.Resources(cpu="4", memory="16Gi", gpu=1),
+    # Only needed for gated or private repos; IMDB is public.
+    secrets=[flyte.Secret(key="huggingface-token", as_env_var="HF_TOKEN")],
+)
+
+REPO = "stanfordnlp/imdb"
+CONFIG = "plain_text"
+MODEL = "distilbert-base-uncased"
+
+# Shared across every run in this project. The first run downloads IMDB from the
+# Hub; every run after that reads these Parquet shards instead.
+CACHE_ROOT = "s3://my-bucket/flyte-hf-cache"
+# {{/docs-fragment env}}
+
+
+# {{docs-fragment prepare}}
+import datasets
+
+
+@cpu_env.task(cache="auto")
+async def subsample(ds: datasets.Dataset, n_rows: int, seed: int = 42) -> datasets.Dataset:
+    """Take a reproducible random subset, so the pipeline is cheap to iterate on.
+
+    flatten_indices() materializes the shuffled selection into a real table.
+    Skip it and shuffle/select leave only an index mapping, which the encoder
+    does not serialize -- the task would hand the full 25,000 rows downstream.
+    """
+    return ds.shuffle(seed=seed).select(range(min(n_rows, len(ds)))).flatten_indices()
+# {{/docs-fragment prepare}}
+
+
+# {{docs-fragment tokenize}}
+@cpu_env.task(cache="auto")
+async def tokenize(ds: datasets.Dataset, max_length: int = 256) -> datasets.Dataset:
+    """Tokenize on CPU, once, and hand the result on as a dataset.
+
+    The returned dataset carries list-valued `input_ids` and `attention_mask`
+    columns. Those survive the Parquet round trip, so the GPU task receives them
+    ready to train on and never loads a tokenizer.
+    """
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+
+    def encode(batch):
+        return tokenizer(batch["text"], truncation=True, padding="max_length", max_length=max_length)
+
+    return ds.map(encode, batched=True, remove_columns=["text"])
+# {{/docs-fragment tokenize}}
+
+
+# {{docs-fragment train}}
+import flyte.io
+
+
+@gpu_env.task
+async def finetune(
+    train_ds: datasets.Dataset,
+    eval_ds: datasets.Dataset,
+    epochs: float = 1.0,
+    lr: float = 5e-5,
+    batch_size: int = 16,
+) -> flyte.io.Dir:
+    import tempfile
+
+    import numpy as np
+    from sklearn.metrics import accuracy_score, f1_score
+    from transformers import AutoModelForSequenceClassification, Trainer, TrainingArguments
+
+    model = AutoModelForSequenceClassification.from_pretrained(MODEL, num_labels=2)
+    out_dir = tempfile.mkdtemp()
+
+    def metrics(eval_pred):
+        logits, labels = eval_pred
+        preds = np.argmax(logits, axis=-1)
+        return {
+            "accuracy": accuracy_score(labels, preds),
+            "f1": f1_score(labels, preds, average="binary"),
+        }
+
+    trainer = Trainer(
+        model=model,
+        args=TrainingArguments(
+            output_dir=out_dir,
+            num_train_epochs=epochs,
+            learning_rate=lr,
+            per_device_train_batch_size=batch_size,
+            per_device_eval_batch_size=batch_size,
+            eval_strategy="epoch",
+            save_strategy="no",
+            report_to=[],
+        ),
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
+        compute_metrics=metrics,
+    )
+    trainer.train()
+    trainer.save_model(out_dir)
+
+    return await flyte.io.Dir.from_local(out_dir)
+# {{/docs-fragment train}}
+
+
+# {{docs-fragment evaluate}}
+@gpu_env.task(report=True)
+async def score_stream(
+    model_dir: flyte.io.Dir,
+    ds: datasets.IterableDataset,
+    batch_size: int = 32,
+) -> float:
+    """Score held-out reviews by streaming them, never holding the split in memory.
+
+    The caller passes the same value it gave `tokenize`, a `datasets.Dataset`.
+    It arrives here as an IterableDataset purely because that is the annotation,
+    so rows are pulled from Parquet a batch at a time and peak memory is one
+    batch whether the split holds 1,000 rows or 25,000.
+    """
+    import torch
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    local = await model_dir.download()
+    tokenizer = AutoTokenizer.from_pretrained(MODEL)
+    model = AutoModelForSequenceClassification.from_pretrained(local).eval()
+
+    correct = seen = 0
+    batch: list[dict] = []
+
+    def flush(rows):
+        nonlocal correct, seen
+        if not rows:
+            return
+        enc = tokenizer(
+            [r["text"] for r in rows], truncation=True, padding=True, max_length=256, return_tensors="pt"
+        )
+        with torch.no_grad():
+            preds = model(**enc).logits.argmax(dim=-1).tolist()
+        correct += sum(int(p == r["label"]) for p, r in zip(preds, rows))
+        seen += len(rows)
+
+    for row in ds:
+        batch.append(row)
+        if len(batch) == batch_size:
+            flush(batch)
+            batch = []
+    flush(batch)
+
+    accuracy = correct / seen
+    await flyte.report.replace.aio(
+        f"<h2>Held-out accuracy</h2><p>{accuracy:.1%} over {seen} streamed reviews.</p>"
+    )
+    await flyte.report.flush.aio()
+    return accuracy
+# {{/docs-fragment evaluate}}
+
+
+# {{docs-fragment main}}
+import asyncio
+
+from flyteplugins.huggingface.datasets import from_hf
+
+
+@cpu_env.task
+async def main(train_rows: int = 4_000, eval_rows: int = 1_000) -> float:
+    # Both references point at the same cache_root, so the two splits download
+    # once and every later run of this pipeline skips the Hub entirely.
+    train_src = from_hf(REPO, name=CONFIG, split="train", cache_root=CACHE_ROOT)
+    test_src = from_hf(REPO, name=CONFIG, split="test", cache_root=CACHE_ROOT)
+
+    train_raw, eval_raw = await asyncio.gather(
+        subsample(train_src, train_rows),
+        subsample(test_src, eval_rows),
+    )
+    train_tok, eval_tok = await asyncio.gather(tokenize(train_raw), tokenize(eval_raw))
+
+    model_dir = await finetune(train_tok, eval_tok)
+
+    # eval_raw is a datasets.Dataset. score_stream annotates the same value as an
+    # IterableDataset and therefore receives it as a stream -- same bytes in
+    # storage, different view. Note it scores the *shuffled* sample rather than
+    # the head of the raw split: IMDB's test split is ordered by label, so the
+    # first N rows are all negative and would score meaninglessly high.
+    return await score_stream(model_dir, eval_raw)
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(main)
+    print(run.url)
+# {{/docs-fragment main}}

--- a/v2/integrations/flyte-plugins/huggingface/imdb_sentiment.py
+++ b/v2/integrations/flyte-plugins/huggingface/imdb_sentiment.py
@@ -1,7 +1,7 @@
 # /// script
-# requires-python = "==3.12"
+# requires-python = "==3.13"
 # dependencies = [
-#    "flyte",
+#    "flyte>=2.0.0b52",
 #    "flyteplugins-huggingface",
 #    "datasets",
 #    "transformers",
@@ -11,7 +11,7 @@
 #    "numpy",
 # ]
 # main = "main"
-# params = ""
+# params = "train_rows=200 eval_rows=100"
 # ///
 """Fine-tune DistilBERT on IMDB, sourcing the dataset straight from the Hub.
 
@@ -20,6 +20,9 @@ plugin handles the Parquet on both sides, so no task writes a file by hand.
 """
 
 # {{docs-fragment env}}
+import os
+import tempfile
+
 import flyte
 
 image = flyte.Image.from_uv_script(__file__, name="imdb-sentiment", pre=True)
@@ -43,8 +46,10 @@ CONFIG = "plain_text"
 MODEL = "distilbert-base-uncased"
 
 # Shared across every run in this project. The first run downloads IMDB from the
-# Hub; every run after that reads these Parquet shards instead.
-CACHE_ROOT = "s3://my-bucket/flyte-hf-cache"
+# Hub; every run after that reads these Parquet shards instead. Point HF_CACHE_ROOT
+# at object storage (s3://..., gs://...) to share one copy across a team; it falls
+# back to a local directory so the example runs anywhere.
+CACHE_ROOT = os.environ.get("HF_CACHE_ROOT", os.path.join(tempfile.gettempdir(), "flyte-hf-cache"))
 # {{/docs-fragment env}}
 
 


### PR DESCRIPTION
Two runnable examples for the flyteplugins-huggingface docs page:

- hf_datasets.py covers the plugin mechanics: from_hf() as a signature default and as a runtime value, config and split selection, cache_root, column projection, Dataset vs IterableDataset, and passing datasets between tasks.
- imdb_sentiment.py is an end-to-end pipeline: source IMDB from the Hub, tokenize on CPU, fine-tune DistilBERT on GPU, and score a held-out sample by streaming it.

Both were run end to end locally against flyte 2.6.2 and 2.6.5.

Two details are load-bearing and easy to get wrong, so they carry comments in the source:

- filter()/shuffle()/non-contiguous select() only record an index mapping, and the encoder serializes the underlying table. Without flatten_indices() a task silently returns every row it was given. Caught by running it: the trainer was seeing all 25,000 rows.
- IMDB's test split is ordered by label, so evaluation scores the shuffled subsample rather than a prefix of the raw split, which would sample negatives only.

<!--
Thanks for contributing to unionai-examples! See CONTRIBUTING.md for the full
authoring and testing conventions. Scope is Flyte 2.x (v2/) — v1/ is legacy.
-->

## What this changes

<!-- Briefly describe the example/tutorial added or updated, and the docs page it
     supports (if any). -->

## Checklist

- [ ] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [ ] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
