### PR TITLE
docsy: fix two image paths that 404 on the published v1 tutorials

### DIFF
--- a/v1/tutorials/arize/apps.py
+++ b/v1/tutorials/arize/apps.py
@@ -75,7 +75,7 @@ deepseek_app = VLLMApp(
 # We use `PhoenixConfig` to generate a link to the Phoenix dashboard. This link appears in the app UI,
 # allowing you to view trace data directly and gain end-to-end observability of model behavior.
 #
-# ![Phoenix traces](/_static/images/tutorials/arize/phoenix_traces.png)
+# ![Phoenix traces](../../_static/images/tutorials/arize/phoenix_traces.png)
 
 gradio_image = union.ImageSpec(
     name="vllm-deepseek-gradio-phoenix",

--- a/v1/tutorials/weave/rag_app.py
+++ b/v1/tutorials/weave/rag_app.py
@@ -384,7 +384,7 @@ Suggested Answer:
 # which generates a convenient link to the Weave dashboard.
 # This link is available on the app page for easy access to traces and insights.
 
-# ![Weave traces](/_static/images/tutorials/weave/weave_traces.png)
+# ![Weave traces](../../_static/images/tutorials/weave/weave_traces.png)
 
 fastapi_app = FastAPI(lifespan=lifespan)
 app = App(


### PR DESCRIPTION
Two tutorial screenshots are broken on the live site.

```
live:  <img src="/_static/images/tutorials/arize/phoenix_traces.png">   → 404
file:  /docs/v1/union/_static/images/tutorials/arize/phoenix_traces.png → 200
```

Both were written root-relative to the **domain** rather than to the docs tree, so the browser asks `union.ai/_static/…` and gets nothing. These are the **only two** references in `v1/` written that way; every other one is relative.

Affects `tutorials/serving/arize` and `tutorials/serving/weave`, both union-only pages.

## Why `../../` and not `../../../`

Hugo's image render hook rebases an image against the page URL and **adds one `../` of its own**. So a source-relative path is what it expects. The page sits two levels below the variant root (`tutorials/serving`), so `../../_static` is correct and `../../../_static` overshoots by one — which I confirmed by building it the wrong way first:

```
../../../_static  →  /docs/v1/union/tutorials/serving/arize/../../../../_static/…  →  /docs/v1/_static/…   ✗
../../_static     →  /docs/v1/union/tutorials/serving/arize/../../../_static/…     →  /docs/v1/union/_static/… ✓
```

## Verified

`check-rendered-images` goes from **2 failures to clean**, and the emitted `src` resolves to the file that is actually in the built tree.

Found by the rendered-image gate, which reads the built HTML. `check-images` reads `content/` and cannot see this — the `src` is correct in the source and wrong in the HTML, because the render hook rewrites it.

---
— docsy · automated docs agent · [DOC-1525](https://linear.app/unionai/issue/DOC-1525)