### PR TITLE
Add fork and recover run examples

### DIFF
--- a/v2/user-guide/task-deployment/fork-runs/README.md
+++ b/v2/user-guide/task-deployment/fork-runs/README.md
@@ -1,0 +1,34 @@
+# Fork a run — ML pipeline example
+
+The same ML pipeline as the recovery example, but the failure is a bug in our own code, not a
+flaky dependency: `evaluate` divides by the number of predictions clearing `threshold`, and a
+release evaluation with `--threshold 1.0` yields none — `ZeroDivisionError` at the very last
+step. Recovery cannot help (it replays the source run's code as-is); the fix is a code change,
+and `flyte fork` is the verb for it.
+
+- `ml_pipeline.py` — the pipeline as deployed, **buggy `evaluate` included**. Running it
+  launches the failing run and prints the next steps.
+- `ml_pipeline_fixed.py` — the one-line fix, and the automated tour: it launches the buggy
+  pipeline, forks the failed run with the fixed code (`flyteplugins.union.fork`), and prints
+  which actions were reused.
+
+The two files share `load_dataset`, `preprocess`, `train` and an identical `main`, so the fork
+reuses all of them (`RECOVERED` phase) and re-executes only the fixed `evaluate`.
+
+## Run it
+
+Forking is remote-only and ships in `flyteplugins-union` (`pip install flyteplugins-union`).
+
+```bash
+# Automated end-to-end tour:
+uv run python ml_pipeline_fixed.py
+
+# Or the manual flow — what you would actually do:
+flyte run ml_pipeline.py main --threshold 1.0        # fails at evaluate
+# ...apply the one-line fix to `evaluate` in ml_pipeline.py...
+flyte fork <RUN> ml_pipeline.py main --follow        # reuses load/preprocess/train
+flyte get action <FORKED_RUN>                        # reused actions show up as RECOVERED
+```
+
+Embedded in the [Fork a run](https://www.union.ai/docs/v2/union/user-guide/tasks/task-deployment/fork-runs/)
+user guide page.

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/README.md
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/README.md
@@ -19,6 +19,11 @@ edit-run-observe debugging loop into something an agent can run cheaply inside t
 function is an LLM call (source + error message in, patch out). Forking does not care which
 produced the edit.
 
+One sharp edge the agent has to handle: Flyte memoizes code-bundle builds in-process on their
+arguments, so without intervention every fork from the pod would replay the *first* bundle —
+buggy code and all. After writing each patch to disk the agent clears that memo
+(`_force_fresh_code_bundle`), which forces the fork to bundle the edited working tree.
+
 ## Run it
 
 Forking is remote-only, so the full story needs a Union backend:

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/README.md
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/README.md
@@ -1,0 +1,38 @@
+# Agent-mediated forking
+
+An agent, running as a Flyte task, develops and debugs another Flyte workflow — no human in the
+loop.
+
+- `workflow.py` — a toy data-processing pipeline (`load_records` → `clean_records` →
+  `summarize`) over mock sales data, shipped with two planted bugs (a wrong field name, a wrong
+  dict access), one per downstream step.
+- `agent_task.py` — the agent. It launches `workflow.main`, reads the failed action's error,
+  picks a patch from its playbook, edits `workflow.py` on the pod, reloads it, and forks the
+  failed run with the fixed code. It repeats until the workflow succeeds.
+
+Because each iteration **forks** the latest failed run, every action that already succeeded is
+reused: `load_records` executes exactly once across the whole debug session, and each fix
+re-executes only the step it repairs. That is the point of the example — fork turns the
+edit-run-observe debugging loop into something an agent can run cheaply inside the platform.
+
+`propose_fix` is a deterministic playbook so the example runs anywhere; in a real system that
+function is an LLM call (source + error message in, patch out). Forking does not care which
+produced the edit.
+
+## Run it
+
+Forking is remote-only, so the full story needs a Union backend:
+
+```bash
+uv run python agent_task.py
+```
+
+Watch the agent's logs: attempt 0 fails in `clean_records`, iteration 1 patches the field name
+and forks (reusing `load_records`), iteration 2 patches the summary and forks again (reusing
+`load_records` *and* `clean_records`), and the workflow succeeds.
+
+Running locally (`make test-local`) exercises the same loop without a control plane — the
+agent re-runs the patched workflow inline instead of forking.
+
+> The agent edits code that it then executes. Sandbox and review before pointing this pattern
+> at real code.

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/agent_task.py
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/agent_task.py
@@ -1,0 +1,216 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.6.5",
+#    "flyteplugins-union>=0.8.1",
+# ]
+# main = "agent"
+# params = ""
+# ///
+
+"""Agent-mediated forking: an agent task that develops and debugs a Flyte workflow.
+
+`workflow.py` next to this file is a toy data-processing pipeline that ships with bugs.
+Instead of a human in the debug loop, the `agent` task below closes the loop itself, from
+inside a Flyte pod:
+
+    1. Launch `workflow.main` as a real run and observe it fail.
+    2. Read the failed action's error message and pick a patch from its playbook.
+    3. Apply the patch to `workflow.py` on disk and reload the module.
+    4. `fork()` the failed run with the fixed code — reusing every action that already
+       succeeded, so only the broken step (and anything after it) re-executes.
+    5. Repeat until the run succeeds.
+
+That is the power of forking: each fix builds on the previous run's completed work instead of
+re-running the whole pipeline. Across this example's two bugs, `load_records` executes exactly
+once — every fix forks from the latest failed run.
+
+The "brain" here (`propose_fix`) is a deterministic playbook so the example runs anywhere. In
+a real system it is an LLM call — feed it the workflow source and the failed action's error
+message, and let it return the patch (see the agent tutorials under `v2/tutorials/`). Forking
+does not care which produced the edit.
+
+Notes:
+
+  * Forking is remote-only. When this example runs locally (no control plane), the agent falls
+    back to re-running the workflow inline after each patch — same loop, no action reuse.
+  * The agent edits code that it then runs. Treat this pattern with the sandboxing and review
+    it deserves before pointing it at real code.
+
+Run it (remote, the full story):
+
+    uv run python agent_task.py
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import flyte
+from flyte.models import ActionPhase
+from flyte.remote import Action
+from flyteplugins.union import fork
+
+# {{docs-fragment imports-and-env}}
+# Importing `workflow` here does two things: it makes `workflow.py` a loaded module, so it
+# ships in this file's code bundle, and it gives the agent its first handle on the pipeline.
+import workflow  # noqa: F401
+
+env = flyte.TaskEnvironment(
+    name="workflow_agent",
+    resources=flyte.Resources(cpu=1, memory="500Mi"),
+)
+
+WORKFLOW_FILE = Path(__file__).with_name("workflow.py")
+# {{/docs-fragment imports-and-env}}
+
+
+# {{docs-fragment playbook}}
+# The agent's playbook: (error signature, buggy snippet, fixed snippet). `propose_fix` picks
+# the patch whose signature matches the observed failure; a deterministic stand-in for an LLM.
+KNOWN_BUGS = [
+    ("KeyError", 'record["price"]', 'record["unit_price"]'),
+    ("TypeError", 'kv[1]["total"]', 'kv[1]'),
+]
+
+
+def propose_fix(source: str, error_message: str) -> tuple[str, str] | None:
+    """Pick the next patch: one that matches the error, else the first still-applicable one."""
+    applicable = [(old, new) for _, old, new in KNOWN_BUGS if old in source]
+    if not applicable:
+        return None
+    for hint, old, new in KNOWN_BUGS:
+        if old in source and hint.lower() in error_message.lower():
+            return old, new
+    return applicable[0]
+# {{/docs-fragment playbook}}
+
+
+def apply_patch(source: str, old: str, new: str) -> tuple[str, ModuleType]:
+    """Patch the workflow source and reload the module so the fix takes effect.
+
+    The fix is written to disk first: code bundles are built from the working tree, and child
+    actions re-import the module from disk, so the fix only counts once the file itself has
+    changed. In local runs the agent restores the file when it is done.
+    """
+    patched = source.replace(old, new)
+    WORKFLOW_FILE.write_text(patched, encoding="utf-8")
+    module = importlib.reload(sys.modules["workflow"])
+    return patched, module
+
+
+def _control_plane_available() -> bool:
+    """True in remote task pods, where runs can be launched and forked."""
+    try:
+        from flyte._initialize import get_client
+
+        return get_client() is not None
+    except Exception:
+        return False
+
+
+async def _first_failure(run_name: str) -> tuple[str, str]:
+    """The pipeline step that failed a run, and its error message."""
+    fallback: tuple[str, str] = ("unknown", "")
+    async for action in Action.listall.aio(for_run_name=run_name, in_phase=(ActionPhase.FAILED,)):
+        details = await action.details()
+        message = details.error_info.message if details.error_info else ""
+        if action.parent_name:  # a step inside the pipeline, not the root action
+            return action.task_name or action.name, message
+        if message and not fallback[1]:
+            fallback = (action.task_name or action.name, message)
+    return fallback
+
+
+# {{docs-fragment agent}}
+@env.task
+async def agent(n_records: int = 50, seed: int = 7, max_iterations: int = 5) -> dict:
+    """Run the develop-debug loop until `workflow.main` succeeds. Returns a report."""
+    remote = _control_plane_available()
+    original_source = WORKFLOW_FILE.read_text(encoding="utf-8")
+    source = original_source
+    wf = sys.modules["workflow"]
+    attempts: list[dict] = []
+    phase = ActionPhase.FAILED
+    run = None
+
+    # --- Attempt 0: run the workflow as written, and observe how it fails. ----------------
+    if remote:
+        run = await flyte.run.aio(wf.main, n_records=n_records, seed=seed)
+        print(f"[attempt 0] launched {run.name}: {run.url}")
+        await run.wait.aio(quiet=True)
+        phase = run.phase
+        failed_task, error = (
+            (None, "") if phase == ActionPhase.SUCCEEDED else await _first_failure(run.name)
+        )
+    else:
+        try:
+            await wf.main(n_records=n_records, seed=seed)
+            phase = ActionPhase.SUCCEEDED
+            failed_task, error = None, ""
+        except Exception as e:
+            failed_task, error = "workflow", f"{type(e).__name__}: {e}"
+            print(f"[attempt 0] failed: {error}")
+
+    # --- The loop: observe -> patch -> fork (or re-run locally) -> observe ... -----------
+    try:
+        for iteration in range(1, max_iterations + 1):
+            if phase == ActionPhase.SUCCEEDED:
+                break
+            if failed_task is None:
+                raise RuntimeError("the workflow failed, but no failed step was found")
+
+            patch = propose_fix(source, error or "")
+            if patch is None:
+                raise RuntimeError(f"the playbook has no patch left for: {error!r}")
+            old, new = patch
+            print(f"[iteration {iteration}] {failed_task} failed with: {error}")
+            print(f"[iteration {iteration}] patching {old!r} -> {new!r}")
+            source, wf = apply_patch(source, old, new)
+            attempts.append({"failed_task": failed_task, "error": error, "patch": f"{old} -> {new}"})
+
+            if remote:
+                # Fork the run that just failed: every action that succeeded in it is reused,
+                # and only the patched step (and anything downstream) re-executes.
+                run = await fork.aio(run.name, task_template=wf.main)
+                print(f"[iteration {iteration}] forked {run.name}: {run.url}")
+                await run.wait.aio(quiet=True)
+                phase = run.phase
+                failed_task, error = (
+                    (None, "") if phase == ActionPhase.SUCCEEDED else await _first_failure(run.name)
+                )
+            else:
+                # Local mode has no control plane to fork from — re-run the patched workflow.
+                try:
+                    await wf.main(n_records=n_records, seed=seed)
+                    phase = ActionPhase.SUCCEEDED
+                    failed_task, error = None, ""
+                except Exception as e:
+                    failed_task, error = "workflow", f"{type(e).__name__}: {e}"
+    finally:
+        if not remote:
+            # Leave the working tree as we found it: local patches are ephemeral.
+            WORKFLOW_FILE.write_text(original_source, encoding="utf-8")
+
+    if phase != ActionPhase.SUCCEEDED:
+        raise RuntimeError(f"the workflow still fails after {max_iterations} iterations: {error}")
+
+    print(f"[done] the workflow succeeds after {len(attempts)} patch(es)")
+    return {
+        "mode": "remote: fork reused every succeeded action" if remote else "local: fresh re-runs (fork is remote-only)",
+        "final_run": run.name if run is not None else "(local)",
+        "patches": json.dumps(attempts),
+        "iterations": str(len(attempts)),
+    }
+# {{/docs-fragment agent}}
+
+
+if __name__ == "__main__":
+    flyte.init_from_config()
+    run = flyte.run(agent)
+    print(run.name)
+    print(run.url)
+    run.wait()
+    print(run.outputs())

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/agent_task.py
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/agent_task.py
@@ -45,6 +45,8 @@ Run it (remote, the full story):
 import importlib
 import json
 import sys
+import types
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 
@@ -61,52 +63,114 @@ import workflow  # noqa: F401
 env = flyte.TaskEnvironment(
     name="workflow_agent",
     resources=flyte.Resources(cpu=1, memory="500Mi"),
+    image=flyte.Image.from_uv_script(__file__, name="agent_mediated_form")
 )
+
+@dataclass
+class ForkSummary:
+    """A summary of a forked run, for tracing and debugging."""
+
+    run_url: str
+    error: str
+    old_snippet: str
+    new_snippet: str
 
 WORKFLOW_FILE = Path(__file__).with_name("workflow.py")
 # {{/docs-fragment imports-and-env}}
 
 
 # {{docs-fragment playbook}}
-# The agent's playbook: (error signature, buggy snippet, fixed snippet). `propose_fix` picks
-# the patch whose signature matches the observed failure; a deterministic stand-in for an LLM.
+# The agent's playbook: (failing task, error signature, buggy snippet, fixed snippet).
+# `propose_fix` picks the patch for the step that failed; a deterministic stand-in for an LLM.
 KNOWN_BUGS = [
-    ("KeyError", 'record["price"]', 'record["unit_price"]'),
-    ("TypeError", 'kv[1]["total"]', 'kv[1]'),
+    ("clean_records", "KeyError", 'record["price"]', 'record["unit_price"]'),
+    ("summarize", "TypeError", 'kv[1]["total"]', 'kv[1]'),
 ]
 
 
-def propose_fix(source: str, error_message: str) -> tuple[str, str] | None:
-    """Pick the next patch: one that matches the error, else the first still-applicable one."""
-    applicable = [(old, new) for _, old, new in KNOWN_BUGS if old in source]
+def propose_fix(source: str, failed_task: str, error_message: str) -> tuple[str, str] | None:
+    """Pick the next patch: the one for the step that failed, else the first still-applicable.
+
+    Matching prefers the failed task's name (always available, stable), then the error's type
+    signature (platforms sometimes strip it down to the bare message), and finally falls back
+    to the first patch whose buggy snippet is still in the source.
+    """
+    applicable = [(old, new) for _, _, old, new in KNOWN_BUGS if old in source]
     if not applicable:
         return None
-    for hint, old, new in KNOWN_BUGS:
-        if old in source and hint.lower() in error_message.lower():
+    lowered = (failed_task or "").lower()
+    for task, hint, old, new in KNOWN_BUGS:
+        if old in source and task in lowered:
+            return old, new
+    lowered_err = (error_message or "").lower()
+    for _, hint, old, new in KNOWN_BUGS:
+        if old in source and hint.lower() in lowered_err:
             return old, new
     return applicable[0]
 # {{/docs-fragment playbook}}
 
 
-def apply_patch(source: str, old: str, new: str) -> tuple[str, ModuleType]:
+def _force_fresh_code_bundle() -> None:
+    """Make the next launch/fork bundle the working tree as it is *now*.
+
+    `flyte._code_bundle.bundle.build_code_bundle` is memoized in-process on its arguments
+    alone, so the agent's first launch caches its code bundle and every later fork in this pod
+    would replay that original bundle — edits and all. Clearing the memo forces a fresh bundle;
+    the persistent cache underneath is keyed on a content digest, so it misses and re-uploads.
+    """
+    try:
+        from flyte._code_bundle import bundle as _bundle
+
+        _bundle.build_code_bundle.cache_clear()
+        _bundle.build_code_bundle_from_relative_paths.cache_clear()
+    except Exception:  # best effort: bundling internals may move between releases
+        pass
+
+
+def apply_patch(source: str, old: str, new: str, *, write_to_disk: bool) -> tuple[str, ModuleType]:
     """Patch the workflow source and reload the module so the fix takes effect.
 
-    The fix is written to disk first: code bundles are built from the working tree, and child
-    actions re-import the module from disk, so the fix only counts once the file itself has
-    changed. In local runs the agent restores the file when it is done.
+    Remote runs write the fix to disk first: a fork's code bundle is built from the working
+    tree, so the forked run only sees the fix if the file itself changed. Local runs execute
+    the workflow inline from the module object, so they reload in memory and leave the file
+    alone.
     """
     patched = source.replace(old, new)
-    WORKFLOW_FILE.write_text(patched, encoding="utf-8")
-    module = importlib.reload(sys.modules["workflow"])
+    if write_to_disk:
+        WORKFLOW_FILE.write_text(patched, encoding="utf-8")
+        _force_fresh_code_bundle()
+        module = importlib.reload(sys.modules["workflow"])
+    else:
+        module = types.ModuleType("workflow")
+        module.__file__ = str(WORKFLOW_FILE)
+        exec(compile(patched, str(WORKFLOW_FILE), "exec"), module.__dict__)
+        sys.modules["workflow"] = module
     return patched, module
 
 
-def _control_plane_available() -> bool:
-    """True in remote task pods, where runs can be launched and forked."""
-    try:
-        from flyte._initialize import get_client
+async def run_workflow_inline(wf: ModuleType, n_records: int, seed: int) -> dict:
+    """Local mode: run the workflow's steps in-process, straight from the module object.
 
-        return get_client() is not None
+    Child actions would re-import the workflow from the code bundle captured when the agent
+    run launched, so patches would never reach them. Calling the tasks' raw functions runs
+    exactly what the module holds right now — which is what the loop needs.
+    """
+    records = await wf.load_records.func(n_records=n_records, seed=seed)
+    cleaned = await wf.clean_records.func(records)
+    return await wf.summarize.func(cleaned)
+
+
+def _control_plane_available() -> bool:
+    """True when the agent runs on a real backend, where runs can be launched and forked.
+
+    A configured client is not enough — `flyte run --local` initializes one too. The controller
+    is what decides: only the remote controller submits runs the fork API can replay.
+    """
+    try:
+        from flyte._internal.controllers import get_controller
+        from flyte._internal.controllers.remote._controller import RemoteController
+
+        return isinstance(get_controller(), RemoteController)
     except Exception:
         return False
 
@@ -129,14 +193,14 @@ async def _first_failure(run_name: str) -> tuple[str, str]:
 async def agent(n_records: int = 50, seed: int = 7, max_iterations: int = 5) -> dict:
     """Run the develop-debug loop until `workflow.main` succeeds. Returns a report."""
     remote = _control_plane_available()
-    original_source = WORKFLOW_FILE.read_text(encoding="utf-8")
-    source = original_source
+    source = WORKFLOW_FILE.read_text(encoding="utf-8")
     wf = sys.modules["workflow"]
     attempts: list[dict] = []
     phase = ActionPhase.FAILED
     run = None
 
     # --- Attempt 0: run the workflow as written, and observe how it fails. ----------------
+    final_outputs = None
     if remote:
         run = await flyte.run.aio(wf.main, n_records=n_records, seed=seed)
         print(f"[attempt 0] launched {run.name}: {run.url}")
@@ -145,9 +209,15 @@ async def agent(n_records: int = 50, seed: int = 7, max_iterations: int = 5) -> 
         failed_task, error = (
             (None, "") if phase == ActionPhase.SUCCEEDED else await _first_failure(run.name)
         )
+
+        @flyte.trace
+        async def workflow_run_url() -> str:
+            return run.url
+
+        await workflow_run_url()
     else:
         try:
-            await wf.main(n_records=n_records, seed=seed)
+            final_outputs = await run_workflow_inline(wf, n_records, seed)
             phase = ActionPhase.SUCCEEDED
             failed_task, error = None, ""
         except Exception as e:
@@ -155,47 +225,52 @@ async def agent(n_records: int = 50, seed: int = 7, max_iterations: int = 5) -> 
             print(f"[attempt 0] failed: {error}")
 
     # --- The loop: observe -> patch -> fork (or re-run locally) -> observe ... -----------
-    try:
-        for iteration in range(1, max_iterations + 1):
-            if phase == ActionPhase.SUCCEEDED:
-                break
-            if failed_task is None:
-                raise RuntimeError("the workflow failed, but no failed step was found")
+    for iteration in range(1, max_iterations + 1):
+        if phase == ActionPhase.SUCCEEDED:
+            break
+        if failed_task is None:
+            raise RuntimeError("the workflow failed, but no failed step was found")
 
-            patch = propose_fix(source, error or "")
-            if patch is None:
-                raise RuntimeError(f"the playbook has no patch left for: {error!r}")
-            old, new = patch
-            print(f"[iteration {iteration}] {failed_task} failed with: {error}")
-            print(f"[iteration {iteration}] patching {old!r} -> {new!r}")
-            source, wf = apply_patch(source, old, new)
-            attempts.append({"failed_task": failed_task, "error": error, "patch": f"{old} -> {new}"})
+        patch = propose_fix(source, failed_task or "", error or "")
+        if patch is None:
+            raise RuntimeError(f"the playbook has no patch left for: {error!r}")
+        old, new = patch
+        print(f"[iteration {iteration}] {failed_task} failed with: {error}")
+        print(f"[iteration {iteration}] patching {old!r} -> {new!r}")
+        source, wf = apply_patch(source, old, new, write_to_disk=remote)
+        attempts.append({"failed_task": failed_task, "error": error, "patch": f"{old} -> {new}"})
 
-            if remote:
-                # Fork the run that just failed: every action that succeeded in it is reused,
-                # and only the patched step (and anything downstream) re-executes.
-                run = await fork.aio(run.name, task_template=wf.main)
-                print(f"[iteration {iteration}] forked {run.name}: {run.url}")
-                await run.wait.aio(quiet=True)
-                phase = run.phase
-                failed_task, error = (
-                    (None, "") if phase == ActionPhase.SUCCEEDED else await _first_failure(run.name)
-                )
-            else:
-                # Local mode has no control plane to fork from — re-run the patched workflow.
-                try:
-                    await wf.main(n_records=n_records, seed=seed)
-                    phase = ActionPhase.SUCCEEDED
-                    failed_task, error = None, ""
-                except Exception as e:
-                    failed_task, error = "workflow", f"{type(e).__name__}: {e}"
-    finally:
-        if not remote:
-            # Leave the working tree as we found it: local patches are ephemeral.
-            WORKFLOW_FILE.write_text(original_source, encoding="utf-8")
+        if remote:
+            # Fork the run that just failed: every action that succeeded in it is reused,
+            # and only the patched step (and anything downstream) re-executes.
+            run = await fork.aio(run.name, task_template=wf.main)
+            print(f"[iteration {iteration}] forked {run.name}: {run.url}")
+            await run.wait.aio(quiet=True)
+            phase = run.phase
+            failed_task, error = (
+                (None, "") if phase == ActionPhase.SUCCEEDED else await _first_failure(run.name)
+            )
+
+            @flyte.trace
+            async def fork_run_summary() -> ForkSummary:
+                return ForkSummary(run.url, error, old, new)
+
+            await fork_run_summary()
+        else:
+            # Local mode has no control plane to fork from — re-run the patched workflow inline.
+            try:
+                final_outputs = await run_workflow_inline(wf, n_records, seed)
+                phase = ActionPhase.SUCCEEDED
+                failed_task, error = None, ""
+            except Exception as e:
+                failed_task, error = "workflow", f"{type(e).__name__}: {e}"
 
     if phase != ActionPhase.SUCCEEDED:
         raise RuntimeError(f"the workflow still fails after {max_iterations} iterations: {error}")
+
+    if remote and run is not None:
+        outputs = await run.outputs.aio()
+        final_outputs = list(outputs)[0] if len(outputs) else None
 
     print(f"[done] the workflow succeeds after {len(attempts)} patch(es)")
     return {
@@ -203,6 +278,7 @@ async def agent(n_records: int = 50, seed: int = 7, max_iterations: int = 5) -> 
         "final_run": run.name if run is not None else "(local)",
         "patches": json.dumps(attempts),
         "iterations": str(len(attempts)),
+        "outputs": json.dumps(final_outputs),
     }
 # {{/docs-fragment agent}}
 

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/workflow.py
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/workflow.py
@@ -1,0 +1,95 @@
+"""A toy data-processing workflow — developed (and debugged) by an agent.
+
+This is the workflow the agent in `agent_task.py` runs, observes, patches, and forks until it
+passes. It processes mock sales records through three steps:
+
+    load_records -> clean_records -> summarize
+
+It ships with two planted bugs, one per downstream step, so the agent's
+observe -> patch -> fork loop has real work to do — and so each fork reuses everything
+upstream of the fix:
+
+  * `clean_records` reads a `price` field that does not exist — the field is called
+    `unit_price` — so it dies with `KeyError: 'price'` on the first record.
+  * `summarize` treats the per-region averages as dicts when they are floats, and dies with
+    `TypeError: 'float' object is not subscriptable`.
+
+This file is intentionally a plain module: it is launched by the agent (and forked with the
+agent's patches), not run directly.
+"""
+
+import asyncio
+import random
+
+import flyte
+
+env = flyte.TaskEnvironment(
+    name="toy_sales_pipeline",
+    resources=flyte.Resources(cpu=1, memory="250Mi"),
+)
+
+REGIONS = ("AMER", "EMEA", "APAC")
+
+
+# {{docs-fragment workflow}}
+@env.task
+async def load_records(n_records: int, seed: int) -> list[dict]:
+    """Ingest mock sales records (stand-in for a slow data source)."""
+    rng = random.Random(seed)
+    records = [
+        {
+            "id": i,
+            "region": rng.choice(REGIONS),
+            "units": rng.randint(1, 100),
+            "unit_price": round(rng.uniform(5.0, 50.0), 2),
+        }
+        for i in range(n_records)
+    ]
+    print(f"load_records: ingested {n_records} records")
+    await asyncio.sleep(2)  # stand-in for a real ingestion cost
+    return records
+
+
+@env.task
+async def clean_records(records: list[dict]) -> list[dict]:
+    """Derive per-record revenue."""
+    cleaned = []
+    for record in records:
+        record = dict(record)
+        # BUG 1: the field is called "unit_price", not "price" -> KeyError on every record.
+        record["revenue"] = record["units"] * record["unit_price"]
+        cleaned.append(record)
+    print(f"clean_records: derived revenue for {len(cleaned)} records")
+    await asyncio.sleep(2)
+    return cleaned
+
+
+@env.task
+async def summarize(records: list[dict]) -> dict:
+    """Average revenue per region and pick the top region."""
+    totals: dict[str, float] = {}
+    counts: dict[str, int] = {}
+    for record in records:
+        region = record["region"]
+        totals[region] = totals.get(region, 0.0) + record["revenue"]
+        counts[region] = counts.get(region, 0) + 1
+    averages = {region: totals[region] / counts[region] for region in totals}
+    # BUG 2: the averages are floats, not dicts -> TypeError: 'float' is not subscriptable.
+    top_region, top_average = max(averages.items(), key=lambda kv: kv[1])
+    summary = {
+        "average_revenue_by_region": averages,
+        "top_region": top_region,
+        "top_region_average_revenue": top_average,
+    }
+    print(f"summarize: {summary}")
+    await asyncio.sleep(2)
+    return summary
+
+
+@env.task
+async def main(n_records: int = 50, seed: int = 7) -> dict:
+    """The whole toy pipeline."""
+    records = await load_records(n_records, seed)
+    cleaned = await clean_records(records)
+    return await summarize(cleaned)
+# {{/docs-fragment workflow}}

--- a/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/workflow.py
+++ b/v2/user-guide/task-deployment/fork-runs/agent-mediated-fork/workflow.py
@@ -57,7 +57,7 @@ async def clean_records(records: list[dict]) -> list[dict]:
     for record in records:
         record = dict(record)
         # BUG 1: the field is called "unit_price", not "price" -> KeyError on every record.
-        record["revenue"] = record["units"] * record["unit_price"]
+        record["revenue"] = record["units"] * record["price"]
         cleaned.append(record)
     print(f"clean_records: derived revenue for {len(cleaned)} records")
     await asyncio.sleep(2)
@@ -75,7 +75,7 @@ async def summarize(records: list[dict]) -> dict:
         counts[region] = counts.get(region, 0) + 1
     averages = {region: totals[region] / counts[region] for region in totals}
     # BUG 2: the averages are floats, not dicts -> TypeError: 'float' is not subscriptable.
-    top_region, top_average = max(averages.items(), key=lambda kv: kv[1])
+    top_region, top_average = max(averages.items(), key=lambda kv: kv[1]["total"])
     summary = {
         "average_revenue_by_region": averages,
         "top_region": top_region,

--- a/v2/user-guide/task-deployment/fork-runs/ml_pipeline.py
+++ b/v2/user-guide/task-deployment/fork-runs/ml_pipeline.py
@@ -160,7 +160,11 @@ async def evaluate(model: Model, data: Dataset, threshold: float) -> EvaluationR
             confident_correct += int(pred == y)
 
     accuracy = correct / len(data.labels)
-    confident_accuracy = confident_correct / confident_count  # <- ZeroDivisionError when empty
+    confident_accuracy = (
+        confident_correct / confident_count  # BUG: ZeroDivisionError when confident_count == 0
+        if confident_count > 0
+        else 0.0  # <- fix: avoid ZeroDivisionError when empty
+    )
 
     approved = confident_accuracy >= 0.85
     print(
@@ -193,7 +197,7 @@ async def main(
 def summarize(run_name: str) -> None:
     """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
     for action in Action.listall(for_run_name=run_name):
-        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase.value}")
 
 
 # {{docs-fragment launch-failing-run}}
@@ -206,14 +210,14 @@ if __name__ == "__main__":
     run = flyte.run(main, threshold=1.0)
     print(f"seed run: {run.name}\n  {run.url}")
     run.wait(quiet=True)
-    print(f"  finished in phase: {run.phase}  (expected: ZeroDivisionError in evaluate)")
+    print(f"  finished in phase: {run.phase.value}  (expected: ZeroDivisionError in evaluate)")
     summarize(run.name)
     assert run.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
 
     print(
         "\nNext steps:\n"
         "  1. Apply the one-line fix to `evaluate` (see ml_pipeline_fixed.py).\n"
-        f"  2. flyte fork {run.name} ml_pipeline.py main --follow\n"
+        f"  2. flyte fork --follow {run.name} ml_pipeline.py main\n"
         "Or run the automated tour:  uv run python ml_pipeline_fixed.py"
     )
 # {{/docs-fragment launch-failing-run}}

--- a/v2/user-guide/task-deployment/fork-runs/ml_pipeline.py
+++ b/v2/user-guide/task-deployment/fork-runs/ml_pipeline.py
@@ -1,0 +1,219 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.6.5",
+#    "flyteplugins-union>=0.8.1",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+"""Fork a failed ML training pipeline: fix the code, keep the completed work.
+
+Same pipeline as the recovery example — load, preprocess, train, then `evaluate` registers the
+result with the validation service — but this time the failure is not a flaky dependency. It is
+a bug in our own code: `evaluate` divides by the number of predictions that clear
+`threshold`, and when a release evaluation runs with `threshold=1.0` (a legitimate "how many
+predictions are *certain*?" query), nothing clears it and the task dies at the very last step
+with a `ZeroDivisionError`.
+
+Recovery cannot help here — it replays the source run's code as-is, so the recovered run would
+hit the same division by zero. The fix is a code change, and `flyte fork` is the verb for it:
+it replays the run with the code in your working tree, reusing every action whose code and
+inputs are unchanged. Edit `evaluate`, fork the failed run, and load / preprocess / train are
+reused while only `evaluate` re-executes.
+
+This file ships in the buggy state (the code that was deployed when the run failed). The
+corrected version lives in `ml_pipeline_fixed.py`, which also automates the whole tour: launch
+the buggy pipeline, fork it with the fix, and print which actions were reused.
+
+--------------------------------------------------------------------------------------------
+The manual flow (what you would actually do)
+--------------------------------------------------------------------------------------------
+Requires `flyteplugins-union` (`pip install flyteplugins-union`), which ships `flyte fork`.
+
+    # 1. Launch the pipeline as deployed. A threshold of 1.0 trips the bug in `evaluate`.
+    flyte run ml_pipeline.py main --threshold 1.0
+    # -> fails at evaluate: ZeroDivisionError: division by zero
+
+    # 2. Fix `evaluate` in this file (the one-line change shown in ml_pipeline_fixed.py):
+    #        confident_accuracy = confident_correct / confident_count if confident_count else 0.0
+
+    # 3. Fork the failed run with your edited working tree. Actions whose code and inputs are
+    #    unchanged — load_dataset, preprocess, train — are reused; only evaluate re-executes.
+    flyte fork <RUN> ml_pipeline.py main --follow
+
+    # Inspect what the fork reused — reused actions show up as RECOVERED:
+    flyte get action <FORKED_RUN>
+
+Or run the automated end-to-end tour:
+
+    uv run python ml_pipeline_fixed.py
+"""
+
+import asyncio
+import math
+import random
+from dataclasses import dataclass
+
+import flyte
+from flyte.models import ActionPhase
+from flyte.remote import Action
+
+env = flyte.TaskEnvironment(
+    name="ml_pipeline",
+    resources=flyte.Resources(cpu=1, memory="500Mi"),
+)
+
+
+@dataclass
+class Dataset:
+    features: list[list[float]]
+    labels: list[int]
+
+
+@dataclass
+class Model:
+    weights: list[float]
+    bias: float
+
+
+@dataclass
+class EvaluationReport:
+    accuracy: float
+    confident_accuracy: float
+    confident_count: int
+    approved: bool
+
+
+# {{docs-fragment pipeline}}
+@env.task
+async def load_dataset(n_samples: int, seed: int) -> Dataset:
+    """Pull a synthetic training set from the (mock) feature store."""
+    rng = random.Random(seed)
+    features, labels = [], []
+    for _ in range(n_samples):
+        label = rng.randint(0, 1)
+        center = 2.0 if label else -2.0
+        features.append([rng.gauss(center, 1.0), rng.gauss(center, 1.0)])
+        labels.append(label)
+    print(f"load_dataset: loaded {n_samples} samples")
+    await asyncio.sleep(2)  # stand-in for a slow warehouse read
+    return Dataset(features=features, labels=labels)
+
+
+@env.task
+async def preprocess(data: Dataset) -> Dataset:
+    """Standardize features to zero mean and unit variance."""
+    n = len(data.features)
+    means = [sum(f[j] for f in data.features) / n for j in range(2)]
+    stds = [
+        max(math.sqrt(sum((f[j] - means[j]) ** 2 for f in data.features) / n), 1e-9)
+        for j in range(2)
+    ]
+    scaled = [[(f[j] - means[j]) / stds[j] for j in range(2)] for f in data.features]
+    print(f"preprocess: standardized {n} rows")
+    await asyncio.sleep(2)  # stand-in for an expensive feature transformation
+    return Dataset(features=scaled, labels=data.labels)
+
+
+@env.task
+async def train(data: Dataset, epochs: int) -> Model:
+    """Fit a small logistic-regression model with gradient descent."""
+    w = [0.0, 0.0]
+    b = 0.0
+    lr = 0.1
+    n = len(data.features)
+    for _ in range(epochs):
+        gw0 = gw1 = gb = 0.0
+        for x, y in zip(data.features, data.labels):
+            p = 1.0 / (1.0 + math.exp(-(w[0] * x[0] + w[1] * x[1] + b)))
+            err = p - y
+            gw0 += err * x[0]
+            gw1 += err * x[1]
+            gb += err
+        w[0] -= lr * gw0 / n
+        w[1] -= lr * gw1 / n
+        b -= lr * gb / n
+    print(f"train: fitted for {epochs} epochs, weights={[round(wi, 3) for wi in w]}")
+    await asyncio.sleep(2)  # stand-in for a real training loop
+    return Model(weights=w, bias=b)
+# {{/docs-fragment pipeline}}
+
+
+# {{docs-fragment evaluate-buggy}}
+@env.task
+async def evaluate(model: Model, data: Dataset, threshold: float) -> EvaluationReport:
+    """Score the model, then register the result with the validation service.
+
+    BUG: `confident_correct / confident_count` raises `ZeroDivisionError` when no prediction
+    clears `threshold` (e.g. the release query `--threshold 1.0`), failing the whole run at
+    the very last step.
+    """
+    correct = confident_correct = confident_count = 0
+    for x, y in zip(data.features, data.labels):
+        p = 1.0 / (1.0 + math.exp(-(model.weights[0] * x[0] + model.weights[1] * x[1] + model.bias)))
+        pred = int(p >= 0.5)
+        correct += int(pred == y)
+        if max(p, 1.0 - p) > threshold:
+            confident_count += 1
+            confident_correct += int(pred == y)
+
+    accuracy = correct / len(data.labels)
+    confident_accuracy = confident_correct / confident_count  # <- ZeroDivisionError when empty
+
+    approved = confident_accuracy >= 0.85
+    print(
+        f"evaluate: accuracy={accuracy:.3f} confident_accuracy={confident_accuracy:.3f} "
+        f"({confident_count} samples above threshold={threshold}) approved={approved}"
+    )
+    return EvaluationReport(
+        accuracy=accuracy,
+        confident_accuracy=confident_accuracy,
+        confident_count=confident_count,
+        approved=approved,
+    )
+# {{/docs-fragment evaluate-buggy}}
+
+
+@env.task
+async def main(
+    n_samples: int = 2000,
+    seed: int = 7,
+    epochs: int = 5,
+    threshold: float = 0.6,
+) -> EvaluationReport:
+    """Load, preprocess, train, evaluate — the whole nightly pipeline."""
+    data = await load_dataset(n_samples, seed)
+    clean = await preprocess(data)
+    model = await train(clean, epochs)
+    return await evaluate(model, clean, threshold)
+
+
+def summarize(run_name: str) -> None:
+    """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
+    for action in Action.listall(for_run_name=run_name):
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+
+
+# {{docs-fragment launch-failing-run}}
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    # Launch the pipeline as deployed, with the release-evaluation threshold that trips the
+    # bug. Everything succeeds until `evaluate` — the very last step — divides by zero.
+    #     CLI: flyte run ml_pipeline.py main --threshold 1.0
+    run = flyte.run(main, threshold=1.0)
+    print(f"seed run: {run.name}\n  {run.url}")
+    run.wait(quiet=True)
+    print(f"  finished in phase: {run.phase}  (expected: ZeroDivisionError in evaluate)")
+    summarize(run.name)
+    assert run.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
+
+    print(
+        "\nNext steps:\n"
+        "  1. Apply the one-line fix to `evaluate` (see ml_pipeline_fixed.py).\n"
+        f"  2. flyte fork {run.name} ml_pipeline.py main --follow\n"
+        "Or run the automated tour:  uv run python ml_pipeline_fixed.py"
+    )
+# {{/docs-fragment launch-failing-run}}

--- a/v2/user-guide/task-deployment/fork-runs/ml_pipeline_fixed.py
+++ b/v2/user-guide/task-deployment/fork-runs/ml_pipeline_fixed.py
@@ -1,0 +1,143 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.6.5",
+#    "flyteplugins-union>=0.8.1",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+"""The same ML pipeline, one commit later: `evaluate` fixed, ready to fork.
+
+This is the state of the code after the one-line fix to `evaluate` from `ml_pipeline.py`:
+
+    - confident_accuracy = confident_correct / confident_count
+    + confident_accuracy = confident_correct / confident_count if confident_count else 0.0
+
+`load_dataset`, `preprocess` and `train` are imported unchanged from `ml_pipeline.py`, and
+`main`'s body is identical, so forking a failed run of `ml_pipeline.py` with this file's
+`main` reuses every one of their actions and re-executes only `evaluate`:
+
+    # Manual flow — fork the failed run with your edited working tree:
+    flyte fork <RUN> ml_pipeline.py main --follow          # after editing ml_pipeline.py
+    flyte fork <RUN> ml_pipeline_fixed.py main --follow    # or fork this file directly
+
+    # Programmatic flow — same thing, from Python:
+    from flyteplugins.union import fork
+    forked = fork("<RUN>", task_template=main)
+
+Run the automated end-to-end tour (remote only — forking has no local equivalent):
+
+    uv run python ml_pipeline_fixed.py            # launches the buggy run, then forks it
+    uv run python ml_pipeline_fixed.py <RUN>      # ...or fork a run you launched yourself
+"""
+
+import math
+import sys
+
+import flyte
+from flyte.models import ActionPhase
+from flyte.remote import Action
+from flyteplugins.union import fork
+
+# {{docs-fragment fixed-code}}
+# The upstream steps are unchanged by the fix — importing them guarantees their task
+# identities are exactly the ones the failed run recorded, so a fork reuses them as-is.
+from ml_pipeline import (
+    Dataset,
+    EvaluationReport,
+    Model,
+    env,
+    load_dataset,
+    preprocess,
+    train,
+)
+
+
+@env.task
+async def evaluate(model: Model, data: Dataset, threshold: float) -> EvaluationReport:
+    """Score the model, then register the result with the validation service.
+
+    FIXED: an empty confident subset reports a confident accuracy of 0.0 instead of raising
+    `ZeroDivisionError`.
+    """
+    correct = confident_correct = confident_count = 0
+    for x, y in zip(data.features, data.labels):
+        p = 1.0 / (1.0 + math.exp(-(model.weights[0] * x[0] + model.weights[1] * x[1] + model.bias)))
+        pred = int(p >= 0.5)
+        correct += int(pred == y)
+        if max(p, 1.0 - p) > threshold:
+            confident_count += 1
+            confident_correct += int(pred == y)
+
+    accuracy = correct / len(data.labels)
+    confident_accuracy = (
+        confident_correct / confident_count if confident_count else 0.0  # <- the fix
+    )
+
+    approved = confident_accuracy >= 0.85
+    print(
+        f"evaluate: accuracy={accuracy:.3f} confident_accuracy={confident_accuracy:.3f} "
+        f"({confident_count} samples above threshold={threshold}) approved={approved}"
+    )
+    return EvaluationReport(
+        accuracy=accuracy,
+        confident_accuracy=confident_accuracy,
+        confident_count=confident_count,
+        approved=approved,
+    )
+
+
+@env.task
+async def main(
+    n_samples: int = 2000,
+    seed: int = 7,
+    epochs: int = 5,
+    threshold: float = 0.6,
+) -> EvaluationReport:
+    """Load, preprocess, train, evaluate — the whole nightly pipeline."""
+    data = await load_dataset(n_samples, seed)
+    clean = await preprocess(data)
+    model = await train(clean, epochs)
+    return await evaluate(model, clean, threshold)
+# {{/docs-fragment fixed-code}}
+
+
+def summarize(run_name: str) -> None:
+    """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
+    for action in Action.listall(for_run_name=run_name):
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+
+
+# {{docs-fragment fork-tour}}
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    if len(sys.argv) > 1:
+        # Fork a run you launched yourself (e.g. via `flyte run ml_pipeline.py main --threshold 1.0`).
+        source_name = sys.argv[1]
+    else:
+        # Automated tour: first launch the buggy pipeline exactly as it was deployed.
+        # A threshold of 1.0 trips the ZeroDivisionError in `evaluate`.
+        import ml_pipeline
+
+        seed = flyte.run(ml_pipeline.main, threshold=1.0)
+        print(f"seed run (buggy code): {seed.name}\n  {seed.url}")
+        seed.wait(quiet=True)
+        print(f"  finished in phase: {seed.phase}  (expected: ZeroDivisionError in evaluate)")
+        summarize(seed.name)
+        assert seed.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
+        source_name = seed.name
+
+    # Fork the failed run with this file's code: the fix to `evaluate` is the only change, so
+    # load_dataset / preprocess / train are reused and only `evaluate` re-executes.
+    #     CLI: flyte fork <RUN> ml_pipeline_fixed.py main --follow
+    forked = fork(source_name, task_template=main)
+    print(f"\nfork {source_name} -> {forked.name}\n  {forked.url}")
+    forked.wait()
+    print(f"  finished in phase: {forked.phase}")
+    print("  (load_dataset / preprocess / train should read RECOVERED; evaluate re-executed)")
+    summarize(forked.name)
+    assert forked.phase == ActionPhase.SUCCEEDED, "the forked run should complete"
+# {{/docs-fragment fork-tour}}

--- a/v2/user-guide/task-deployment/fork-runs/ml_pipeline_fixed.py
+++ b/v2/user-guide/task-deployment/fork-runs/ml_pipeline_fixed.py
@@ -73,7 +73,9 @@ async def evaluate(model: Model, data: Dataset, threshold: float) -> EvaluationR
 
     accuracy = correct / len(data.labels)
     confident_accuracy = (
-        confident_correct / confident_count if confident_count else 0.0  # <- the fix
+        confident_correct / confident_count
+        if confident_count
+        else 0.0  # <- the fix
     )
 
     approved = confident_accuracy >= 0.85
@@ -107,7 +109,7 @@ async def main(
 def summarize(run_name: str) -> None:
     """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
     for action in Action.listall(for_run_name=run_name):
-        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase.value}")
 
 
 # {{docs-fragment fork-tour}}
@@ -125,7 +127,7 @@ if __name__ == "__main__":
         seed = flyte.run(ml_pipeline.main, threshold=1.0)
         print(f"seed run (buggy code): {seed.name}\n  {seed.url}")
         seed.wait(quiet=True)
-        print(f"  finished in phase: {seed.phase}  (expected: ZeroDivisionError in evaluate)")
+        print(f"  finished in phase: {seed.phase.value}  (expected: ZeroDivisionError in evaluate)")
         summarize(seed.name)
         assert seed.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
         source_name = seed.name
@@ -136,7 +138,7 @@ if __name__ == "__main__":
     forked = fork(source_name, task_template=main)
     print(f"\nfork {source_name} -> {forked.name}\n  {forked.url}")
     forked.wait()
-    print(f"  finished in phase: {forked.phase}")
+    print(f"  finished in phase: {forked.phase.value}")
     print("  (load_dataset / preprocess / train should read RECOVERED; evaluate re-executed)")
     summarize(forked.name)
     assert forked.phase == ActionPhase.SUCCEEDED, "the forked run should complete"

--- a/v2/user-guide/task-deployment/recover-runs/README.md
+++ b/v2/user-guide/task-deployment/recover-runs/README.md
@@ -1,0 +1,35 @@
+# Recover a failed run — ML pipeline example
+
+A nightly ML pipeline (load → preprocess → train → evaluate) that fails at the very last step
+because the external model-validation service is down for maintenance — simulated with the
+`VALIDATION_SERVICE_OUTAGE` env var so the failure is reproducible.
+
+`ml_pipeline.py` runs the whole tour against a Union backend:
+
+1. **The failure.** The run is launched during the simulated outage and fails at `evaluate`,
+   after the expensive steps have all succeeded.
+2. **Recover.** `flyte.rerun(run, recover=True)` (CLI: `flyte rerun <run> --recover`) relaunches
+   the run with the outage switch cleared. `load_dataset`, `preprocess` and `train` land in the
+   `RECOVERED` phase — reused, never re-executed — and only `evaluate` runs. The pipeline
+   completes.
+3. **Recover with changed inputs.** The eval threshold should have been `0.9`. Since `threshold`
+   feeds only `evaluate`, `flyte.rerun(run, recover=True, threshold=0.9)` re-executes only
+   `evaluate`; every upstream action is reused as-is.
+
+## Run it
+
+Recovery is remote-only — you need a configured Union backend (`flyte.init_from_config()`).
+
+```bash
+# End-to-end tour (all three phases):
+uv run python ml_pipeline.py
+
+# Or step by step, from the CLI:
+flyte run ml_pipeline.py main -e VALIDATION_SERVICE_OUTAGE=1
+flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --follow
+flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 --follow
+flyte get action <RECOVERED_RUN>     # reused actions show up as RECOVERED
+```
+
+Embedded in the [Recover a run](https://www.union.ai/docs/v2/union/user-guide/tasks/task-deployment/recover-runs/)
+user guide page.

--- a/v2/user-guide/task-deployment/recover-runs/README.md
+++ b/v2/user-guide/task-deployment/recover-runs/README.md
@@ -15,19 +15,25 @@ because the external model-validation service is down for maintenance — simula
 3. **Recover with changed inputs.** The eval threshold should have been `0.9`. Since `threshold`
    feeds only `evaluate`, `flyte.rerun(run, recover=True, threshold=0.9)` re-executes only
    `evaluate`; every upstream action is reused as-is.
+4. **Recover with a forced re-run.** `train` succeeded in the source run, so recovery would
+   reuse it. Naming it in `force_rerun_actions` re-executes it anyway — handy when you want a
+   fresh model before re-evaluating, and it re-enqueues its children too.
 
 ## Run it
 
 Recovery is remote-only — you need a configured Union backend (`flyte.init_from_config()`).
 
 ```bash
-# End-to-end tour (all three phases):
+# End-to-end tour (all four phases):
 uv run python ml_pipeline.py
 
 # Or step by step, from the CLI:
 flyte run ml_pipeline.py main -e VALIDATION_SERVICE_OUTAGE=1
 flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --follow
 flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 --follow
+flyte get action <RUN>     # copy the train action's name
+flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 \
+    --force-rerun-action <TRAIN_ACTION> --follow
 flyte get action <RECOVERED_RUN>     # reused actions show up as RECOVERED
 ```
 

--- a/v2/user-guide/task-deployment/recover-runs/ml_pipeline.py
+++ b/v2/user-guide/task-deployment/recover-runs/ml_pipeline.py
@@ -1,0 +1,256 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.6.5",
+# ]
+# main = "main"
+# params = ""
+# ///
+
+"""Recover a failed ML training pipeline: reuse every step that succeeded.
+
+A nightly pipeline loads a dataset, preprocesses it, trains a small model, and finishes by
+registering the evaluation with an external model-validation service. That service is the
+pipeline's only external dependency — and in this story it goes down for maintenance right
+when `evaluate` calls it, so the whole run fails at the very last step.
+
+Recovery (`flyte rerun --recover` / `flyte.rerun(..., recover=True)`) relaunches the run with
+its original code and inputs, reusing every action that already succeeded: the dataset is not
+re-read, the features are not recomputed, the model is not retrained. Only `evaluate`
+re-executes. Once the validation service is back, the recovered run completes.
+
+The outage is simulated with the `VALIDATION_SERVICE_OUTAGE` environment variable so the
+failure is reproducible; recovery clears it with an `-e` / `env_vars` override. Because the
+source run's environment is inherited by the recovered run, the override is what models "the
+service has recovered".
+
+Then a second twist: the team decides the evaluation threshold should have been 0.9, not 0.6.
+`threshold` is a root input consumed only by `evaluate`, so a recovery with the changed input
+re-executes `evaluate` and nothing else — load, preprocess and train are reused as-is.
+
+Run the whole tour (remote only — rerun and recover are not supported locally):
+
+    uv run python ml_pipeline.py
+
+--------------------------------------------------------------------------------------------
+Equivalent `flyte` CLI commands
+--------------------------------------------------------------------------------------------
+The script prints the seed run's name; substitute it for <RUN> below.
+
+    # Seed run: launched during the simulated validation-service outage; fails at `evaluate`.
+    flyte run ml_pipeline.py main -e VALIDATION_SERVICE_OUTAGE=1
+
+    # 1. Recover: the outage is over, so clear the switch. Everything that succeeded in the
+    #    seed run is reused (RECOVERED phase); only `evaluate` re-executes.
+    flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --follow
+
+    # 2. Recover AND change an input. `threshold` feeds only `evaluate`, so the upstream steps
+    #    keep their recorded outputs and only `evaluate` re-executes against the new value.
+    flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 --follow
+
+    # Inspect what recovery reused — reused actions show up as RECOVERED:
+    flyte get action <RECOVERED_RUN>
+"""
+
+import asyncio
+import math
+import os
+import random
+from dataclasses import dataclass
+
+import flyte
+from flyte.models import ActionPhase
+from flyte.remote import Action
+
+env = flyte.TaskEnvironment(
+    name="ml_pipeline",
+    resources=flyte.Resources(cpu=1, memory="500Mi"),
+)
+
+#: Set to "1" on a run to simulate the external validation service being down.
+VALIDATION_SERVICE_OUTAGE = "VALIDATION_SERVICE_OUTAGE"
+
+
+@dataclass
+class Dataset:
+    features: list[list[float]]
+    labels: list[int]
+
+
+@dataclass
+class Model:
+    weights: list[float]
+    bias: float
+
+
+@dataclass
+class EvaluationReport:
+    accuracy: float
+    confident_accuracy: float
+    confident_count: int
+    approved: bool
+
+
+# {{docs-fragment pipeline}}
+@env.task
+async def load_dataset(n_samples: int, seed: int) -> Dataset:
+    """Pull a synthetic training set from the (mock) feature store."""
+    rng = random.Random(seed)
+    features, labels = [], []
+    for _ in range(n_samples):
+        label = rng.randint(0, 1)
+        center = 2.0 if label else -2.0
+        features.append([rng.gauss(center, 1.0), rng.gauss(center, 1.0)])
+        labels.append(label)
+    print(f"load_dataset: loaded {n_samples} samples")
+    await asyncio.sleep(2)  # stand-in for a slow warehouse read
+    return Dataset(features=features, labels=labels)
+
+
+@env.task
+async def preprocess(data: Dataset) -> Dataset:
+    """Standardize features to zero mean and unit variance."""
+    n = len(data.features)
+    means = [sum(f[j] for f in data.features) / n for j in range(2)]
+    stds = [
+        max(math.sqrt(sum((f[j] - means[j]) ** 2 for f in data.features) / n), 1e-9)
+        for j in range(2)
+    ]
+    scaled = [[(f[j] - means[j]) / stds[j] for j in range(2)] for f in data.features]
+    print(f"preprocess: standardized {n} rows")
+    await asyncio.sleep(2)  # stand-in for an expensive feature transformation
+    return Dataset(features=scaled, labels=data.labels)
+
+
+@env.task
+async def train(data: Dataset, epochs: int) -> Model:
+    """Fit a small logistic-regression model with gradient descent."""
+    w = [0.0, 0.0]
+    b = 0.0
+    lr = 0.1
+    n = len(data.features)
+    for _ in range(epochs):
+        gw0 = gw1 = gb = 0.0
+        for x, y in zip(data.features, data.labels):
+            p = 1.0 / (1.0 + math.exp(-(w[0] * x[0] + w[1] * x[1] + b)))
+            err = p - y
+            gw0 += err * x[0]
+            gw1 += err * x[1]
+            gb += err
+        w[0] -= lr * gw0 / n
+        w[1] -= lr * gw1 / n
+        b -= lr * gb / n
+    print(f"train: fitted for {epochs} epochs, weights={[round(wi, 3) for wi in w]}")
+    await asyncio.sleep(2)  # stand-in for a real training loop
+    return Model(weights=w, bias=b)
+# {{/docs-fragment pipeline}}
+
+
+# {{docs-fragment evaluate}}
+@env.task
+async def evaluate(model: Model, data: Dataset, threshold: float) -> EvaluationReport:
+    """Score the model, then register the result with the external validation service.
+
+    The service call is the pipeline's final step — an intermittent 503 here fails the whole
+    run after everything expensive has already finished. That is exactly the shape recovery
+    is for.
+    """
+    correct = confident_correct = confident_count = 0
+    for x, y in zip(data.features, data.labels):
+        p = 1.0 / (1.0 + math.exp(-(model.weights[0] * x[0] + model.weights[1] * x[1] + model.bias)))
+        pred = int(p >= 0.5)
+        correct += int(pred == y)
+        if max(p, 1.0 - p) >= threshold:
+            confident_count += 1
+            confident_correct += int(pred == y)
+
+    accuracy = correct / len(data.labels)
+    confident_accuracy = confident_correct / confident_count if confident_count else 0.0
+
+    # The simulated outage: during the maintenance window the call fails with a 503.
+    # In a real pipeline this would be an ordinary HTTP call to a flaky upstream service.
+    if os.environ.get(VALIDATION_SERVICE_OUTAGE) == "1":
+        raise ConnectionError(
+            "HTTP 503 Service Unavailable: POST https://validation.internal/api/v1/approve"
+        )
+
+    approved = confident_accuracy >= 0.85
+    print(
+        f"evaluate: accuracy={accuracy:.3f} confident_accuracy={confident_accuracy:.3f} "
+        f"({confident_count} samples above threshold={threshold}) approved={approved}"
+    )
+    return EvaluationReport(
+        accuracy=accuracy,
+        confident_accuracy=confident_accuracy,
+        confident_count=confident_count,
+        approved=approved,
+    )
+# {{/docs-fragment evaluate}}
+
+
+# {{docs-fragment main}}
+@env.task
+async def main(
+    n_samples: int = 2000,
+    seed: int = 7,
+    epochs: int = 5,
+    threshold: float = 0.6,
+) -> EvaluationReport:
+    """Load, preprocess, train, evaluate. `threshold` feeds only the final step."""
+    data = await load_dataset(n_samples, seed)
+    clean = await preprocess(data)
+    model = await train(clean, epochs)
+    return await evaluate(model, clean, threshold)
+# {{/docs-fragment main}}
+
+
+def summarize(run_name: str) -> None:
+    """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
+    for action in Action.listall(for_run_name=run_name):
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+
+
+# {{docs-fragment recover-tour}}
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    # --- The seed run: launched during the simulated outage, fails at `evaluate`. ----------
+    #     CLI: flyte run ml_pipeline.py main -e VALIDATION_SERVICE_OUTAGE=1
+    seed = flyte.with_runcontext(env_vars={VALIDATION_SERVICE_OUTAGE: "1"}).run(main)
+    print(f"seed run: {seed.name}\n  {seed.url}")
+    seed.wait(quiet=True)
+    print(f"  finished in phase: {seed.phase}  (expected: the validation service is 'down')")
+    summarize(seed.name)
+    assert seed.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
+
+    # --- 1. Recover: the outage is over, so recover the run with the switch cleared. --------
+    #     Every succeeded action of the seed run is reused as-is — the dataset is not re-read,
+    #     the features are not recomputed, the model is not retrained. Only `evaluate`
+    #     re-executes, and this time the service answers.
+    #     CLI: flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --follow
+    recovered = flyte.with_runcontext(env_vars={VALIDATION_SERVICE_OUTAGE: "0"}).rerun(
+        seed.name, recover=True
+    )
+    print(f"\n1. rerun(recover=True) -> {recovered.name}\n  {recovered.url}")
+    recovered.wait()
+    print(f"  finished in phase: {recovered.phase}")
+    print("  (load_dataset / preprocess / train should read RECOVERED; evaluate re-executed)")
+    summarize(recovered.name)
+    assert recovered.phase == ActionPhase.SUCCEEDED, "recovery should complete the pipeline"
+
+    # --- 2. Recover with a changed input: the eval threshold should have been 0.9. ----------
+    #     `threshold` is consumed only by `evaluate`, so the upstream actions keep the outputs
+    #     they produced under the original inputs and only `evaluate` re-executes. That is the
+    #     safe case for changed inputs — no recovered output goes stale, so nothing needs
+    #     `--force-rerun-action`.
+    #     CLI: flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 --follow
+    regraded = flyte.with_runcontext(env_vars={VALIDATION_SERVICE_OUTAGE: "0"}).rerun(
+        seed.name, recover=True, threshold=0.9
+    )
+    print(f"\n2. rerun(recover=True, threshold=0.9) -> {regraded.name}\n  {regraded.url}")
+    regraded.wait()
+    print(f"  finished in phase: {regraded.phase}")
+    print("  (upstream RECOVERED again — the changed input only feeds `evaluate`)")
+    summarize(regraded.name)
+    assert regraded.phase == ActionPhase.SUCCEEDED
+# {{/docs-fragment recover-tour}}

--- a/v2/user-guide/task-deployment/recover-runs/ml_pipeline.py
+++ b/v2/user-guide/task-deployment/recover-runs/ml_pipeline.py
@@ -28,6 +28,9 @@ Then a second twist: the team decides the evaluation threshold should have been 
 `threshold` is a root input consumed only by `evaluate`, so a recovery with the changed input
 re-executes `evaluate` and nothing else — load, preprocess and train are reused as-is.
 
+Finally, `force_rerun_actions` re-executes an action that succeeded in the source run — used
+here to retrain the model before re-evaluating it.
+
 Run the whole tour (remote only — rerun and recover are not supported locally):
 
     uv run python ml_pipeline.py
@@ -47,6 +50,12 @@ The script prints the seed run's name; substitute it for <RUN> below.
     # 2. Recover AND change an input. `threshold` feeds only `evaluate`, so the upstream steps
     #    keep their recorded outputs and only `evaluate` re-executes against the new value.
     flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 --follow
+
+    # 3. Recover, change an input, AND force a succeeded action to re-execute. Action names
+    #    are deterministic hashes — list them first and copy the one you want.
+    flyte get action <RUN>
+    flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 \
+        --force-rerun-action <TRAIN_ACTION> --follow
 
     # Inspect what recovery reused — reused actions show up as RECOVERED:
     flyte get action <RECOVERED_RUN>
@@ -207,7 +216,7 @@ async def main(
 def summarize(run_name: str) -> None:
     """Print each action's phase. RECOVERED == reused from the source run, never re-executed."""
     for action in Action.listall(for_run_name=run_name):
-        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase}")
+        print(f"    {action.name:<14} {action.task_name or '-':<28} {action.phase.value}")
 
 
 # {{docs-fragment recover-tour}}
@@ -219,7 +228,7 @@ if __name__ == "__main__":
     seed = flyte.with_runcontext(env_vars={VALIDATION_SERVICE_OUTAGE: "1"}).run(main)
     print(f"seed run: {seed.name}\n  {seed.url}")
     seed.wait(quiet=True)
-    print(f"  finished in phase: {seed.phase}  (expected: the validation service is 'down')")
+    print(f"  finished in phase: {seed.phase.value}  (expected: the validation service is 'down')")
     summarize(seed.name)
     assert seed.phase == ActionPhase.FAILED, "the seed run should fail at evaluate"
 
@@ -233,7 +242,7 @@ if __name__ == "__main__":
     )
     print(f"\n1. rerun(recover=True) -> {recovered.name}\n  {recovered.url}")
     recovered.wait()
-    print(f"  finished in phase: {recovered.phase}")
+    print(f"  finished in phase: {recovered.phase.value}")
     print("  (load_dataset / preprocess / train should read RECOVERED; evaluate re-executed)")
     summarize(recovered.name)
     assert recovered.phase == ActionPhase.SUCCEEDED, "recovery should complete the pipeline"
@@ -249,8 +258,33 @@ if __name__ == "__main__":
     )
     print(f"\n2. rerun(recover=True, threshold=0.9) -> {regraded.name}\n  {regraded.url}")
     regraded.wait()
-    print(f"  finished in phase: {regraded.phase}")
+    print(f"  finished in phase: {regraded.phase.value}")
     print("  (upstream RECOVERED again — the changed input only feeds `evaluate`)")
     summarize(regraded.name)
     assert regraded.phase == ActionPhase.SUCCEEDED
+
+    # --- 3. Recover with a forced re-execution: retrain the model for reproducibility. -----
+    #     `train` succeeded in the seed run, so recovery would reuse it. Naming it in
+    #     force_rerun_actions re-executes it anyway — and re-enqueues its children, so
+    #     `evaluate` runs on the fresh model.
+    #     Action names are deterministic hashes, so look them up rather than guessing:
+    #     CLI: flyte get action <RUN>
+    #          flyte rerun <RUN> --recover -e VALIDATION_SERVICE_OUTAGE=0 --threshold 0.9 \
+    #              --force-rerun-action <TRAIN_ACTION>
+    train_action = next(
+        (a for a in Action.listall(for_run_name=seed.name) if a.task_name == "ml_pipeline.train"),
+        None,
+    )
+    assert train_action is not None, "expected a train action in the seed run"
+    print(f"\n  forcing re-execution of {train_action.name} ({train_action.task_name})")
+    retrained = flyte.with_runcontext(env_vars={VALIDATION_SERVICE_OUTAGE: "0"}).rerun(
+        seed.name, recover=True, threshold=0.9, force_rerun_actions=[train_action.name]
+    )
+    print(f"\n3. rerun(recover=True, threshold=0.9, force_rerun_actions=[{train_action.name!r}])")
+    print(f"   -> {retrained.name}\n  {retrained.url}")
+    retrained.wait()
+    print(f"  finished in phase: {retrained.phase.value}")
+    print("  (load_dataset / preprocess RECOVERED; train and evaluate re-executed)")
+    summarize(retrained.name)
+    assert retrained.phase == ActionPhase.SUCCEEDED
 # {{/docs-fragment recover-tour}}


### PR DESCRIPTION
## Summary

Adds runnable examples for the [Recover a run](https://www.union.ai/docs/v2/union/user-guide/tasks/task-deployment/recover-runs/) and [Fork a run](https://www.union.ai/docs/v2/union/user-guide/tasks/task-deployment/fork-runs/) v2 user-guide pages.

**`recover-runs/`** — a nightly ML pipeline (load → preprocess → train → evaluate) that fails at the last step due to a simulated external-service outage. The tour covers plain recovery (`flyte.rerun(run, recover=True)`), recovery with changed inputs, and forcing a re-run of a succeeded action via `force_rerun_actions` — showing upstream actions land in the `RECOVERED` phase without re-executing.

**`fork-runs/`** — the same pipeline, but the failure is a code bug (`ZeroDivisionError` in `evaluate`), so recovery can't help. Shows fixing the code and using `flyte fork` (`flyteplugins.union.fork`) to reuse the expensive upstream actions and re-execute only the fixed step. Includes an `agent-mediated-fork/` variant where an agent task diagnoses the failure, patches the code, and forks the run.

## Test plan

- [ ] `uv run python recover-runs/ml_pipeline.py` against a Union backend completes all four recovery phases
- [ ] `uv run python fork-runs/ml_pipeline_fixed.py` launches the buggy run, forks with the fix, and reports reused actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QZ23ESzmk2qAdW2gpdt69