### PR TITLE
Multi Node GRPO RL tutorial 

### DIFF
--- a/v2/tutorials/multinode_rl_grpo_lora/README.md
+++ b/v2/tutorials/multinode_rl_grpo_lora/README.md
@@ -1,0 +1,342 @@
+# Async Multi-Node RL Post-Training with GRPO on Union
+
+*Part 2 of the GRPO tutorial. Part 1 —
+[`rl_grpo_lora`](../rl_grpo_lora/) — builds the single-GPU loop; this tutorial turns its trainer
+into a gang of pods on a `ClusteredTaskEnvironment`, upgrades the objective to real GRPO, pipelines
+generation against training, and proves it on an 8B policy with a held-out benchmark.*
+
+RL post-training with verifiable rewards (RLVR — the DeepSeek-R1 recipe) is where the
+competitive frontier moved in 2025–26, and GRPO is the algorithm everyone runs. Outside the big
+labs, multi-node GRPO is usually held together with shell scripts across several terminals, and a
+dead GPU ruins an overnight run. The promise of this tutorial:
+
+> **Frontier-lab-style RL post-training — a warm rollout fleet, a multi-node trainer, async
+> off-policy pipelining, a held-out eval — declared in Python, run with one command, on your own
+> cluster.**
+
+The receipts, from the reference run (Qwen3-8B, GSM8K, 2 trainer pods × 4 L40S, 20 iterations):
+
+| | |
+|---|---|
+| Held-out GSM8K accuracy (64 questions, greedy) | **60.9 % → 92.2 % peak (step 14) → 85.9 % final** |
+| Steady-state iteration | **≈ 5 min, all of it generation** — the ≈ 2.3 min clustered train step (JobSet spin-up + 8B load + two epochs) is entirely hidden under the next batch's generation |
+| vs. the same loop run sequentially | ≈ 7.3 min per iteration → **pipelining is worth ~⅓ of the wall-clock** |
+| Held-out eval | never on the critical path (runs in the background, overlapping the next train step) |
+| Actions | 1,323 (640 rollout calls, 640 reward calls, 20 JobSets, 21 evals), **0 failures, 0 restarts** |
+
+---
+
+## Why Union fits multi-node RL
+
+- **Heterogeneous fleet in one run.** Rollouts run on a warm, autoscaling pool of single-GPU
+  vLLM actors; the trainer bursts onto multi-GPU nodes only while it trains; reward and the
+  driver are CPU tasks. Each stage is a right-sized `TaskEnvironment`; the driver is an `async`
+  `for` loop.
+- **The trainer is an environment declaration, not a rewrite.** Moving `train_step` from one GPU
+  to *N pods × G GPUs* is a `ClusteredTaskEnvironment(replicas=…, nproc_per_node=…)` — one
+  Kubernetes JobSet per call, torchrun bootstrapped, whole-gang restarts on any pod death.
+- **The orchestrator's async driver *is* the async-RL controller** script-land setups have to
+  hand-build: overlapping generation N+1 with training N is a `create_task` in the driver.
+- **Weight sync is not a network protocol.** Trainer → generator handoff is a few-MB LoRA
+  adapter through the object store, so the rollout fleet and the trainer are decoupled — no
+  gang-scheduled two-cluster topology, no NCCL broadcast, no tight coupling.
+
+## 1. What changes from Part 1
+
+Part 1 already *is* post-training — a validated GRPO + LoRA loop — but small: a 0.6B model, eight
+arithmetic questions, one GPU, a simplified objective, no eval. This tutorial adds four things:
+
+1. **A multi-node trainer** on a `ClusteredTaskEnvironment` (`train_step_clustered`).
+2. **The real GRPO objective.** Part 1's loss is `−Â · mean_t log π(o_t)` — REINFORCE with
+   group-normalized advantages. That is fine *on-policy*, but the pipelined driver below trains
+   on rollouts sampled by the *previous* adapter. This trainer uses the token-level
+   clipped-importance-ratio surrogate with a KL penalty against the base model, which is what
+   makes off-policy training sound. AdamW state persists across iterations (Part 1 rebuilt it
+   every step).
+3. **Async pipelining.** Generation of batch N+1 overlaps the clustered step on batch N;
+   `pipelined=False` runs the identical loop sequentially for a clean comparison.
+4. **A held-out eval** (greedy, on the warm pool) before training and after every step — the
+   report charts the delta against the base model — plus a real dataset (GSM8K).
+
+Everything else — the warm vLLM pool, the verifiable reward, the adapter handoff, the live
+report — is imported from Part 1 unchanged.
+
+## 2. How the work is laid out
+
+```
+  driver task  (rl-grpo-driver-v2, CPU)            the async loop; owns checkpoints + the live report
+     │
+     ├─ init_adapter          (rl-grpo-train, 1 GPU)        mint LoRA v0
+     ├─ evaluate              (rl-grpo-rollout, warm pool)  baseline: base model, no adapter
+     │
+     │   per iteration N (pipelined):
+     ├─ generate ×P           (rl-grpo-rollout, warm pool)  batch N+1 with adapter v_N  ─┐ overlaps
+     ├─ score_group ×P        (rl-grpo-reward, CPU)         verifiable reward            │
+     ├─ train_step_clustered  (rl-grpo-train-cluster)       JobSet: R pods × G GPUs     ─┘ ← batch N → adapter v_N+1
+     └─ evaluate              (rl-grpo-rollout, warm pool)  in the background; overlaps train N+1
+```
+
+| Environment | Kind | Runs |
+|---|---|---|
+| `rl-grpo-rollout` | reusable warm pool, 1 GPU/replica, `ReusePolicy(replicas=(1–2, 4), concurrency=1)` | `generate`, `evaluate` — in-process vLLM with `enable_lora=True`; the adapter version is attached per request via `LoRARequest` |
+| `rl-grpo-reward` | plain CPU task env | `score_group` — exact-match + format reward, one call per prompt group |
+| `rl-grpo-train` | single-GPU task env (Part 1) | `init_adapter` only |
+| `rl-grpo-train-cluster` | **`ClusteredTaskEnvironment`** — `replicas` pods × `nproc_per_node` ranks, `TorchRun`, `ClusterFailurePolicy(max_restarts=2)` | `train_step_clustered` |
+| `rl-grpo-driver-v2` | plain CPU task env, `depends_on` all of the above | `train_rl_clustered` |
+
+Two hard rules about clustered tasks shape this layout: **rank 0's return value is the task's
+output** (other ranks' are discarded, but every rank must return matching types), and **a
+clustered task has no controller** — it cannot call other tasks — so the loop lives in the plain
+driver and *awaits* the clustered step like any other task.
+
+## 3. Getting started
+
+**Prerequisites**
+
+- A Union deployment with GPU capacity: single-GPU nodes for the pool, and — for the stress
+  profile — multi-GPU nodes such as `g6e.12xlarge` (4× L40S). The clustered environment
+  currently supports `interconnect="tcp"` only, which is exactly why this tutorial trains a
+  LoRA adapter: cross-node traffic is the few-MB adapter gradient, not the model.
+- A Hugging Face token stored as a cluster secret named `hf-token`
+  (`flyte create secret hf-token --value …`).
+- Locally: a `config.yaml` for your tenant, or an API key for the Colab path.
+
+**Profiles.** Everything is sized by one environment variable, read at import time:
+
+| `GRPO_PROFILE` | policy / data | iterations | rollouts / iter | trainer | wall-clock |
+|---|---|---|---|---|---|
+| `smoke` (default) | Qwen3-0.6B, 8 arithmetic questions | 3 | 4 × 6 | 2 pods × 1 GPU | ~25 min |
+| `stress` | **Qwen3-8B, GSM8K** (64 held-out) | 20 | 32 × 6, 512 tokens | **2 pods × 4 L40S**, 2 epochs/step | ~2 h + node provisioning |
+
+`GRPO_GPU_TYPE` (default `L4`) picks the accelerator; set it to `L40s` on tenants whose L4 pool is
+unavailable. Both variables are re-injected into every environment's `env_vars`, so the module
+constants resolve identically inside the containers (see `_PROFILE_ENV_VARS` in
+`rl_grpo_lora.py`).
+
+**Run from a terminal**
+
+```bash
+# smoke: proves every path in ~25 minutes
+python rl_grpo_lora_clustered.py
+
+# the real thing
+GRPO_PROFILE=stress GRPO_GPU_TYPE=L40s python rl_grpo_lora_clustered.py
+# the sequential half of the timing comparison
+GRPO_PROFILE=stress GRPO_GPU_TYPE=L40s python rl_grpo_lora_clustered.py --sequential
+```
+
+The entrypoint prefetches the profile's base model once (`flyte.prefetch.hf_model`) and submits
+the driver with the profile's defaults; `--dataset`, `--iterations`, and `--sequential` override
+them.
+
+**Run from Colab** — `grpo_rl_colab_client.ipynb` drives the same code with Colab as a pure
+client (no torch, no CUDA locally). It walks: upload the three modules → pick the profile →
+authenticate with an API key → secret → prefetch → launch → read the receipts → switch to
+`stress` in place (reloads the modules, re-prefetches) → optional sequential comparison. Two
+notebook-specific gotchas it handles for you:
+
+- In a notebook the SDK defaults to *interactive mode* and ships the task as a cloudpickle
+  **without source files**, so the container fails with `ModuleNotFoundError` on the tutorial's
+  own modules. The run cells use `flyte.with_runcontext(interactive_mode=False).run(...)`, which
+  builds a normal source bundle from `root_dir`.
+- The profile is read at import, so switching it means reloading the modules (the switch cell
+  does this in dependency order) — no runtime restart needed.
+
+## 4. Walkthrough
+
+### 4.1 The clustered environment
+
+```python
+train_env = ClusteredTaskEnvironment(
+    name="rl-grpo-train-cluster",
+    image=image,                                  # same image as Part 1
+    resources=flyte.Resources(gpu=flyte.GPU("L40s", 4), cpu=16, memory="120Gi", shm="auto"),  # PER POD
+    replicas=2,                                   # pods == nodes
+    nproc_per_node=4,                             # ranks per pod; world_size = 8
+    runtime=TorchRun(rdzv_backend="static"),      # in-pod torchrun; restarts are JobSet-level
+    failure_policy=ClusterFailurePolicy(max_restarts=2),  # any pod dies → the whole gang restarts
+    secrets=[HF_SECRET],
+    env_vars=_PROFILE_ENV_VARS,
+)
+```
+
+Each call to a task in this environment emits one JobSet. `resources` are per pod and must
+cover `nproc_per_node` GPUs. Inside the task, `torchrun` has already set `RANK`, `WORLD_SIZE`,
+`MASTER_ADDR`; `flyte.ctx()` exposes `local_rank`, `node_rank`, `nnodes`. `reusable` is
+rejected on purpose — a JobSet runs to completion, it is not a warm actor; the warm pool stays
+where it belongs, on the rollout environment.
+
+### 4.2 Rollouts carry what the trainer needs (`Rollout`, `generate`)
+
+vLLM tokenizes prompt and completion separately, while a trainer that re-tokenizes
+`prompt + completion` can merge boundary tokens and misalign — fatal for an importance ratio.
+So `generate` requests `SamplingParams(logprobs=0)` and each `Rollout` carries
+`prompt_token_ids`, `token_ids`, and `logprobs` (log π<sub>old</sub> of every sampled token,
+valid as the behaviour policy because sampling runs at temperature 1.0). The trainer feeds the
+model exactly those ids. All three fields default to empty, so Part-1 payloads still deserialize.
+
+### 4.3 The objective (`grpo_sample_loss`)
+
+```python
+ratio     = exp(new_logp - old_logp)                                # π_θ / π_old, per token
+surrogate = min(ratio * Â, clamp(ratio, 1-ε, 1+ε) * Â).mean()       # PPO-style clip, ε = 0.2
+kl        = (exp(ref_logp - new_logp) - (ref_logp - new_logp) - 1).mean()   # k3 estimator ≥ 0
+loss      = -(surrogate - β * kl)                                   # β = 0.03
+```
+
+`old_logp` comes from the rollout; `ref_logp` is the same weights with the adapter disabled
+(`with peft_model.disable_adapter():`) — one extra forward, no second model. Logits are sliced
+to the completion positions *before* the fp32 upcast and log-softmax so the transient is
+(T × vocab), not (sequence × vocab). At ratio = 1 the surrogate's gradient equals REINFORCE's
+(its value does not — it is the constant Â), which is why `mean_loss` sits near zero while the
+policy learns; watch the gradient norm and the eval instead.
+
+### 4.4 The DDP discipline (`ddp_shard_step`)
+
+Every rank must execute the same number of collective operations. Part 1's pattern —
+per-sample `backward()` with `if advantage == 0: continue` — breaks that under DDP the moment
+ranks' shards disagree on how many samples carry signal (they always do: rollouts are
+group-contiguous and whole groups get advantage 0), and NCCL desyncs.
+
+```python
+def ddp_shard_step(ddp_model, sample_loss_fns, sync_forward):
+    with ddp_model.no_sync():
+        for fn in sample_loss_fns:
+            fn().backward()                          # local grads; graph freed per sample
+    (sync_forward().float().sum() * 0.0).backward()  # the ONE synchronizing backward, every rank
+```
+
+Backwards inside `no_sync()` accumulate locally with no collectives; the first forward-backward
+after the context syncs everything. Every rank unconditionally runs one dummy 1-token forward
+and a zero-scaled backward, so the collective count is identical by construction — empty shards
+included. (A bare `(0.0 * Σ p.sum()).backward()` would *not* work: it never passes through
+`DDP.forward`, so the reducer is not prepared.) Each per-sample loss is scaled by
+`world_size / n_valid` so the DDP-averaged gradient equals the single-process mean; `n_valid`
+is a property of the rollout payload every rank holds, so no pre-backward communication is
+needed. Zero-advantage samples still train — the KL term anchors them; skipping them would bias
+the KL and reintroduce data-dependent divergence.
+
+### 4.5 State that persists (`opt_state`, the return contract)
+
+The step takes `opt_state: flyte.io.Dir | None` and returns
+`(new_adapter, new_opt_state, TrainMetrics)`. All ranks build AdamW over the same parameter
+sequence and all ranks load the state; rank 0 saves the adapter and `optimizer.state_dict()`,
+uploads both, and `dist.broadcast_object_list`s their URIs so every rank returns real,
+identically-typed `Dir`s. `TrainMetrics` (`mean_loss`, `mean_ratio`, `clip_fraction`, `mean_kl`,
+`grad_norm`, `contributing`, `num_valid`) is all-reduced across ranks, so the driver sees global
+numbers, not rank 0's shard.
+
+### 4.6 The async driver (`train_rl_clustered`)
+
+```
+sequential:  [gen 0][train 0][gen 1][train 1]...
+pipelined:   [gen 0][gen 1   ][gen 2   ]...
+                    [train 0 ][train 1 ]...      ← JobSet cold start hidden under generation
+                             [eval 0  ][eval 1  ] ← off the critical path in both modes
+```
+
+```python
+rollouts, rewards, gen_s = await pending
+if pipelined:                       # kick batch N+1 NOW, with the current (soon one-step-stale) adapter
+    pending = asyncio.create_task(_timed_generate_and_score(base, train_pairs, it + 1, adapter, version, seed))
+adapter, opt_state, tm = await train_step_clustered(base, rollouts, rewards, adapter, version, opt_state)
+if not pipelined:
+    pending = asyncio.create_task(...)   # sequential: only now start the next batch
+await _settle_eval()                 # the previous step's eval overlapped this train step; back-fill its row
+pending_eval = asyncio.create_task(evaluate(base, eval_qs, eval_as, adapter=adapter, version=version))
+```
+
+One-step-off-policy training is standard in async GRPO at the labs; the clipped ratio in 4.3 is
+what makes it legitimate here. Each step's eval is launched in the background and awaited only
+after the *next* step's training, so its row in the report fills in one iteration late; only the
+final eval is waited on. Loop state — adapter, optimizer state, baseline accuracy, history — is
+checkpointed every iteration; a resumed driver re-launches a lost in-flight eval.
+
+### 4.7 The report
+
+`report_helpers.render_report` publishes a single HTML page after every iteration
+(`flyte.report.replace.aio(..., do_flush=True)`) with the Part-1 charts plus three new ones,
+rendered only when their data exists:
+
+- **Held-out eval accuracy vs. iteration**, against the base-model baseline.
+- **Off-policy drift**: |mean ratio − 1|, clip fraction, KL — near zero on-policy, lifting when
+  the policy moves faster than one step's worth.
+- **Iteration timing**: generate+score, clustered train step, iteration end-to-end. The overlap
+  hidden by pipelining is Σ(gen + train − iteration).
+
+Axis tick precision follows the tick spacing, so small-range series (KL ≈ 0.001, clip fraction
+≈ 0.007) read correctly instead of collapsing onto `0.00`.
+
+## 5. Results from the reference runs
+
+**Smoke (0.6B, arithmetic, 2 × 1 GPU, 3 iterations — 25 min).** Every invariant we wanted from
+a smoke test, and one lesson: `contributing = 24/24` on all steps (the gradient path really
+ran on both ranks); `mean_ratio` 1.0003 / 1.0001 / 0.9996 with clip fraction ≈ 0.6 % (token
+alignment between vLLM and the trainer is correct); `mean_kl` **exactly 0.0** on step 1 — a
+fresh LoRA has B = 0, so policy ≡ base — then 9e-4 (the adapter-disabled reference works);
+adapter and optimizer state chained across steps. The lesson: the three clustered steps took
+641 s / 204 s / 329 s against ~60 s of generation, so at smoke scale training is the long pole
+and pipelining can only hide that minute. The async claim needs generation to dominate.
+
+**Stress (8B, GSM8K, 2 × 4 L40S, 20 iterations).** Generation of 192 rollouts × up to 512
+tokens on four pool replicas takes ≈ 275 s; the clustered step (JobSet spin-up + 8B load + two
+epochs on world size 8) ≈ 140 s. Batch N+1 launches 1–2 s before train N and finishes ≈ 130 s
+*after* it: the train step, cold start included, is entirely hidden, and the iteration costs
+≈ 298 s — the generation time. Sequentially the same iteration is ≈ 440 s. Evals (median
+129 s) started before the next train step began and ended well before it did, every time.
+
+Held-out accuracy climbed 60.9 % → 92.2 % (step 14) and settled at 85.9 % — 25 points on 64
+questions, against a standard error of ~4. `contributing` fell from 180 to ~100 of 192 as more
+prompt groups became all-correct: textbook GRPO saturation, and the cue to move to harder
+prompts. Importance ratios stayed at 1.000 ± 0.0003 with a 0.6–0.8 % clip fraction and KL rising
+smoothly from 7e-4 to 4.6e-3; gradient norms ≈ 0.02 (the clip at 1.0 never engaged).
+
+Three honest notes:
+
+- **The 61 % baseline is low for Qwen3-8B on GSM8K** (published numbers are 90 %+ with a chat
+  template and free chain-of-thought). Our prompt is deliberately plain — no chat template,
+  "reason briefly", a 512-token cap, strict `####` exact match — so a good part of the gain is
+  the model learning the task's format and length budget. That is legitimate RLVR behaviour
+  and a real held-out gain, but it is not new arithmetic ability.
+- **The staleness signal is invisible at this learning rate.** Clip fraction was the same
+  on-policy and pipelined; the ≈ 0.6 % floor is vLLM-vs-HuggingFace numerics mismatch — the
+  well-known training/inference gap, measured here for free. The importance correction is cheap
+  insurance that starts to matter at higher LR or more epochs per step.
+- **The first JobSet waited 3 h 29 min for nodes.** The JobSet was created at 06:54, torchrun
+  started inside the pods at 10:23, and the step then took 90 s. That is 4-GPU instance
+  capacity (Karpenter retrying for `g6e.12xlarge`), i.e. gang admission on a shared cluster.
+  The driver simply waited — iteration-1 generation had already finished — and the run
+  completed without a failure. Budget for it; a nodepool that allows several 4-GPU instance
+  types helps.
+
+For scale: Part 1's single-GPU loop on the same 20 × 192 rollouts took ≈ 12.4 min per iteration
+(247 min total) versus ≈ 5 min here — but that is not the right pipelining baseline (different
+objective, one optimizer step per iteration, no eval). `pipelined=False` under the same profile
+is.
+
+## 6. Going further
+
+- **Bigger policies.** L40S-48GB fits an 8B in bf16, so DDP suffices here. Past ~30B, swap the
+  DDP wrap for FSDP at the marked line in `train_step_clustered` — on a TCP interconnect prefer
+  hybrid sharding (shard within a node over NVLink, replicate across nodes) so cross-node
+  traffic stays at LoRA-gradient scale.
+- **Harder prompts / curriculum.** `contributing` decaying to ~50 % of the batch is the signal:
+  sample prompts the current policy gets *sometimes* right.
+- **Kill-a-node demo.** `ClusterFailurePolicy` already restarts the whole gang; with in-step
+  checkpointing (`flyte.ctx().checkpoint`) the loss curve continues across a pod death — the
+  fault-tolerance receipt no other GRPO tutorial shows.
+- **Full-weight RL.** When LoRA capacity runs out: full-parameter training, multi-GB weight
+  handoff, vLLM `sleep`/`wake_up` + `load_weights` instead of `LoRARequest`. That is where
+  multi-role JobSets (trainer + rollout replicas in one gang, NCCL weight sync) pay off.
+- **Model-based or executable rewards.** Replace `score_group`'s rule with an LLM judge on a
+  second warm pool, or with code/SQL execution — the reward is just a task, so it scales,
+  retries, and versions like one.
+
+## 7. Files
+
+| File | What it is |
+|---|---|
+| `rl_grpo_lora_clustered.py` | Part 2: profiles' trainer knobs, `ClusteredTaskEnvironment`, `grpo_sample_loss`, `ddp_shard_step`, `train_step_clustered`, `_load_pairs` (arithmetic / GSM8K), the async driver `train_rl_clustered`, CLI entrypoint |
+| `rl_grpo_lora.py` | Part 1, extended: `PROFILES`, `Rollout` with token ids + logprobs, `generate` (logprobs on), `_extract_answer` (comma-safe), `evaluate`, the four Part-1 environments with profile env-vars injected |
+| `report_helpers.py` | Live report: `IterationMetrics` (+ eval/drift/timing fields), `render_report` with the three new charts, adaptive axis ticks |
+| `grpo_rl_colab_client.ipynb` | Colab-as-client notebook: setup → smoke → in-place switch to stress → sequential comparison; Part-1 loop as an optional appendix |

--- a/v2/tutorials/multinode_rl_grpo_lora/grpo_rl_colab_client.ipynb
+++ b/v2/tutorials/multinode_rl_grpo_lora/grpo_rl_colab_client.ipynb
@@ -1,0 +1,515 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Async Multi-Node RL Post-Training with GRPO on Union \u2014 from Google Colab\n",
+    "\n",
+    "This notebook runs **multi-node reinforcement learning for LLMs** (GRPO + LoRA \u2014 the family of\n",
+    "techniques behind reasoning models like DeepSeek-R1) **on your Union cluster, driven from Colab**.\n",
+    "It is Part 2 of the GRPO tutorial: the single-GPU loop from\n",
+    "[Part 1](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/rl_grpo_lora) is\n",
+    "imported here as a library (its warm vLLM pool, reward, and eval), and the trainer becomes a\n",
+    "**gang of pods** on a `ClusteredTaskEnvironment`, with generation pipelined against training.\n",
+    "\n",
+    "Colab is only the *client*: nothing heavy runs in this notebook. Each cell below submits work to\n",
+    "Union, which provisions the GPUs, runs the tasks, and streams a live report you can watch in the\n",
+    "browser.\n",
+    "\n",
+    "```\n",
+    "  Colab (this notebook)                    Your Union cluster\n",
+    "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500                    \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\n",
+    "  pip install flyte         \u2500\u2500submit\u2500\u2500\u25b6    driver task (the async RL loop, CPU)\n",
+    "  authenticate (API key)                     \u251c\u2500 warm vLLM pool        (1 GPU \u00d7 N replicas) \u2190 rollouts + held-out eval\n",
+    "  run(train_rl_clustered)                    \u251c\u2500 reward tasks          (CPU)                \u2190 verifiable scoring\n",
+    "  watch run.url                              \u2514\u2500 train_step_clustered  (JobSet: R pods \u00d7 G GPUs, torchrun/DDP)\n",
+    "                                                                                           \u2190 real GRPO step, overlapped with\n",
+    "                                                                                             the NEXT batch's generation\n",
+    "```\n",
+    "\n",
+    "### What you need\n",
+    "1. A **Union deployment with GPU capacity** \u2014 single-GPU nodes for the pool, and multi-GPU nodes\n",
+    "   (e.g. `g6e.12xlarge`, 4\u00d7 L40S) for the stress run.\n",
+    "2. A **Union API key** \u2014 a single base64 string that encodes the endpoint, org, and credentials,\n",
+    "   so no `config.yaml` or browser login is needed. Create one from the **Union web console**\n",
+    "   (org/admin settings \u2192 API keys / apps), or with the `union` CLI from a machine where you're\n",
+    "   already logged in. *(Note: the v2 `flyte` CLI does not create API keys.)*\n",
+    "3. A **Hugging Face token** stored on the cluster as a secret named `hf-token`\n",
+    "   (one-time setup \u2014 see the secret cell below).\n",
+    "\n",
+    "The flow: set up once \u2192 run the **`smoke`** profile (~25 min, proves everything) \u2192 switch to the\n",
+    "**`stress`** profile (8B policy on GSM8K, 2 pods \u00d7 4 GPUs) \u2192 optionally the sequential comparison.\n",
+    "The profile is a single environment variable, `GRPO_PROFILE`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "install-md",
+   "metadata": {},
+   "source": [
+    "## 1. Install the client\n",
+    "\n",
+    "Only the Flyte SDK and two tiny pure-Python deps \u2014 **no torch, no vLLM, no CUDA** in Colab.\n",
+    "The tutorial module imports GPU libraries lazily *inside* the tasks, which run on the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"flyte>=2.4.0\" \"async-lru>=2.0.0\" \"pydantic>=2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Get the tutorial code\n",
+    "\n",
+    "The tutorial is three modules \u2014 `rl_grpo_lora.py` (Part 1: envs, warm vLLM pool, reward, eval),\n",
+    "`report_helpers.py` (the live report), and `rl_grpo_lora_clustered.py` (Part 2: the clustered\n",
+    "trainer + async driver). Upload your local copies; Flyte bundles the folder and ships it to the\n",
+    "cluster when a run is submitted.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import pathlib, sys\n",
+    "from google.colab import files\n",
+    "\n",
+    "TUTORIAL_DIR = pathlib.Path(\"/content/rl_grpo\")\n",
+    "TUTORIAL_DIR.mkdir(exist_ok=True)\n",
+    "\n",
+    "NEEDED = {\"rl_grpo_lora.py\", \"report_helpers.py\", \"rl_grpo_lora_clustered.py\"}\n",
+    "missing = NEEDED - {p.name for p in TUTORIAL_DIR.iterdir()}\n",
+    "if missing:\n",
+    "    print(\"Select:\", \", \".join(sorted(missing)))\n",
+    "    for name, data in files.upload().items():  # pick the three tutorial modules\n",
+    "        (TUTORIAL_DIR / name).write_bytes(data)\n",
+    "        print(\"wrote\", TUTORIAL_DIR / name)\n",
+    "\n",
+    "assert not (NEEDED - {p.name for p in TUTORIAL_DIR.iterdir()}), \"still missing modules\"\n",
+    "sys.path.insert(0, str(TUTORIAL_DIR))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pick the profile and GPU type\n",
+    "\n",
+    "Both are read **at import time** and baked into every task's spec (and re-injected into each\n",
+    "environment as env vars, so the containers resolve identical constants):\n",
+    "\n",
+    "- `GRPO_PROFILE`\n",
+    "  - `smoke` (default) \u2014 Qwen3-0.6B, the toy arithmetic set, 3 iterations, 2 single-GPU trainer\n",
+    "    pods. ~25 min. Run this first: it exercises every path (pool, reward, clustered JobSet,\n",
+    "    real GRPO objective, eval, report) cheaply.\n",
+    "  - `stress` \u2014 Qwen3-8B, GSM8K, 20 iterations, 32 prompts \u00d7 6 samples per iteration, 2 trainer\n",
+    "    pods \u00d7 **4 L40S** each (world size 8). Needs multi-GPU nodes. This is the configuration the\n",
+    "    tutorial's async claim is actually about: with 192 rollouts of up to 512 tokens per\n",
+    "    iteration, *generation* is the long pole, so the clustered trainer's whole lifetime hides\n",
+    "    under it.\n",
+    "- `GRPO_GPU_TYPE` \u2014 on this tenant L4 nodes wedge (`NotReady`), so everything runs on L40S.\n",
+    "\n",
+    "Start with `smoke`. Section 8 has a cell that switches to `stress` **in place** (it reloads the\n",
+    "modules and re-prefetches the base model), so no runtime restart is needed.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ.setdefault(\"GRPO_PROFILE\", \"smoke\")   # \"stress\" for the real run \u2014 see above\n",
+    "os.environ.setdefault(\"GRPO_GPU_TYPE\", \"L40s\")   # set BEFORE importing any tutorial module\n",
+    "print(\"profile:\", os.environ[\"GRPO_PROFILE\"], \"| GPU type:\", os.environ[\"GRPO_GPU_TYPE\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "auth-md",
+   "metadata": {},
+   "source": [
+    "## 3. Authenticate to your Union cluster\n",
+    "\n",
+    "Paste your API key when prompted (it is not stored in the notebook). Three things worth noting:\n",
+    "\n",
+    "- `init_from_api_key` is the headless auth path \u2014 no browser redirect, which is exactly what a\n",
+    "  Colab runtime needs. (Locally you'd normally use `flyte.init_from_config()` with a\n",
+    "  `config.yaml` and a browser login; that flow doesn't fit a hosted notebook.)\n",
+    "- `image_builder=\"remote\"` makes Union build the task container image **on the cluster** the\n",
+    "  first time (vLLM + flashinfer + PEFT \u2014 takes a few minutes once, cached afterwards). Colab has\n",
+    "  no Docker, so the local builder would fail.\n",
+    "- `root_dir` points at the tutorial folder so the code bundle contains all three modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auth",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import flyte\n",
+    "\n",
+    "api_key = getpass.getpass(\"Union API key: \")\n",
+    "\n",
+    "flyte.init_from_api_key(\n",
+    "    api_key=api_key,\n",
+    "    project=\"default\",          # \u2190 change to your project\n",
+    "    domain=\"development\",       # \u2190 change to your domain\n",
+    "    root_dir=TUTORIAL_DIR,\n",
+    "    image_builder=\"remote\",\n",
+    ")\n",
+    "print(\"Authenticated.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "secret-md",
+   "metadata": {},
+   "source": [
+    "## 4. One-time: the Hugging Face token secret\n",
+    "\n",
+    "The rollout and trainer tasks read a cluster secret named `hf-token` to pull the base model.\n",
+    "If your cluster already has it, skip this cell. Creating it is a one-time step\n",
+    "(`flyte create secret NAME --value ...`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "secret",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Skip if the `hf-token` secret already exists on the cluster.\n",
+    "hf_token = getpass.getpass(\"Hugging Face token (or blank to skip): \")\n",
+    "if hf_token:\n",
+    "    import subprocess\n",
+    "    subprocess.run([\"flyte\", \"create\", \"secret\", \"hf-token\", \"--value\", hf_token], check=True)\n",
+    "    print(\"Secret created.\")\n",
+    "else:\n",
+    "    print(\"Skipped \u2014 assuming hf-token already exists.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Prefetch the base model (once per profile)\n",
+    "\n",
+    "Rather than every task pulling from Hugging Face, Union downloads the profile's base model\n",
+    "(**Qwen3-0.6B** for `smoke`, **Qwen3-8B** for `stress`) once into the cluster's object store; the\n",
+    "resulting directory is handed to every task as a `flyte.io.Dir`. The helper is reused by the\n",
+    "profile-switch cell in section 8.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import inspect, asyncio\n",
+    "import flyte.prefetch\n",
+    "import rl_grpo_lora as tutorial\n",
+    "\n",
+    "\n",
+    "def prefetch_base(repo: str):\n",
+    "    \"\"\"Download `repo` from Hugging Face into the object store once; return its flyte.io.Dir.\"\"\"\n",
+    "    run = flyte.prefetch.hf_model(repo=repo, hf_token_key=\"hf-token\")\n",
+    "    print(\"Prefetch run:\", run.url)\n",
+    "    run.wait()\n",
+    "    outs = run.outputs()\n",
+    "    if inspect.isawaitable(outs):\n",
+    "        outs = asyncio.get_event_loop().run_until_complete(outs)\n",
+    "    return outs[0]\n",
+    "\n",
+    "\n",
+    "base_dir = prefetch_base(tutorial.BASE_MODEL_REPO)   # follows GRPO_PROFILE\n",
+    "print(\"Base model in object store:\", base_dir.path)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How the multi-node loop works\n",
+    "\n",
+    "In Part 1 the GRPO gradient step ran on **one GPU in one pod**. When the policy outgrows a\n",
+    "single GPU (or you want bigger rollout batches per step), the trainer needs to become a\n",
+    "**gang of pods training cooperatively** \u2014 multiple nodes, one `torch.distributed` process\n",
+    "group, starting together and failing together.\n",
+    "\n",
+    "That is exactly what a `ClusteredTaskEnvironment` declares. Each call to a task in this\n",
+    "environment launches **one Kubernetes JobSet**: `replicas` pods, each bootstrapped by\n",
+    "`torchrun` with `nproc_per_node` workers, all rendezvoused into a single world. You write one\n",
+    "Python function; it runs on every rank; rank 0's return value is the task's output.\n",
+    "\n",
+    "```python\n",
+    "from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun\n",
+    "\n",
+    "train_env = ClusteredTaskEnvironment(\n",
+    "    name=\"rl-grpo-train-cluster\",\n",
+    "    image=image,                                   # same image as Part 1\n",
+    "    resources=flyte.Resources(gpu=flyte.GPU(\"L40s\", 4), cpu=16, memory=\"120Gi\"),  # PER POD\n",
+    "    replicas=2,                                    # 2 pods == 2 nodes\n",
+    "    nproc_per_node=4,                              # ranks per pod; world_size = 8\n",
+    "    runtime=TorchRun(),                            # in-pod torchrun bootstrap\n",
+    "    failure_policy=ClusterFailurePolicy(max_restarts=2),  # any pod dies \u2192 whole gang restarts\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Three more ideas ride on top of the environment change:\n",
+    "\n",
+    "- **The real GRPO objective.** The trainer computes token-level importance ratios from vLLM's\n",
+    "  sampling-time logprobs (carried in each `Rollout`), clips them PPO-style, and adds a KL\n",
+    "  penalty against the adapter-disabled base. This is what makes training on *stale* rollouts\n",
+    "  sound \u2014 which the next point exploits. AdamW state persists across iterations through the\n",
+    "  object store, like the adapter.\n",
+    "- **Async pipelining** (`pipelined=True`): while the clustered trainer spins up and trains on\n",
+    "  batch N, the warm pool is already generating batch N+1 with the one-step-stale adapter \u2014 the\n",
+    "  JobSet's whole lifetime, cold start included, disappears under generation. `pipelined=False`\n",
+    "  runs the identical loop sequentially so the timing chart can prove the difference.\n",
+    "- **A held-out eval**, off the critical path: greedy decoding on a fixed question set, once for\n",
+    "  the raw base model (the baseline) and after every step. Each eval runs in the background and\n",
+    "  overlaps the *next* train step; only the final one is waited on.\n",
+    "\n",
+    "One DDP discipline the multi-node trainer has to respect, and the tutorial code shows how:\n",
+    "**every rank must execute the same number of collective operations.** Per-sample `backward()`\n",
+    "with data-dependent skips desyncs NCCL the moment ranks disagree; see `ddp_shard_step` in\n",
+    "`rl_grpo_lora_clustered.py` for the `no_sync` pattern that makes the invariant hold by\n",
+    "construction, empty shards included.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Launch the multi-node loop \ud83d\ude80\n",
+    "\n",
+    "This submits the **driver task** and returns immediately with a URL. Remotely, the driver runs:\n",
+    "\n",
+    "> baseline eval \u2192 [ sample prompts \u2192 generate on the **warm pool** \u2192 **score** ] \u2016 [ **clustered\n",
+    "> GRPO step** on batch N ] \u2192 eval in the background \u2192 repeat\n",
+    "\n",
+    "The cell uses whatever profile is active \u2014 `smoke` the first time through, `stress` after the\n",
+    "switch in section 8.\n",
+    "\n",
+    "**Note the `with_runcontext(interactive_mode=False)`.** In a notebook the SDK defaults to\n",
+    "\"interactive mode\", which ships the task as a *cloudpickle only* \u2014 no source files. Because the\n",
+    "tutorial's modules import each other, the container would unpickle the task, try to import\n",
+    "`report_helpers`, and fail with `ModuleNotFoundError`. Turning interactive mode off makes the\n",
+    "SDK build a normal source bundle from `root_dir` instead, shipping every loaded module.\n",
+    "\n",
+    "**Open the printed URL.** In the DAG you'll see an `eval-baseline` group, then per iteration an\n",
+    "`iter-N-generate` group (warm-pool actor tasks), an `iter-N-train` group whose single node fans\n",
+    "out into a **JobSet of `replicas` pods**, and an `iter-N-eval` group. The *Report* tab updates\n",
+    "after every iteration.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import rl_grpo_lora_clustered as part2\n",
+    "\n",
+    "# Dataset, iterations, model, and trainer shape all follow GRPO_PROFILE; override here to deviate.\n",
+    "print(f\"profile={tutorial.PROFILE_NAME}: {tutorial.BASE_MODEL_REPO}, {tutorial.DEFAULT_DATASET}, \"\n",
+    "      f\"{part2.NUM_ITERATIONS} iters, trainer {part2.REPLICAS}x{part2.NPROC_PER_NODE} GPUs\")\n",
+    "rl2_run = flyte.with_runcontext(interactive_mode=False).run(\n",
+    "    part2.train_rl_clustered,\n",
+    "    base=base_dir,                       # the prefetched base model for this profile\n",
+    "    num_iterations=part2.NUM_ITERATIONS, # profile default (smoke: 3, stress: 20)\n",
+    "    dataset=tutorial.DEFAULT_DATASET,    # profile default (smoke: arithmetic, stress: gsm8k)\n",
+    "    pipelined=True,\n",
+    ")\n",
+    "print(\"\u25b6 Watch the multi-node run:\", rl2_run.url)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Wait for completion, fetch the adapter, check the receipts\n",
+    "\n",
+    "You can leave this running \u2014 even if Colab disconnects, **the run continues on the cluster**\n",
+    "(that's the point of Colab-as-client). Re-attach later from any machine, or just use the UI.\n",
+    "\n",
+    "When it finishes, the Report tab should show, even on the smoke profile:\n",
+    "\n",
+    "- **Per-iteration table**: `contributing` > 0 \u2014 the gradient path really ran on every rank.\n",
+    "- **Off-policy drift chart**: importance ratio \u2248 1, clip fraction well under 1%, KL exactly 0 on\n",
+    "  step 1 (a fresh LoRA *is* the base model) and small-but-nonzero afterwards. The ~0.5% clip\n",
+    "  fraction you see even fully on-policy is pure vLLM-vs-HuggingFace numerics mismatch \u2014 a known\n",
+    "  training/inference gap, measured here for free.\n",
+    "- **Timing chart**: on the smoke profile the clustered step (~2\u201310 min including JobSet\n",
+    "  spin-up) is *longer* than the ~1 min of generation, so pipelining can only hide that minute.\n",
+    "  That inversion is the point of the stress profile below.\n",
+    "- **Held-out eval**: on the toy set it reuses the 8 training questions \u2014 a wiring check only.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "rl2_run.wait()\n",
+    "\n",
+    "outputs = rl2_run.outputs()\n",
+    "if inspect.isawaitable(outputs):\n",
+    "    outputs = asyncio.get_event_loop().run_until_complete(outputs)\n",
+    "if not outputs or outputs[0] is None:\n",
+    "    raise RuntimeError(\n",
+    "        f\"No outputs \u2014 the run did not succeed. Open {rl2_run.url}, click the failed action, \"\n",
+    "        \"and read its logs/error before re-running.\"\n",
+    "    )\n",
+    "adapter = outputs[0]\n",
+    "print(\"Trained LoRA adapter (flyte.io.Dir):\", adapter.path)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Switch to the stress profile \u2014 where the async claim becomes true\n",
+    "\n",
+    "The cell below flips `GRPO_PROFILE`, reloads the three modules (they read the profile at import\n",
+    "time, so a plain env-var change is not enough), and prefetches **Qwen3-8B**. Then go back and\n",
+    "**re-run sections 6 and 7**: the pool replicas size up for the 8B, and the trainer becomes\n",
+    "**2 pods \u00d7 4 L40S** (world size 8, two clipped epochs per step) on 192 rollouts of up to 512\n",
+    "GSM8K tokens per iteration. To go back, set the value to `\"smoke\"` and run the cell again.\n",
+    "\n",
+    "What to expect, from a reference run on a Union demo tenant:\n",
+    "\n",
+    "- **Held-out GSM8K accuracy (64 questions, greedy): 61% baseline \u2192 ~86\u201392% after 20 steps.**\n",
+    "  Part of that gain is the model learning the task's answer format and length budget under a\n",
+    "  deliberately plain prompt (no chat template, 512-token cap) \u2014 legitimate RLVR behaviour, and\n",
+    "  worth stating plainly rather than reading it as new math ability.\n",
+    "- **Steady state \u2248 5 min per iteration, all of it generation.** The clustered step\n",
+    "  (JobSet spin-up + 8B load + training, ~2.3 min) starts 1\u20132 s after the next batch's\n",
+    "  generation begins and finishes ~2 min *before* it \u2014 entirely hidden. Sequentially the same\n",
+    "  iteration is ~7.3 min, so pipelining is worth roughly a third of the wall-clock.\n",
+    "- **Evals never touch the critical path**; only the final one is waited on.\n",
+    "- **`contributing` falls from ~180 to ~100 of 192** as more prompt groups become all-correct \u2014\n",
+    "  textbook GRPO saturation, and the cue to move to harder prompts.\n",
+    "- **The first JobSet can wait a long time for 4-GPU nodes.** On the reference run Karpenter\n",
+    "  took 3\u00bd hours to obtain two `g6e.12xlarge` instances; the driver simply waited (iteration-1\n",
+    "  generation had already finished) and the run completed without a failure. Budget for it, and\n",
+    "  give the tenant owner a heads-up before pinning two 4-GPU nodes for a couple of hours.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import importlib, os\n",
+    "import report_helpers, rl_grpo_lora, rl_grpo_lora_clustered\n",
+    "\n",
+    "os.environ[\"GRPO_PROFILE\"] = \"stress\"   # or \"smoke\" to switch back\n",
+    "\n",
+    "# Reload in dependency order so every module sees the new profile.\n",
+    "for m in (report_helpers, rl_grpo_lora, rl_grpo_lora_clustered):\n",
+    "    importlib.reload(m)\n",
+    "tutorial, part2 = rl_grpo_lora, rl_grpo_lora_clustered\n",
+    "print(f\"profile={tutorial.PROFILE_NAME}: {tutorial.BASE_MODEL_REPO}, {tutorial.DEFAULT_DATASET}, \"\n",
+    "      f\"{part2.NUM_ITERATIONS} iters, trainer {part2.REPLICAS}x{part2.NPROC_PER_NODE} GPUs\")\n",
+    "\n",
+    "base_dir = prefetch_base(tutorial.BASE_MODEL_REPO)   # the profile's base model (cached if already fetched)\n",
+    "print(\"Base model in object store:\", base_dir.path)\n",
+    "print(\"\u2192 now re-run sections 6 and 7\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Optional: the sequential comparison\n",
+    "\n",
+    "The timing chart's overlap figure (`\u03a3 generate + train \u2212 iteration`) is measured within a single\n",
+    "run, but the cleanest evidence is a second run with pipelining off \u2014 same objective, same\n",
+    "trainer, same eval, only the overlap removed. Run it under the same profile and compare the two\n",
+    "Report tabs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "rl2_seq = flyte.with_runcontext(interactive_mode=False).run(\n",
+    "    part2.train_rl_clustered,\n",
+    "    base=base_dir,\n",
+    "    num_iterations=part2.NUM_ITERATIONS,\n",
+    "    dataset=tutorial.DEFAULT_DATASET,\n",
+    "    pipelined=False,                     # generate \u2192 train \u2192 generate \u2192 train ...\n",
+    ")\n",
+    "print(\"\u25b6 Sequential run:\", rl2_seq.url)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Appendix (optional): the single-GPU Part-1 loop\n",
+    "\n",
+    "Nothing above depends on running Part 1 \u2014 Part 2 only *imports* it. Run this if you want to see\n",
+    "the single-pod loop from the original tutorial in action. It is pinned to 3 iterations: under\n",
+    "the stress profile it would otherwise spend hours doing 20 iterations of the simplified\n",
+    "REINFORCE objective on one GPU. Note it is **not** the right baseline for the pipelining claim\n",
+    "(different objective, one optimizer step per iteration, no eval); section 9 is.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "rl1_run = flyte.with_runcontext(interactive_mode=False).run(\n",
+    "    tutorial.train_rl,\n",
+    "    base=base_dir,\n",
+    "    num_iterations=3,   # pinned: this is a demonstration, not a benchmark\n",
+    ")\n",
+    "print(\"\u25b6 Part-1 single-GPU run:\", rl1_run.url)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "grpo_rl_colab_client.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/v2/tutorials/multinode_rl_grpo_lora/report_helpers.py
+++ b/v2/tutorials/multinode_rl_grpo_lora/report_helpers.py
@@ -1,0 +1,465 @@
+"""HTML report helpers for the GRPO loop.
+
+Pure-python (no extra dependencies) so the CPU driver task stays light. Builds a single self-contained
+HTML body for ``flyte.report`` that shows per-iteration GRPO progress (reward, accuracy, format
+adherence, loss) plus a running summary. The driver rebuilds and re-publishes this every iteration via
+``flyte.report.replace.aio(render_report(...), do_flush=True)`` so progress streams live in the UI.
+
+The visual style intentionally mirrors the sibling ``llm_fine_tuning_lora_qlora`` example.
+"""
+
+from __future__ import annotations
+
+import html
+from dataclasses import dataclass
+
+REPORT_CSS = """
+<style>
+  .report { font-family: system-ui, -apple-system, sans-serif; max-width: 960px; margin: 0 auto; color: #1a1a2e; }
+  .report h2 { color: #16213e; border-bottom: 2px solid #0f3460; padding-bottom: 8px; margin-top: 24px; }
+  .report h3 { color: #0f3460; margin-top: 20px; }
+  .report .card { background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 12px 0; }
+  .report .stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin: 12px 0; }
+  .report .stat { background: #fff; border: 1px solid #e9ecef; border-radius: 6px; padding: 12px; text-align: center; }
+  .report .stat .value { font-size: 1.5em; font-weight: 700; color: #0f3460; }
+  .report .stat .label { font-size: 0.85em; color: #6c757d; margin-top: 4px; }
+  .report .stat .delta-up { color: #1e7e34; font-size: 0.8em; }
+  .report .stat .delta-down { color: #b02a37; font-size: 0.8em; }
+  .report table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+  .report th { background: #0f3460; color: #fff; padding: 10px 14px; text-align: left; font-weight: 600; }
+  .report td { padding: 8px 14px; border-bottom: 1px solid #dee2e6; }
+  .report tr:nth-child(even) { background: #f8f9fa; }
+  .report .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: 10px 14px; border-radius: 4px; margin: 12px 0; font-size: 0.9em; }
+  .report .chart-container { background: #fff; border: 1px solid #dee2e6; border-radius: 8px; padding: 16px; margin: 16px 0; }
+  .report pre.sample { background: #1a1a2e; color: #e6e6e6; padding: 12px 14px; border-radius: 6px; overflow-x: auto; white-space: pre-wrap; font-size: 0.85em; line-height: 1.4; }
+  .report .muted { color: #6c757d; font-size: 0.85em; }
+</style>
+"""
+
+
+@dataclass
+class IterationMetrics:
+    """One row of GRPO progress, accumulated by the driver after each outer step."""
+
+    iteration: int
+    adapter_version: int
+    num_rollouts: int
+    mean_reward: float
+    max_reward: float
+    accuracy: float  # fraction of completions with the exactly-correct answer
+    format_rate: float  # fraction of completions that emitted the '####' marker
+    mean_loss: float  # mean GRPO loss reported by train_step
+    contributing: int  # rollouts that produced a gradient (non-zero advantage)
+    sample_question: str
+    sample_completion: str
+    sample_reward: float
+    # Part-2 (clustered/async) fields — all defaulted so Part-1 rows and old checkpoints still load.
+    eval_accuracy: float | None = None  # held-out greedy-eval accuracy after this iteration's step
+    mean_ratio: float | None = None  # mean importance ratio pi_new/pi_old (staleness signal)
+    clip_fraction: float | None = None  # fraction of tokens outside the 1±eps clip window
+    mean_kl: float | None = None  # mean k3 KL vs the adapter-disabled reference
+    gen_seconds: float | None = None  # wall time to generate+score this iteration's rollouts
+    train_seconds: float | None = None  # wall time of the clustered train step
+    iter_seconds: float | None = None  # end-to-end iteration wall time (shows pipelining overlap)
+
+
+def wrap_report(body: str) -> str:
+    """Wrap an HTML fragment with the report stylesheet + container div."""
+    return f'{REPORT_CSS}<div class="report">{body}</div>'
+
+
+def _tick_label(value: float, step: float) -> str:
+    """Format an axis tick with just enough precision that ticks `step` apart read as different.
+
+    A fixed ``.2f`` collapses small-range series (KL ≈ 0.0007–0.0046, clip fraction ≈ 0.006) onto
+    identical labels, so the axis looks frozen while the line moves. Show two significant figures
+    of the tick spacing instead: step 0.00078 → 5 decimals, step 0.2 → 2, step 2500 → 0. Beyond six
+    decimals fall back to scientific notation.
+    """
+    import math
+
+    if step <= 0 or not math.isfinite(step):
+        return f"{value:.2f}"
+    decimals = max(0, 1 - math.floor(math.log10(step)))
+    if decimals > 6:
+        return f"{value:.2e}"
+    return f"{value:.{decimals}f}"
+
+
+def make_line_chart(
+    data: list[dict],
+    x_key: str,
+    y_keys: list[str],
+    title: str = "",
+    x_label: str = "",
+    y_label: str = "",
+    y_display_names: dict[str, str] | None = None,
+    colors: list[str] | None = None,
+    width: int = 720,
+    height: int = 300,
+) -> str:
+    """Generate a self-contained SVG line chart from a list of dicts (no plotting deps)."""
+    colors = colors or ["#0f3460", "#06d6a0", "#ffc107", "#5a7db5", "#6c757d"]
+
+    x_vals = [d[x_key] for d in data] if data else []
+    x_min, x_max = (min(x_vals), max(x_vals)) if x_vals else (0, 1)
+    x_range = (x_max - x_min) or 1
+
+    all_y = [d[k] for k in y_keys for d in data if k in d]
+    y_min = min(all_y) if all_y else 0.0
+    y_max = max(all_y) if all_y else 1.0
+    y_pad = (y_max - y_min) * 0.1 or 0.1
+    y_min_plot = y_min - y_pad
+    if y_min >= 0 > y_min_plot:
+        y_min_plot = 0.0  # non-negative data (fractions, seconds): never pad below zero
+    y_max_plot = y_max + y_pad
+    y_range = (y_max_plot - y_min_plot) or 1
+    y_step = y_range / 5
+    y_tick_labels = [_tick_label(y_min_plot + y_step * i, y_step) for i in range(6)]
+
+    # Left margin grows with the widest tick label (~6.5px per character at font-size 11).
+    ml = max(60, 12 + int(6.5 * max(len(s) for s in y_tick_labels)))
+    mr, mt, mb = 20, 40, 50
+    cw = width - ml - mr
+    ch = height - mt - mb
+
+    def sx(v: float) -> float:
+        return ml + (v - x_min) / x_range * cw
+
+    def sy(v: float) -> float:
+        return mt + ch - (v - y_min_plot) / y_range * ch
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" '
+        f'style="width:100%;max-width:{width}px;height:auto;">',
+        f'<rect width="{width}" height="{height}" fill="#fff" rx="6"/>',
+    ]
+
+    # Horizontal grid + y ticks (label precision follows the tick spacing — see _tick_label)
+    for i, label in enumerate(y_tick_labels):
+        py = sy(y_min_plot + y_step * i)
+        lines.append(f'<line x1="{ml}" y1="{py:.1f}" x2="{ml + cw}" y2="{py:.1f}" stroke="#e9ecef" stroke-width="1"/>')
+        lines.append(
+            f'<text x="{ml - 8}" y="{py + 4:.1f}" text-anchor="end" font-size="11" fill="#6c757d">{label}</text>'
+        )
+
+    # Axes
+    lines.append(f'<line x1="{ml}" y1="{mt}" x2="{ml}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+    lines.append(f'<line x1="{ml}" y1="{mt + ch}" x2="{ml + cw}" y2="{mt + ch}" stroke="#adb5bd" stroke-width="1.5"/>')
+
+    # X ticks (integer iteration labels)
+    for i, xv in enumerate(x_vals):
+        px = sx(xv)
+        lines.append(
+            f'<text x="{px:.1f}" y="{mt + ch + 20}" text-anchor="middle" font-size="11" fill="#6c757d">{int(xv)}</text>'
+        )
+
+    if not data:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{mt + ch / 2}" text-anchor="middle" font-size="13" '
+            f'fill="#adb5bd" font-style="italic">Waiting for the first iteration...</text>'
+        )
+
+    # Series
+    for si, key in enumerate(y_keys):
+        color = colors[si % len(colors)]
+        points = [(sx(d[x_key]), sy(d[key])) for d in data if key in d]
+        if not points:
+            continue
+        if len(points) >= 2:
+            path_d = f"M {points[0][0]:.1f},{points[0][1]:.1f}" + "".join(
+                f" L {px:.1f},{py:.1f}" for px, py in points[1:]
+            )
+            lines.append(f'<path d="{path_d}" fill="none" stroke="{color}" stroke-width="2" stroke-linejoin="round"/>')
+        for px, py in points:
+            lines.append(f'<circle cx="{px:.1f}" cy="{py:.1f}" r="3" fill="{color}"/>')
+
+    if title:
+        lines.append(
+            f'<text x="{width / 2}" y="22" text-anchor="middle" font-size="14" font-weight="600" '
+            f'fill="#1a1a2e">{html.escape(title)}</text>'
+        )
+    if x_label:
+        lines.append(
+            f'<text x="{ml + cw / 2}" y="{height - 6}" text-anchor="middle" font-size="12" '
+            f'fill="#6c757d">{html.escape(x_label)}</text>'
+        )
+    if y_label:
+        lines.append(
+            f'<text x="14" y="{mt + ch / 2}" text-anchor="middle" font-size="12" fill="#6c757d" '
+            f'transform="rotate(-90, 14, {mt + ch / 2})">{html.escape(y_label)}</text>'
+        )
+
+    # Legend
+    names = y_display_names or {}
+    if len(y_keys) > 1:
+        for si, key in enumerate(y_keys):
+            color = colors[si % len(colors)]
+            ly = mt + 14 + si * 18
+            lines.append(f'<rect x="{ml + 10}" y="{ly - 6}" width="12" height="12" rx="2" fill="{color}"/>')
+            lines.append(
+                f'<text x="{ml + 28}" y="{ly + 4}" font-size="11" fill="#1a1a2e">{html.escape(names.get(key, key))}</text>'
+            )
+
+    lines.append("</svg>")
+    return "\n".join(lines)
+
+
+def _delta_html(curr: float, prev: float | None, fmt: str = "{:+.3f}") -> str:
+    if prev is None:
+        return ""
+    d = curr - prev
+    cls = "delta-up" if d >= 0 else "delta-down"
+    arrow = "▲" if d >= 0 else "▼"
+    return f'<div class="{cls}">{arrow} {fmt.format(d)}</div>'
+
+
+def render_report(
+    history: list[IterationMetrics],
+    *,
+    base_model: str,
+    num_iterations: int,
+    group_size: int,
+    prompts_per_iter: int,
+    lora_rank: int,
+    learning_rate: float,
+    status: str = "running",
+    extra: dict | None = None,
+) -> str:
+    """Render the full GRPO progress report (returns an HTML body for ``flyte.report.replace``).
+
+    ``extra`` is Part-2 run config (dataset, pipelined, clip_eps, kl_beta, replicas,
+    baseline_accuracy). When present it switches the objective note to the clipped-ratio + KL form
+    and adds the eval / staleness / timing charts (each rendered only if its data exists).
+    """
+    latest = history[-1] if history else None
+    prev = history[-2] if len(history) >= 2 else None
+    extra = extra or {}
+    baseline_accuracy = extra.get("baseline_accuracy")
+
+    # --- Header + run config ---
+    parts: list[str] = []
+    badge = "✅ complete" if status == "complete" else "⏳ running"
+    parts.append(f"<h2>GRPO + LoRA training progress &nbsp;<span class='muted'>({badge})</span></h2>")
+    config_bits = [
+        f"<b>Base model:</b> <code>{html.escape(base_model)}</code>",
+        f"<b>Iterations:</b> {len(history)}/{num_iterations}",
+        f"<b>Group size (G):</b> {group_size}",
+        f"<b>Prompts/iter:</b> {prompts_per_iter}",
+        f"<b>LoRA rank:</b> {lora_rank}",
+        f"<b>LR:</b> {learning_rate:g}",
+    ]
+    for key in ("profile", "dataset", "pipelined", "replicas", "nproc_per_node", "clip_eps", "kl_beta"):
+        if key in extra:
+            config_bits.append(f"<b>{html.escape(key)}:</b> {html.escape(str(extra[key]))}")
+    parts.append("<div class='card'>" + " &nbsp;|&nbsp; ".join(config_bits) + "</div>")
+    if "clip_eps" in extra:
+        parts.append(
+            "<div class='note'><b>Objective:</b> token-level clipped-ratio GRPO — maximize "
+            "<code>mean&#8203;<sub>t</sub> min( r<sub>t</sub> A&#770;, clip(r<sub>t</sub>, 1&minus;&epsilon;, "
+            "1+&epsilon;) A&#770; ) &minus; &beta;&middot;KL<sub>k3</sub>(&pi;<sub>&theta;</sub> &Vert; "
+            "&pi;<sub>ref</sub>)</code> with <code>r<sub>t</sub> = &pi;<sub>&theta;</sub>(o<sub>t</sub>) / "
+            "&pi;<sub>old</sub>(o<sub>t</sub>)</code> from vLLM sampling-time logprobs and the reference = "
+            "the adapter-disabled base. The importance ratio is what makes the one-step-off-policy "
+            "(pipelined) training sound.</div>"
+        )
+    else:
+        parts.append(
+            "<div class='note'><b>Objective:</b> single-step, group-normalized GRPO policy gradient — "
+            "maximize <code>mean( A&#770;<sub>i</sub> &middot; mean&#8203;<sub>t</sub> log &pi;<sub>&theta;</sub>"
+            "(o<sub>i,t</sub>) )</code> with "
+            "<code>A&#770;<sub>i</sub> = (r<sub>i</sub> &minus; mean&#8203;<sub>group</sub>) / "
+            "(std&#8203;<sub>group</sub> + &epsilon;)</code> over completions, training the LoRA adapter only. "
+            "(No PPO clip / no KL term in this MVP — see <code>README.md</code>.)</div>"
+        )
+
+    # --- Summary stat cards (latest values, with delta vs previous iter) ---
+    if latest is not None:
+        parts.append("<h3>Latest iteration</h3>")
+        parts.append("<div class='stat-grid'>")
+        cards = [
+            ("Mean reward", f"{latest.mean_reward:.3f}", _delta_html(latest.mean_reward, prev.mean_reward if prev else None)),
+            ("Accuracy", f"{latest.accuracy * 100:.1f}%", _delta_html(latest.accuracy, prev.accuracy if prev else None, "{:+.1%}")),
+            ("Format rate", f"{latest.format_rate * 100:.1f}%", _delta_html(latest.format_rate, prev.format_rate if prev else None, "{:+.1%}")),
+            ("Mean loss", f"{latest.mean_loss:.4f}", _delta_html(latest.mean_loss, prev.mean_loss if prev else None, "{:+.4f}")),
+            ("Adapter version", f"v{latest.adapter_version}", ""),
+        ]
+        if latest.eval_accuracy is not None:
+            # Delta vs the pre-training baseline (not vs the previous iteration) — the headline number.
+            cards.insert(
+                2,
+                (
+                    "Eval accuracy (held-out)"
+                    + (f" — base {baseline_accuracy * 100:.1f}%" if baseline_accuracy is not None else ""),
+                    f"{latest.eval_accuracy * 100:.1f}%",
+                    _delta_html(latest.eval_accuracy, baseline_accuracy, "{:+.1%}"),
+                ),
+            )
+        for label, value, delta in cards:
+            parts.append(f"<div class='stat'><div class='value'>{value}</div>{delta}<div class='label'>{label}</div></div>")
+        parts.append("</div>")
+
+    # --- Charts ---
+    # Optional Part-2 keys are added only when set; make_line_chart skips rows missing a key, so
+    # mixed-cadence series (e.g. eval every K iterations) degrade gracefully.
+    chart_data: list[dict] = []
+    for m in history:
+        row: dict = {
+            "iter": m.iteration,
+            "mean_reward": m.mean_reward,
+            "accuracy": m.accuracy,
+            "format_rate": m.format_rate,
+            "mean_loss": m.mean_loss,
+        }
+        if m.eval_accuracy is not None:
+            row["eval_accuracy"] = m.eval_accuracy
+        if m.mean_ratio is not None:
+            row["ratio_dev"] = abs(m.mean_ratio - 1.0)  # |mean ratio − 1|: distance off-policy
+        if m.clip_fraction is not None:
+            row["clip_fraction"] = m.clip_fraction
+        if m.mean_kl is not None:
+            row["mean_kl"] = m.mean_kl
+        if m.gen_seconds is not None:
+            row["gen_seconds"] = m.gen_seconds
+        if m.train_seconds is not None:
+            row["train_seconds"] = m.train_seconds
+        if m.iter_seconds is not None:
+            row["iter_seconds"] = m.iter_seconds
+        chart_data.append(row)
+    parts.append("<div class='chart-container'>")
+    parts.append(
+        make_line_chart(
+            chart_data,
+            x_key="iter",
+            y_keys=["mean_reward", "accuracy", "format_rate"],
+            title="Reward & correctness vs. iteration",
+            x_label="iteration",
+            y_display_names={"mean_reward": "mean reward", "accuracy": "accuracy", "format_rate": "format rate"},
+        )
+    )
+    parts.append("</div>")
+    parts.append("<div class='chart-container'>")
+    parts.append(
+        make_line_chart(
+            chart_data,
+            x_key="iter",
+            y_keys=["mean_loss"],
+            title="GRPO loss vs. iteration",
+            x_label="iteration",
+            colors=["#b02a37"],
+        )
+    )
+    parts.append("</div>")
+
+    # --- Part-2 charts (rendered only when their series exist in the data) ---
+    if any("eval_accuracy" in d for d in chart_data):
+        parts.append("<div class='chart-container'>")
+        if baseline_accuracy is not None:
+            parts.append(
+                f"<p class='muted'>Held-out eval, greedy decoding. Pre-training baseline (base model, "
+                f"no adapter): <b>{baseline_accuracy * 100:.1f}%</b>.</p>"
+            )
+        parts.append(
+            make_line_chart(
+                chart_data,
+                x_key="iter",
+                y_keys=["eval_accuracy"],
+                title="Held-out eval accuracy vs. iteration",
+                x_label="iteration",
+                colors=["#06d6a0"],
+            )
+        )
+        parts.append("</div>")
+    if any(k in d for k in ("ratio_dev", "clip_fraction", "mean_kl") for d in chart_data):
+        parts.append("<div class='chart-container'>")
+        parts.append(
+            "<p class='muted'>Staleness / trust-region signals: with pipelining the trainer consumes "
+            "rollouts one adapter version old, so ratios drift off 1 and the clip engages — this chart "
+            "is what makes the async claim measurable.</p>"
+        )
+        parts.append(
+            make_line_chart(
+                chart_data,
+                x_key="iter",
+                y_keys=["ratio_dev", "clip_fraction", "mean_kl"],
+                title="Off-policy drift vs. iteration",
+                x_label="iteration",
+                y_display_names={
+                    "ratio_dev": "|mean ratio − 1|",
+                    "clip_fraction": "clip fraction",
+                    "mean_kl": "KL(policy ‖ ref)",
+                },
+            )
+        )
+        parts.append("</div>")
+    if any(k in d for k in ("gen_seconds", "train_seconds", "iter_seconds") for d in chart_data):
+        timed = [d for d in chart_data if "iter_seconds" in d]
+        parts.append("<div class='chart-container'>")
+        if timed:
+            saved = sum(d.get("gen_seconds", 0.0) + d.get("train_seconds", 0.0) - d["iter_seconds"] for d in timed)
+            parts.append(
+                f"<p class='muted'>Wall-clock per iteration. Overlap hidden by pipelining so far: "
+                f"<b>{saved:.0f}s</b> (Σ gen + train − iter; ≈0 for a sequential run).</p>"
+            )
+        parts.append(
+            make_line_chart(
+                chart_data,
+                x_key="iter",
+                y_keys=["gen_seconds", "train_seconds", "iter_seconds"],
+                title="Iteration timing (generation vs. training vs. end-to-end)",
+                x_label="iteration",
+                y_label="seconds",
+                y_display_names={
+                    "gen_seconds": "generate+score",
+                    "train_seconds": "clustered train step",
+                    "iter_seconds": "iteration end-to-end",
+                },
+            )
+        )
+        parts.append("</div>")
+
+    # --- Per-iteration table ---
+    parts.append("<h3>Per-iteration metrics</h3>")
+    parts.append(
+        "<table><tr><th>Iter</th><th>Adapter</th><th>Rollouts</th><th>Mean reward</th>"
+        "<th>Max reward</th><th>Accuracy</th><th>Format</th><th>Mean loss</th><th>Contributing</th></tr>"
+    )
+    for m in history:
+        parts.append(
+            f"<tr><td>{m.iteration}</td><td>v{m.adapter_version}</td><td>{m.num_rollouts}</td>"
+            f"<td>{m.mean_reward:.3f}</td><td>{m.max_reward:.3f}</td>"
+            f"<td>{m.accuracy * 100:.1f}%</td><td>{m.format_rate * 100:.1f}%</td>"
+            f"<td>{m.mean_loss:.4f}</td><td>{m.contributing}/{m.num_rollouts}</td></tr>"
+        )
+    parts.append("</table>")
+
+    # --- Best sample from the latest iteration (qualitative signal) ---
+    if latest is not None:
+        parts.append("<h3>Best completion (latest iteration)</h3>")
+        parts.append(
+            f"<p class='muted'>Question: <b>{html.escape(latest.sample_question)}</b> &nbsp;|&nbsp; "
+            f"reward = {latest.sample_reward:.2f}</p>"
+        )
+        parts.append(f"<pre class='sample'>{html.escape(latest.sample_completion.strip()) or '(empty)'}</pre>")
+
+    # --- Final summary ---
+    if status == "complete" and history:
+        first, last = history[0], history[-1]
+        eval_bit = ""
+        if last.eval_accuracy is not None and baseline_accuracy is not None:
+            eval_bit = (
+                f" Held-out eval accuracy: <b>{baseline_accuracy * 100:.1f}% (base) → "
+                f"{last.eval_accuracy * 100:.1f}%</b> ({last.eval_accuracy - baseline_accuracy:+.1%})."
+            )
+        parts.append("<h2>Summary</h2>")
+        parts.append(
+            "<div class='card'>"
+            f"Trained <b>{len(history)}</b> GRPO iterations on <code>{html.escape(base_model)}</code>. "
+            f"Mean reward moved <b>{first.mean_reward:.3f} → {last.mean_reward:.3f}</b> "
+            f"({last.mean_reward - first.mean_reward:+.3f}); "
+            f"accuracy <b>{first.accuracy * 100:.1f}% → {last.accuracy * 100:.1f}%</b>; "
+            f"format adherence <b>{first.format_rate * 100:.1f}% → {last.format_rate * 100:.1f}%</b>. "
+            f"Final adapter: <b>v{last.adapter_version}</b>." + eval_bit + "</div>"
+        )
+
+    return wrap_report("".join(parts))

--- a/v2/tutorials/multinode_rl_grpo_lora/rl_grpo_lora.py
+++ b/v2/tutorials/multinode_rl_grpo_lora/rl_grpo_lora.py
@@ -1,0 +1,813 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "unionai-reuse>=0.1.3",
+#    "async-lru>=2.0.0",
+#    "torch>=2.5.0",
+#    "transformers>=4.51.0",
+#    "peft>=0.13.0",
+#    "vllm>=0.11.0",
+#    "accelerate>=0.34.0",
+# ]
+# main = "train_rl"
+# params = ""
+# ///
+"""
+GRPO + LoRA reinforcement learning for LLMs on Union with flyte-sdk
+==================================================================
+
+A runnable reinforcement-learning loop for LLMs (GRPO with LoRA), orchestrated by ordinary Flyte async
+tasks. The sibling ``README.md`` is a step-by-step tutorial that explains the concepts; this module is
+the implementation. The loop has the standard RL-for-LLMs shape::
+
+    sample prompts -> generate rollouts (vLLM) -> score (reward) -> policy update (LoRA) -> refresh adapter -> repeat
+
+Flyte with Union fits this well: each stage runs in its own right-sized environment (GPU rollouts and
+trainer, CPU reward and driver), the driver is just an ``async`` ``for`` loop, the run is resumable via
+``flyte.Checkpoint``, and progress streams to a live ``flyte.report``. The one technique unique to
+RL-for-LLMs is *keeping vLLM warm in a reusable container and swapping the LoRA adapter each
+iteration* — everything else is ordinary Flyte.
+
+What runs where
+---------------
+- ``generate``   — **reusable, warm** ``TaskEnvironment`` (``ReusePolicy``). Holds an in-process vLLM
+                   ``LLM(enable_lora=True)`` engine as a module global so the frozen base never
+                   reloads; the per-iteration LoRA adapter is attached per request via ``LoRARequest``.
+- ``score_group``— plain CPU ``@task``, rule-based / verifiable reward (exact-match + format). Scores a
+                   whole prompt group per call (one reward task per group, not per rollout).
+- ``init_adapter`` / ``train_step`` — single-node GPU ``@task``; one GRPO step over the
+                   externally-generated rollouts, training only the PEFT LoRA adapter (base frozen),
+                   returning the new adapter as a ``flyte.io.Dir`` (a few MB).
+- ``train_rl``   — the driver: a plain async ``@task`` running ``for it in range(N)``, fanning out
+                   rollouts with ``asyncio.create_task`` and scoring each the moment it finishes with
+                   ``asyncio.as_completed`` (no ``flyte.map`` barrier), then calling ``train_step``.
+                   Resumes loop state from ``flyte.Checkpoint`` and wraps each iteration in
+                   ``flyte.group(f"iter-{it}")``.
+
+Two implementation choices worth knowing (also explained in the README):
+
+1. **A custom GRPO step rather than a library trainer (e.g. TRL ``GRPOTrainer``).** Library trainers
+   own the whole loop — they generate completions *and* call the reward function internally — so they
+   can't consume the rollouts+rewards we produce in separate tasks, and would bypass the warm vLLM
+   pool and the as-completed pipelining that are the point of running this on Flyte. The loss here is
+   the standard group-normalized policy gradient (advantage = ``(r - mean_group)/(std_group + eps)``),
+   trained through the PEFT LoRA params only. See ``train_step``.
+
+2. **Plain-HF prefetch rather than vLLM-sharded weights.** vLLM's pre-sharded layout
+   (``model-rank-*-part-*.safetensors``) is *not* readable by the HF/PEFT trainer, and for
+   ``tensor_parallel_size=1`` + a small model vLLM loads plain HF weights directly with no benefit
+   lost. Pre-sharding only pays off for TP>1 rollout replicas, which would then need a *separate* HF
+   copy of the base for the trainer. Here one plain-HF ``Dir`` feeds both generator and trainer.
+
+API verification
+----------------
+Signatures below were checked against source, not assumed:
+- ``flyte`` (src/flyte): ``TaskEnvironment``, ``ReusePolicy(replicas, idle_ttl, concurrency,
+  scaledown_ttl)``, ``Resources``, ``GPU``, ``Secret(key, as_env_var)``, ``Image.from_debian_base``,
+  ``Checkpoint`` (``await load()/save(bytes|path)``), ``group``, ``io.Dir`` (``download``,
+  ``from_local``, ``from_existing_remote``), ``prefetch.hf_model`` (returns a ``Run``; the output
+  ``Dir`` is ``(await run.outputs())[0]``).
+- vLLM 0.11.0 (uv cache): ``vllm.LLM(model=..., enable_lora=True, max_lora_rank=...)``,
+  ``LLM.generate(prompts, sampling_params, lora_request=...)``,
+  ``vllm.lora.request.LoRARequest(lora_name, lora_int_id, lora_path)`` (``lora_int_id >= 1``).
+- PEFT (stable API): ``LoraConfig`` / ``get_peft_model`` / ``PeftModel.from_pretrained(...,
+  is_trainable=True)`` / ``save_pretrained``.
+
+Run::
+
+    # remote (needs a GPU-backed Union deployment + an HF token secret named `hf-token`)
+    python rl_grpo_lora.py
+
+Validated end to end on a Union demo cluster (Qwen3-0.6B, L4 GPUs, 3 GRPO iterations): prefetch →
+init_adapter → 12 warm-vLLM rollouts → 72 pipelined reward tasks → 3 GRPO train steps → final LoRA
+adapter (v3) returned as a flyte.Dir, with the live flyte.report published each iteration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+from typing import Any
+
+from async_lru import alru_cache
+from pydantic import BaseModel, Field
+
+import flyte
+import flyte.io
+import flyte.report
+from report_helpers import IterationMetrics, render_report
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------------------------------------
+# Configuration — two profiles, selected by the GRPO_PROFILE env var
+# ----------------------------------------------------------------------------------------------------
+# "smoke"  (default): tiny and cheap — proves the wiring end to end in ~25 minutes.
+# "stress": the configuration the tutorial's claims are actually about — an 8B policy, a real
+#           verifiable dataset, enough prompts per iteration that GENERATION is the long pole (so the
+#           async pipelining has something to hide the clustered cold start under), and multi-GPU
+#           trainer pods (2 nodes × 4 L40S). Needs multi-GPU nodes; sized for g6e.12xlarge trainers
+#           and single-L40S rollout replicas.
+#
+# The profile (and GPU_TYPE) is read from the CLIENT environment at deploy time. Everything below
+# that is used inside a task body is re-evaluated when the module is imported in the container, so
+# the same env vars are re-injected into every TaskEnvironment (see _PROFILE_ENV_VARS) — that is what
+# keeps client-side and container-side constants identical.
+#
+#   os.environ["GRPO_PROFILE"] = "stress"    # before importing this module
+#   os.environ["GRPO_GPU_TYPE"] = "L40s"     # tenants without one GPU type can switch here
+PROFILES: dict[str, dict[str, Any]] = {
+    "smoke": dict(
+        base_model="Qwen/Qwen3-0.6B",
+        dataset="arithmetic",
+        num_iterations=3,
+        prompts_per_iter=4,
+        group_size=6,
+        max_new_tokens=256,
+        eval_set_size=32,
+        learning_rate=1e-5,
+        # rollout pool (one GPU per replica) + Part-1 single-GPU trainer
+        pool_cpu=4, pool_memory="24Gi", pool_replicas=(1, 4), pool_idle_ttl=600,
+        # Part-2 clustered trainer
+        train_replicas=2, train_nproc_per_node=1, train_gpus=1, train_cpu=4, train_memory="24Gi",
+        train_epochs_per_step=1,
+    ),
+    "stress": dict(
+        base_model="Qwen/Qwen3-8B",  # bf16 ≈ 16GB: fits one 48GB L40S for both vLLM and DDP training
+        dataset="gsm8k",
+        num_iterations=20,
+        prompts_per_iter=32,  # 32 × 6 = 192 rollouts/iter → ~3-4 min of generation on 4 replicas
+        group_size=6,
+        max_new_tokens=512,  # GSM8K reasoning needs room; 256 truncates an 8B's "brief" reasoning
+        eval_set_size=64,
+        learning_rate=2e-5,  # LoRA-RL typical; 1e-5 barely moves the policy in 20 steps
+        # 8B host-side load needs RAM headroom; idle_ttl must outlive a clustered step (~200-600s)
+        # or the pool scales to zero mid-run and every generation pays a vLLM engine cold start.
+        pool_cpu=6, pool_memory="40Gi", pool_replicas=(2, 4), pool_idle_ttl=1200,
+        # 2 pods × 4 L40S = world size 8. Per-pod: 4 ranks each load the 8B on the host first.
+        train_replicas=2, train_nproc_per_node=4, train_gpus=4, train_cpu=16, train_memory="120Gi",
+        train_epochs_per_step=2,  # amortizes the JobSet cold start; legitimate because the objective clips
+    ),
+}
+PROFILE_NAME = os.environ.get("GRPO_PROFILE", "smoke")
+if PROFILE_NAME not in PROFILES:
+    raise ValueError(f"GRPO_PROFILE={PROFILE_NAME!r}; expected one of {sorted(PROFILES)}")
+PROFILE: dict[str, Any] = PROFILES[PROFILE_NAME]
+GPU_TYPE = os.environ.get("GRPO_GPU_TYPE", "L4")
+# Re-injected into every environment so container-side imports resolve the same profile.
+_PROFILE_ENV_VARS = {"GRPO_PROFILE": PROFILE_NAME, "GRPO_GPU_TYPE": GPU_TYPE}
+
+BASE_MODEL_REPO: str = PROFILE["base_model"]
+DEFAULT_DATASET: str = PROFILE["dataset"]
+NUM_ITERATIONS: int = PROFILE["num_iterations"]  # GRPO outer steps the driver runs
+PROMPTS_PER_ITER: int = PROFILE["prompts_per_iter"]  # prompts (= GRPO groups) sampled per iteration
+GROUP_SIZE: int = PROFILE["group_size"]  # completions per prompt; advantage is normalized within each
+MAX_NEW_TOKENS: int = PROFILE["max_new_tokens"]
+SAMPLING_TEMPERATURE = 1.0  # >0 so the group has diverse samples to rank
+EVAL_SET_SIZE: int = PROFILE["eval_set_size"]  # held-out questions scored by the evaluate task
+
+LORA_RANK = 16
+LORA_ALPHA = 32
+LEARNING_RATE: float = PROFILE["learning_rate"]
+
+# Fixed prompt template shared verbatim by the rollout (vLLM) and trainer (HF) sides so completion
+# tokens line up. Kept deliberately tokenizer-agnostic (no chat template) to avoid vLLM/HF drift.
+SYSTEM_PREAMBLE = (
+    "You are a careful math assistant. Reason briefly, then give the final integer answer on its own "
+    "line prefixed by '#### '."
+)
+
+
+def build_prompt(question: str) -> str:
+    """Render a question into the exact text both rollout and trainer condition on."""
+    return f"{SYSTEM_PREAMBLE}\n\nQuestion: {question}\nAnswer:"
+
+
+# A tiny, fully verifiable dataset (no external download → deterministic + cheap). Each entry is
+# (question, ground-truth integer answer as a string).
+DATASET: list[tuple[str, str]] = [
+    ("What is 12 + 7?", "19"),
+    ("What is 9 * 6?", "54"),
+    ("What is 45 - 18?", "27"),
+    ("What is 100 / 4?", "25"),
+    ("What is 13 + 28?", "41"),
+    ("What is 7 * 8?", "56"),
+    ("What is 81 - 36?", "45"),
+    ("What is 144 / 12?", "12"),
+]
+
+
+# ----------------------------------------------------------------------------------------------------
+# Rollout payload — one sampled completion for one prompt, tagged with its GRPO group.
+# ----------------------------------------------------------------------------------------------------
+class Rollout(BaseModel):
+    group_id: int  # which prompt group this completion belongs to (advantage is normalized per group)
+    question: str  # raw question (reward + trainer re-render the prompt via build_prompt)
+    completion: str  # text the policy generated
+    answer: str  # ground-truth answer, for the verifiable reward
+    # Sampling metadata (defaults keep Part-1-era payloads deserializable). The token ids let the
+    # trainer feed the model EXACTLY what vLLM sampled — re-tokenizing prompt+completion text can merge
+    # boundary tokens and misalign. `logprobs` is log π_old(token) at sampling time, the behavior-policy
+    # side of the importance ratio the Part-2 clustered trainer needs to train off-policy.
+    prompt_token_ids: list[int] = Field(default_factory=list)
+    token_ids: list[int] = Field(default_factory=list)  # completion tokens, as sampled
+    logprobs: list[float] = Field(default_factory=list)  # log π_old per completion token
+
+
+# ----------------------------------------------------------------------------------------------------
+# Images & environments
+# ----------------------------------------------------------------------------------------------------
+# One image shared by every env. Built explicitly (rather than from the uv-script header) so we can
+# pull vLLM's flashinfer kernels as *precompiled cubin wheels* — without them vLLM tries to JIT-compile
+# attention at runtime and fails with "Could not find nvcc" (no CUDA toolkit in the base image). This
+# recipe mirrors the proven examples/genai/vllm/vllm_app.py. torch comes transitively from vllm.
+# `unionai-reuse` provides the actor bridge required by the reusable rollout env. The module top level
+# only imports flyte + pydantic; torch/vllm/transformers/peft are imported lazily inside the GPU tasks.
+# {{docs-fragment image}}
+image = (
+    flyte.Image.from_debian_base(name="rl-grpo-lora")
+    .with_pip_packages("flashinfer-python", "flashinfer-cubin")
+    .with_pip_packages("flashinfer-jit-cache", index_url="https://flashinfer.ai/whl/cu129")
+    .with_pip_packages(
+        "vllm==0.11.0",
+        "transformers==4.57.6",
+        "peft>=0.13.0",
+        "accelerate>=0.34.0",
+        "unionai-reuse>=0.1.3",
+        "async-lru>=2.0.0",
+    )
+    # Appended as its own layer so adding it does not invalidate the (slow) vllm layer cache.
+    .with_pip_packages("datasets>=3.0.0")
+)
+# {{/docs-fragment image}}
+
+HF_SECRET = flyte.Secret(key="hf-token", as_env_var="HF_TOKEN")
+
+# Rollout generator: warm, reusable vLLM. concurrency=1 because a single in-process vLLM engine
+# batches internally and is not safe to drive from several coroutines at once; the driver still
+# pipelines by fanning generate() calls across replicas.
+# {{docs-fragment rollout_env}}
+rollout_env = flyte.TaskEnvironment(
+    name="rl-grpo-rollout",
+    image=image,
+    resources=flyte.Resources(
+        cpu=PROFILE["pool_cpu"], memory=PROFILE["pool_memory"], gpu=flyte.GPU(GPU_TYPE, 1), shm="auto"
+    ),
+    # idle_ttl must outlive one clustered train step, or the pool scales to zero while the trainer
+    # runs and the next generation (and eval) pays a full vLLM engine cold start.
+    reusable=flyte.ReusePolicy(
+        replicas=PROFILE["pool_replicas"], concurrency=1, idle_ttl=PROFILE["pool_idle_ttl"], scaledown_ttl=120
+    ),
+    secrets=[HF_SECRET],
+    env_vars={
+        **_PROFILE_ENV_VARS,
+        "VLLM_USE_V1": "1",
+        # flashinfer-python resolves 0.6.17 against flashinfer-cubin 0.6.13 in this image; the version
+        # check would kill vLLM's EngineCore at startup. Disabling it (and the flashinfer sampler) is
+        # the no-rebuild fix; pinning both wheels to the same version is the slow alternative.
+        "FLASHINFER_DISABLE_VERSION_CHECK": "1",
+        "VLLM_USE_FLASHINFER_SAMPLER": "0",
+    },
+)
+# {{/docs-fragment rollout_env}}
+
+# Reward: cheap, rule-based, CPU only.
+# {{docs-fragment reward_env}}
+reward_env = flyte.TaskEnvironment(
+    name="rl-grpo-reward",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="2Gi"),
+    env_vars=_PROFILE_ENV_VARS,
+)
+# {{/docs-fragment reward_env}}
+
+# Trainer: single node, one GPU (Part 1's train_step; Part 2 reuses only init_adapter from here).
+# {{docs-fragment train_env}}
+train_env = flyte.TaskEnvironment(
+    name="rl-grpo-train",
+    image=image,
+    resources=flyte.Resources(
+        cpu=PROFILE["pool_cpu"], memory=PROFILE["pool_memory"], gpu=flyte.GPU(GPU_TYPE, 1), shm="auto"
+    ),
+    secrets=[HF_SECRET],
+    env_vars=_PROFILE_ENV_VARS,
+)
+# {{/docs-fragment train_env}}
+
+# Driver: plain async orchestration, no GPU. It invokes tasks in the rollout/reward/train envs, so it
+# must declare them via depends_on so their images/environments are registered alongside the driver's.
+# {{docs-fragment driver_env}}
+driver_env = flyte.TaskEnvironment(
+    name="rl-grpo-driver",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="2Gi"),
+    depends_on=[rollout_env, reward_env, train_env],
+    env_vars=_PROFILE_ENV_VARS,
+)
+# {{/docs-fragment driver_env}}
+
+# ----------------------------------------------------------------------------------------------------
+# 1. Rollout generation — warm in-process vLLM with per-request LoRA
+# ----------------------------------------------------------------------------------------------------
+# The expensive per-replica work is cached with @alru_cache, so it happens once and is reused across
+# every generate() call a warm replica handles. We key the caches on the remote URI string (hashable)
+# rather than the flyte.io.Dir object. Returns are typed Any because vLLM is imported lazily.
+
+
+# {{docs-fragment engine_cache}}
+@alru_cache(maxsize=1)
+async def _load_engine(base_uri: str) -> Any:
+    """Build the vLLM engine once per warm replica (cached); the frozen base stays resident in GPU."""
+    from vllm import LLM
+
+    local_base: str = await flyte.io.Dir.from_existing_remote(base_uri).download()  # plain-HF base
+    logger.info("Building warm vLLM engine from %s", local_base)
+    return LLM(
+        model=local_base,
+        enable_lora=True,
+        max_lora_rank=LORA_RANK,
+        max_loras=1,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.85,
+        max_model_len=2048,
+        enforce_eager=True,  # skip CUDA-graph capture → faster cold start for an MVP
+    )
+
+
+@alru_cache(maxsize=None)
+async def _adapter_local_path(adapter_uri: str) -> str:
+    """Download a LoRA adapter once per warm replica (cached by its remote URI → one download/version)."""
+    return await flyte.io.Dir.from_existing_remote(adapter_uri).download()
+# {{/docs-fragment engine_cache}}
+
+
+# {{docs-fragment generate}}
+@rollout_env.task
+async def generate(
+    base: flyte.io.Dir,
+    question: str,
+    answer: str,
+    adapter: flyte.io.Dir,
+    version: int,
+    group_id: int,
+) -> list[Rollout]:
+    """Generate a GROUP_SIZE group of completions for one prompt, using the current LoRA adapter.
+
+    The frozen base loads exactly once per replica (cached ``_load_engine``); each adapter version is
+    downloaded once (cached ``_adapter_local_path``) and attached per request via ``LoRARequest`` — the
+    base weights in GPU memory are never touched.
+    """
+    from vllm import SamplingParams
+    from vllm.lora.request import LoRARequest
+
+    engine: Any = await _load_engine(base.path)
+    adapter_path: str = await _adapter_local_path(adapter.path)
+
+    # lora_int_id must be >= 1 and unique per adapter; version starts at 0 so shift by 1.
+    lora: LoRARequest = LoRARequest(f"policy-v{version}", version + 1, adapter_path)
+    # logprobs=0 returns the sampled token's logprob only (the cheapest setting). NOTE: vLLM reports
+    # post-processing logprobs, so they equal log π_old only while SAMPLING_TEMPERATURE == 1.0 and no
+    # top-k/top-p truncation reweighting applies (top_p=1.0 here) — the importance ratios in the
+    # Part-2 trainer rely on this.
+    assert SAMPLING_TEMPERATURE == 1.0, "sampling logprobs stop being log pi_old off temperature 1.0"
+    sampling: SamplingParams = SamplingParams(
+        n=GROUP_SIZE,
+        temperature=SAMPLING_TEMPERATURE,
+        top_p=1.0,
+        max_tokens=MAX_NEW_TOKENS,
+        logprobs=0,
+    )
+
+    prompt: str = build_prompt(question)
+    # vLLM's generate() is a blocking call, so we run it via asyncio.to_thread to keep it off the event
+    # loop — that lets the reusable replica's background actor heartbeat stay responsive while the GPU
+    # is busy. (We deliberately do not use flyte.extras.DynamicBatcher here: it batches many concurrent
+    # producers, whereas this env runs concurrency=1 and each call already submits a full group of
+    # GROUP_SIZE sequences as one vLLM batch.)
+    outputs: Any = await asyncio.to_thread(engine.generate, [prompt], sampling, lora_request=lora)
+    request = outputs[0]
+    prompt_token_ids: list[int] = list(request.prompt_token_ids)
+    logger.info("group %s: generated %d completions (adapter v%d)", group_id, len(request.outputs), version)
+    return [
+        Rollout(
+            group_id=group_id,
+            question=question,
+            completion=o.text,
+            answer=answer,
+            prompt_token_ids=prompt_token_ids,
+            token_ids=list(o.token_ids),
+            # o.logprobs[t] is {token_id: Logprob} for position t; index by the sampled token.
+            logprobs=[o.logprobs[t][tid].logprob for t, tid in enumerate(o.token_ids)],
+        )
+        for o in request.outputs
+    ]
+# {{/docs-fragment generate}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# 2. Reward — rule-based / verifiable
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment reward}}
+def _extract_answer(text: str) -> str | None:
+    """Pull the integer following the last '####' marker; fall back to the last integer in the text."""
+    import re
+
+    text = text.replace(",", "")  # "1,200" must read as 1200, not 1 (GSM8K answers use commas)
+    if "####" in text:
+        tail = text.rsplit("####", 1)[1]
+        m = re.search(r"-?\d+", tail)
+        if m:
+            return m.group(0)
+    nums = re.findall(r"-?\d+", text)
+    return nums[-1] if nums else None
+
+
+def _reward(rollout: Rollout) -> float:
+    """Verifiable reward: 1.0 for the correct answer, +0.2 format bonus for emitting the '####' marker."""
+    reward = 0.0
+    if "####" in rollout.completion:
+        reward += 0.2
+    predicted = _extract_answer(rollout.completion)
+    if predicted is not None and predicted == rollout.answer:
+        reward += 1.0
+    return reward
+# {{/docs-fragment reward}}
+
+
+# {{docs-fragment score_group}}
+@reward_env.task
+async def score_group(rollouts: list[Rollout]) -> list[float]:
+    """Score a whole prompt group in one task — one reward task per group, not per rollout.
+
+    The rule-based reward is microseconds of pure-Python work, so a task *per rollout* would pay pod
+    startup over and over for trivial compute. Scoring at the group granularity (the unit `generate`
+    already returns) keeps reward an observable, pipelined task while cutting the pod count ~GROUP_SIZE×.
+    """
+    return [_reward(r) for r in rollouts]
+# {{/docs-fragment score_group}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# 2b. Held-out eval — greedy decoding on the warm pool, before/after accuracy
+# ----------------------------------------------------------------------------------------------------
+class EvalResult(BaseModel):
+    accuracy: float  # fraction of questions answered exactly right (greedy decoding)
+    n: int
+    correct: int
+    format_rate: float  # fraction of completions that emitted the '####' marker
+
+
+# {{docs-fragment evaluate}}
+@rollout_env.task
+async def evaluate(
+    base: flyte.io.Dir,
+    questions: list[str],
+    answers: list[str],
+    adapter: flyte.io.Dir | None = None,
+    version: int = 0,
+) -> EvalResult:
+    """Score the policy on a held-out set with greedy (temperature-0) decoding.
+
+    Runs on the same warm vLLM pool as ``generate`` (the cached engine is reused), batching every
+    question into one engine call. ``adapter=None`` evaluates the raw base model — the pre-training
+    baseline the report compares against.
+    """
+    from vllm import SamplingParams
+    from vllm.lora.request import LoRARequest
+
+    engine: Any = await _load_engine(base.path)
+    lora: LoRARequest | None = None
+    if adapter is not None:
+        adapter_path: str = await _adapter_local_path(adapter.path)
+        lora = LoRARequest(f"policy-v{version}", version + 1, adapter_path)
+
+    sampling: SamplingParams = SamplingParams(n=1, temperature=0.0, max_tokens=MAX_NEW_TOKENS)
+    prompts: list[str] = [build_prompt(q) for q in questions]
+    outputs: Any = await asyncio.to_thread(engine.generate, prompts, sampling, lora_request=lora)
+
+    completions: list[str] = [req.outputs[0].text for req in outputs]
+    correct = sum(1 for c, a in zip(completions, answers) if _extract_answer(c) == a)
+    formatted = sum(1 for c in completions if "####" in c)
+    n = len(questions)
+    result = EvalResult(
+        accuracy=correct / n if n else 0.0,
+        n=n,
+        correct=correct,
+        format_rate=formatted / n if n else 0.0,
+    )
+    logger.info("eval (adapter v%s): %d/%d correct (%.1f%%)",
+                version if adapter is not None else "base", correct, n, 100 * result.accuracy)
+    return result
+# {{/docs-fragment evaluate}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# 3. Trainer — one GRPO step on the PEFT LoRA adapter (base frozen)
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment init_adapter}}
+@train_env.task
+async def init_adapter(base: flyte.io.Dir) -> flyte.io.Dir:
+    """Create a fresh (untrained) LoRA adapter so iteration 0 already has an adapter to attach."""
+    import torch
+    from peft import LoraConfig, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    local_base: str = await base.download()
+    model: Any = AutoModelForCausalLM.from_pretrained(
+        local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
+    )
+    lora_config: Any = LoraConfig(
+        r=LORA_RANK,
+        lora_alpha=LORA_ALPHA,
+        lora_dropout=0.0,
+        bias="none",
+        task_type="CAUSAL_LM",
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+    )
+    model = get_peft_model(model, lora_config)
+
+    out_dir: str = tempfile.mkdtemp(prefix="adapter-v0-")
+    model.save_pretrained(out_dir)  # writes adapter_config.json + adapter_model.safetensors only
+    logger.info("Initialized fresh LoRA adapter at %s", out_dir)
+    return await flyte.io.Dir.from_local(out_dir)
+# {{/docs-fragment init_adapter}}
+
+
+# {{docs-fragment advantages}}
+def _group_normalized_advantages(rollouts: list[Rollout], rewards: list[float]) -> list[float]:
+    """GRPO advantage: within each prompt group, ``(r - mean) / (std + eps)``."""
+    import statistics
+    from collections import defaultdict
+
+    by_group: dict[int, list[int]] = defaultdict(list)
+    for i, r in enumerate(rollouts):
+        by_group[r.group_id].append(i)
+
+    advantages = [0.0] * len(rollouts)
+    for idxs in by_group.values():
+        group_rewards = [rewards[i] for i in idxs]
+        mean = statistics.fmean(group_rewards)
+        std = statistics.pstdev(group_rewards) if len(group_rewards) > 1 else 0.0
+        for i in idxs:
+            advantages[i] = (rewards[i] - mean) / (std + 1e-4)
+    return advantages
+# {{/docs-fragment advantages}}
+
+
+# {{docs-fragment train_step}}
+@train_env.task
+async def train_step(
+    base: flyte.io.Dir,
+    rollouts: list[Rollout],
+    rewards: list[float],
+    adapter: flyte.io.Dir,
+    version: int,
+) -> tuple[flyte.io.Dir, float, int]:
+    """One GRPO policy-gradient step over externally-generated rollouts; trains the LoRA adapter only.
+
+    Resumes from the previous adapter (``PeftModel.from_pretrained(..., is_trainable=True)``), takes a
+    single optimizer step on the group-normalized policy-gradient loss, and ``save_pretrained()``s the
+    new adapter as a ``flyte.io.Dir``. See module docstring for why this is hand-rolled rather than TRL.
+
+    Returns ``(new_adapter, mean_loss, contributing)`` so the driver can chart loss in the report.
+    """
+    import torch
+    import torch.nn.functional as F
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    local_base: str = await base.download()
+    local_adapter: str = await adapter.download()
+
+    tokenizer: Any = AutoTokenizer.from_pretrained(local_base, trust_remote_code=True)
+    base_model: Any = AutoModelForCausalLM.from_pretrained(
+        local_base, torch_dtype=torch.bfloat16, trust_remote_code=True
+    ).to(device)
+    # Resume the trainable adapter from the previous version (frozen base, only A/B train).
+    model: Any = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True).to(device)
+    model.train()
+
+    advantages: list[float] = _group_normalized_advantages(rollouts, rewards)
+    optimizer: Any = torch.optim.AdamW((p for p in model.parameters() if p.requires_grad), lr=LEARNING_RATE)
+    optimizer.zero_grad()
+
+    total_loss: float = 0.0
+    contributing: int = 0
+    for rollout, advantage in zip(rollouts, advantages):
+        if advantage == 0.0:
+            continue  # no learning signal (whole group scored identically)
+
+        prompt_text = build_prompt(rollout.question)
+        prompt_ids = tokenizer(prompt_text, return_tensors="pt").input_ids
+        full_ids = tokenizer(prompt_text + rollout.completion, return_tensors="pt").input_ids.to(device)
+
+        prompt_len = prompt_ids.shape[1]
+        if full_ids.shape[1] <= prompt_len:
+            continue  # empty completion after tokenization
+
+        logits = model(full_ids).logits  # (1, seq, vocab)
+        # log p(token_t | token_<t): align logits[:-1] with targets full_ids[1:]
+        log_probs = F.log_softmax(logits[:, :-1, :], dim=-1)
+        targets = full_ids[:, 1:]
+        token_log_probs = log_probs.gather(-1, targets.unsqueeze(-1)).squeeze(-1)  # (1, seq-1)
+
+        # Mask to the completion tokens only (targets at positions >= prompt_len-1 in the shifted view).
+        completion_mask = torch.zeros_like(token_log_probs)
+        completion_mask[:, prompt_len - 1 :] = 1.0
+        seq_log_prob = (token_log_probs * completion_mask).sum() / completion_mask.sum().clamp(min=1.0)
+
+        loss = -advantage * seq_log_prob
+        loss.backward()  # accumulate gradients across the batch, single optimizer step below
+        total_loss += float(loss.item())
+        contributing += 1
+
+    if contributing > 0:
+        torch.nn.utils.clip_grad_norm_((p for p in model.parameters() if p.requires_grad), 1.0)
+        optimizer.step()
+        logger.info(
+            "GRPO step v%d: %d/%d rollouts contributed, mean loss %.4f",
+            version,
+            contributing,
+            len(rollouts),
+            total_loss / contributing,
+        )
+    else:
+        logger.info("GRPO step v%d: no contributing rollouts (flat rewards); adapter unchanged", version)
+
+    out_dir = tempfile.mkdtemp(prefix=f"adapter-v{version}-")
+    model.save_pretrained(out_dir)
+    mean_loss = total_loss / contributing if contributing > 0 else 0.0
+    new_adapter = await flyte.io.Dir.from_local(out_dir)
+    return new_adapter, mean_loss, contributing
+# {{/docs-fragment train_step}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# 4. Driver — the RL loop (replaces Ray)
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment driver_helpers}}
+def _sample_prompts(iteration: int) -> list[tuple[str, str]]:
+    """Deterministically rotate through the dataset so each iteration sees a different slice."""
+    start = (iteration * PROMPTS_PER_ITER) % len(DATASET)
+    return [DATASET[(start + i) % len(DATASET)] for i in range(PROMPTS_PER_ITER)]
+
+
+def _report_config() -> dict[str, Any]:
+    """Static run config surfaced in the report header."""
+    return dict(
+        base_model=BASE_MODEL_REPO,
+        num_iterations=NUM_ITERATIONS,
+        group_size=GROUP_SIZE,
+        prompts_per_iter=PROMPTS_PER_ITER,
+        lora_rank=LORA_RANK,
+        learning_rate=LEARNING_RATE,
+    )
+
+
+async def _publish_report(history: list[IterationMetrics], status: str) -> None:
+    """Re-render and flush the live GRPO progress report to the driver task's report tab."""
+    await flyte.report.replace.aio(
+        render_report(history, status=status, **_report_config()),
+        do_flush=True,
+    )
+# {{/docs-fragment driver_helpers}}
+
+
+# {{docs-fragment train_rl}}
+@driver_env.task(report=True)
+async def train_rl(base: flyte.io.Dir, num_iterations: int = NUM_ITERATIONS) -> flyte.io.Dir:
+    """Own the GRPO loop: fan out rollouts, score as they finish, take one GRPO step, repeat.
+
+    Loop state (iteration, current adapter, and the report history) is checkpointed each iteration so a
+    preempted driver resumes mid-run — including the accumulated report rows — instead of restarting.
+    Progress is published to a live HTML report (``report=True``) after every iteration.
+    """
+    ctx = flyte.ctx()
+    cp = ctx.checkpoint if ctx is not None else None
+
+    start_iter = 0
+    adapter: flyte.io.Dir | None = None
+    adapter_version = 0
+    history: list[IterationMetrics] = []
+
+    # Resume from a prior driver attempt, if any.
+    if cp is not None:
+        prev = await cp.load()
+        if prev is not None:
+            state = json.loads(prev.read_text())
+            start_iter = state["iteration"] + 1
+            adapter_version = state["adapter_version"]
+            adapter = flyte.io.Dir.from_existing_remote(state["adapter_path"])
+            history = [IterationMetrics(**row) for row in state.get("history", [])]
+            logger.info("Resumed from checkpoint at iteration %d (adapter v%d)", start_iter, adapter_version)
+
+    # Cold start: mint a fresh LoRA adapter (version 0).
+    if adapter is None:
+        adapter = await init_adapter(base)
+        adapter_version = 0
+
+    await _publish_report(history, status="running")
+
+    for it in range(start_iter, num_iterations):
+        with flyte.group(f"iter-{it}"):
+            prompts = _sample_prompts(it)
+
+            # Launch every rollout group at once on the warm replicas.
+            rollout_futs = [
+                asyncio.create_task(generate(base, q, a, adapter, adapter_version, group_id=gid))
+                for gid, (q, a) in enumerate(prompts)
+            ]
+
+            # Score each group the instant its rollout finishes — reward overlaps in-flight rollouts.
+            # One reward task per group (not per rollout): see score_group.
+            flat_rollouts: list[Rollout] = []
+            reward_futs: list[asyncio.Task[list[float]]] = []
+            for fut in asyncio.as_completed(rollout_futs):
+                group = await fut
+                flat_rollouts.extend(group)
+                reward_futs.append(asyncio.create_task(score_group(group)))
+
+            group_rewards = await asyncio.gather(*reward_futs)  # aligned with append order
+            rewards = [r for gr in group_rewards for r in gr]  # flatten → aligned with flat_rollouts
+            mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
+            logger.info("iter %d: %d rollouts, mean reward %.3f", it, len(rewards), mean_reward)
+
+            # One GRPO step → next adapter version.
+            new_version = adapter_version + 1
+            adapter, mean_loss, contributing = await train_step(
+                base, flat_rollouts, rewards, adapter, new_version
+            )
+            adapter_version = new_version
+
+            # Record metrics for the report (accuracy/format derived directly from the rollouts).
+            n = len(flat_rollouts)
+            correct = sum(1 for r in flat_rollouts if _extract_answer(r.completion) == r.answer)
+            formatted = sum(1 for r in flat_rollouts if "####" in r.completion)
+            best_idx = max(range(n), key=lambda i: rewards[i]) if n else None
+            history.append(
+                IterationMetrics(
+                    iteration=it,
+                    adapter_version=adapter_version,
+                    num_rollouts=n,
+                    mean_reward=mean_reward,
+                    max_reward=max(rewards) if rewards else 0.0,
+                    accuracy=correct / n if n else 0.0,
+                    format_rate=formatted / n if n else 0.0,
+                    mean_loss=mean_loss,
+                    contributing=contributing,
+                    sample_question=flat_rollouts[best_idx].question if best_idx is not None else "",
+                    sample_completion=flat_rollouts[best_idx].completion if best_idx is not None else "",
+                    sample_reward=rewards[best_idx] if best_idx is not None else 0.0,
+                )
+            )
+            await _publish_report(history, status="running")
+
+            # Persist loop state so a preempted driver resumes here (with its report history).
+            if cp is not None:
+                state = {
+                    "iteration": it,
+                    "adapter_version": adapter_version,
+                    "adapter_path": adapter.path,
+                    "history": [vars(m) for m in history],
+                }
+                await cp.save(json.dumps(state).encode())
+
+    await _publish_report(history, status="complete")
+    assert adapter is not None
+    return adapter
+# {{/docs-fragment train_rl}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# Entry point
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment entrypoint}}
+if __name__ == "__main__":
+    import flyte.prefetch
+
+    flyte.init_from_config()
+
+    # Prefetch the base ONCE into the Flyte object store as plain HF weights (see module docstring for
+    # why we do not vLLM-shard for this single-GPU MVP). hf_model returns a Run; its sole output is the
+    # model Dir, which we pass straight into the driver task as a flyte.io.Dir.
+    run = flyte.prefetch.hf_model(repo=BASE_MODEL_REPO, hf_token_key="hf-token")
+    run.wait()
+    print(f"Prefetched base model: {run.url}")
+    # hf_model's sole output is the model Dir. run.outputs() may be sync or awaitable depending on the
+    # SDK build, so handle both. The result is an ActionOutputs tuple; element 0 is the base Dir.
+    import inspect
+
+    outputs = run.outputs()
+    if inspect.isawaitable(outputs):
+        outputs = asyncio.run(outputs)
+    base_dir = outputs[0]
+
+    rl_run = flyte.run(train_rl, base=base_dir, num_iterations=NUM_ITERATIONS)
+    print(rl_run.url)
+    rl_run.wait()
+# {{/docs-fragment entrypoint}}

--- a/v2/tutorials/multinode_rl_grpo_lora/rl_grpo_lora_clustered.py
+++ b/v2/tutorials/multinode_rl_grpo_lora/rl_grpo_lora_clustered.py
@@ -1,0 +1,733 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#    "flyte>=2.4.0",
+#    "unionai-reuse>=0.1.3",
+#    "async-lru>=2.0.0",
+#    "torch>=2.5.0",
+#    "transformers>=4.51.0",
+#    "peft>=0.13.0",
+#    "vllm>=0.11.0",
+#    "accelerate>=0.34.0",
+#    "datasets>=3.0.0",
+# ]
+# main = "train_rl_clustered"
+# params = ""
+# ///
+"""
+Part 2: Async multi-node GRPO — the trainer on a ClusteredTaskEnvironment
+=========================================================================
+
+This module extends the Part-1 tutorial (``rl_grpo_lora.py``, imported here for the rollout /
+reward / eval building blocks) with the Part-2 ideas:
+
+1. **The GRPO trainer becomes a multi-node clustered task.** ``train_step_clustered`` runs on a
+   ``ClusteredTaskEnvironment``: `replicas` pods launched as ONE Kubernetes JobSet, bootstrapped
+   by torchrun, cooperating via ``torch.distributed``. Same call shape as Part 1's ``train_step``
+   — the multi-node part is an *environment declaration*, not a rewrite.
+
+2. **Generation pipelines against training (async, one-step off-policy).** While the clustered
+   trainer spins up and trains on iteration N's rollouts, the warm vLLM pool is already
+   generating iteration N+1's rollouts with the current (one-step-stale) adapter. The JobSet
+   cold start disappears under generation the pool was doing anyway. ``pipelined=False`` runs
+   the same loop strictly sequentially so the two can be measured against each other — the
+   report's timing chart is the receipt.
+
+3. **The real GRPO objective.** Because pipelining trains on rollouts sampled by the *previous*
+   adapter, the plain REINFORCE loss of Part 1 is no longer sound. This trainer implements the
+   token-level clipped-importance-ratio surrogate (ratio from vLLM's sampling-time logprobs
+   carried in each ``Rollout``) plus a k3 KL penalty against the adapter-disabled base model —
+   i.e. GRPO as published, not a simplification. Optimizer (AdamW) state persists across
+   iterations through the object store, exactly like the adapter.
+
+4. **A held-out eval.** ``evaluate`` (Part 1) scores a fixed question set with greedy decoding
+   on the warm pool — once for the raw base model (the baseline) and again after every training
+   step. The live report charts the delta.
+
+What users learn here about clustered task environments:
+- how to CREATE one (``ClusteredTaskEnvironment(replicas=..., nproc_per_node=..., runtime=
+  TorchRun(), failure_policy=ClusterFailurePolicy(...))``),
+- how to USE one (decorate a plain async function with ``@train_env.task``; call it with
+  ``await`` from a driver exactly like any other task),
+- what runs inside (every rank executes the same function; torchrun has already set
+  RANK/WORLD_SIZE/MASTER_ADDR; ``flyte.ctx()`` exposes rank/world_size/node_rank),
+- the two hard rules: rank 0's return value is the task output (other ranks' are discarded, but
+  every rank must return matching types), and a clustered task has NO controller — it cannot
+  call other tasks, so the loop stays in the plain-env driver,
+- the one DDP discipline multi-node training demands: **every rank must execute the same number
+  of collective operations**. Per-sample ``backward()`` with data-dependent skips desyncs NCCL
+  the moment ranks disagree; see ``ddp_shard_step`` for the pattern that makes the invariant
+  hold by construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import flyte
+import flyte.io
+import flyte.report
+from flyte.clustered import ClusteredTaskEnvironment, ClusterFailurePolicy, TorchRun
+from pydantic import BaseModel
+
+# Part 1 building blocks reused verbatim: image, warm vLLM pool, reward, eval, adapter init.
+from report_helpers import IterationMetrics, render_report
+from rl_grpo_lora import (
+    _PROFILE_ENV_VARS,
+    BASE_MODEL_REPO,
+    DATASET,
+    DEFAULT_DATASET,
+    EVAL_SET_SIZE,
+    GPU_TYPE,
+    GROUP_SIZE,
+    HF_SECRET,
+    LEARNING_RATE,
+    LORA_RANK,
+    NUM_ITERATIONS,
+    PROFILE,
+    PROFILE_NAME,
+    PROMPTS_PER_ITER,
+    Rollout,
+    _extract_answer,
+    _group_normalized_advantages,
+    evaluate,
+    generate,
+    image,
+    init_adapter,
+    reward_env,
+    rollout_env,
+    score_group,
+)
+from rl_grpo_lora import train_env as part1_train_env  # init_adapter lives here → must register it
+
+logger = logging.getLogger(__name__)
+
+# --- Part-2 knobs (sized by GRPO_PROFILE; see PROFILES in rl_grpo_lora.py) ----------------------
+REPLICAS: int = PROFILE["train_replicas"]  # pods (== nodes) in the trainer JobSet
+NPROC_PER_NODE: int = PROFILE["train_nproc_per_node"]  # ranks per pod (== GPUs per pod)
+#   world_size = REPLICAS * NPROC_PER_NODE
+USE_GPU = True
+_BACKEND = "nccl" if USE_GPU else "gloo"
+
+CLIP_EPS = 0.2  # PPO/GRPO clip window: ratios outside [1-eps, 1+eps] stop contributing gradient
+KL_BETA = 0.03  # weight of the KL(policy ‖ adapter-disabled base) penalty
+TRAIN_EPOCHS_PER_STEP: int = PROFILE["train_epochs_per_step"]  # optimizer steps per clustered call;
+#   >1 amortizes the JobSet cold start and is legitimate *because* the objective clips — each extra
+#   epoch re-computes ratios against the just-updated policy, PPO-style.
+
+_train_resources = (
+    flyte.Resources(
+        cpu=PROFILE["train_cpu"],
+        memory=PROFILE["train_memory"],
+        gpu=flyte.GPU(GPU_TYPE, PROFILE["train_gpus"]),  # per POD; must be >= nproc_per_node
+        shm="auto",
+    )
+    if USE_GPU
+    else flyte.Resources(cpu=(2, 4), memory=("4Gi", "8Gi"))
+)
+
+# ----------------------------------------------------------------------------------------------------
+# THE clustered task environment — this is the new concept Part 2 teaches.
+# ----------------------------------------------------------------------------------------------------
+# Each call to a task decorated with this env emits ONE Kubernetes JobSet of `replicas` pods.
+# Every pod runs torchrun with `nproc_per_node` workers; all workers rendezvous into a single
+# torch.distributed process group. `failure_policy(max_restarts=2)` = if ANY pod dies, the WHOLE
+# set restarts together (up to twice) — partial restarts would leave ranks desynchronized.
+# NOTE: `reusable` is not supported here (clustered = run-to-completion JobSet, not a warm actor);
+# the warm pool stays where it belongs — on the Part-1 rollout env.
+# {{docs-fragment clustered_env}}
+train_env = ClusteredTaskEnvironment(
+    name="rl-grpo-train-cluster",
+    image=image,  # same image as Part 1 — torch/peft/transformers already in it
+    resources=_train_resources,  # per-POD resources (not per-JobSet)
+    replicas=REPLICAS,
+    nproc_per_node=NPROC_PER_NODE,
+    runtime=TorchRun(rdzv_backend="static", max_restarts=0),  # in-pod torchrun; restarts are JobSet-level
+    failure_policy=ClusterFailurePolicy(max_restarts=2),
+    secrets=[HF_SECRET],
+    env_vars=_PROFILE_ENV_VARS,
+)
+# {{/docs-fragment clustered_env}}
+
+
+class TrainMetrics(BaseModel):
+    """Cross-rank-reduced training statistics returned alongside the new adapter."""
+
+    mean_loss: float
+    mean_ratio: float  # mean importance ratio pi_new/pi_old — drifts off 1.0 when pipelining
+    clip_fraction: float  # fraction of tokens whose ratio left the [1-eps, 1+eps] window
+    mean_kl: float  # mean k3 KL(policy ‖ adapter-disabled base)
+    grad_norm: float
+    contributing: int  # samples with non-zero advantage (metric only — all valid samples train)
+    num_valid: int  # samples carrying token_ids + logprobs that entered the loss
+
+
+# ----------------------------------------------------------------------------------------------------
+# The GRPO objective and the DDP collective pattern — pure functions so `test_grpo_loss_ddp.py`
+# can exercise them on CPU without Flyte or a cluster.
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment grpo_loss}}
+def grpo_sample_loss(
+    new_logp: Any,
+    old_logp: Any,
+    ref_logp: Any,
+    advantage: float,
+    clip_eps: float = CLIP_EPS,
+    kl_beta: float = KL_BETA,
+) -> tuple[Any, dict[str, float]]:
+    """Token-level clipped-ratio GRPO loss for ONE completion.
+
+    All inputs are fp32 tensors of shape (T,) over the completion tokens; only ``new_logp``
+    requires grad. ``old_logp`` is the *behavior* policy — vLLM's sampling-time logprobs, i.e.
+    the adapter version that actually generated the rollout (one step stale when pipelining).
+    ``ref_logp`` is the frozen base with the adapter disabled, for the KL anchor.
+
+    loss = −( mean_t min(r_t·Â, clip(r_t, 1±ε)·Â) − β·mean_t KL_k3 ),  r_t = exp(new−old).
+
+    The k3 estimator ``exp(δ) − δ − 1`` (δ = ref − new) is non-negative and low-variance
+    (Schulman). At r = 1 the surrogate's *gradient* equals REINFORCE's (its value does not).
+    """
+    import torch
+
+    ratio = torch.exp(new_logp - old_logp)
+    clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps)
+    surrogate = torch.minimum(ratio * advantage, clipped * advantage).mean()
+    delta = ref_logp - new_logp
+    kl = (torch.exp(delta) - delta - 1.0).mean()
+    loss = -(surrogate - kl_beta * kl)
+    stats = {
+        "loss": float(loss.detach()),
+        "ratio": float(ratio.mean().detach()),
+        "kl": float(kl.detach()),
+        "clip_frac": float(((ratio - 1.0).abs() > clip_eps).float().mean().detach()),
+    }
+    return loss, stats
+
+
+def ddp_shard_step(ddp_model: Any, sample_loss_fns: list, sync_forward: Any) -> None:
+    """Accumulate per-sample gradients, then synchronize with EXACTLY ONE collective backward.
+
+    DDP fires its gradient all-reduce inside ``backward()``, so all ranks must execute the same
+    number of collective-bearing backwards — but shards are data-dependent and may be empty on
+    some ranks. The documented escape hatch: backwards inside ``no_sync()`` accumulate grads
+    locally with NO collectives (and free each sample's graph immediately), and the first
+    forward-backward AFTER the context syncs everything. Every rank therefore runs one dummy
+    1-token forward + zero-scaled backward, unconditionally — the collective count is identical
+    on every rank *by construction*, empty shards included.
+
+    (A bare ``(0.0 * sum(p.sum())).backward()`` would NOT work: it never passes through
+    ``DDP.forward``, so the reducer is not prepared for the iteration.)
+    """
+    with ddp_model.no_sync():
+        for fn in sample_loss_fns:
+            fn().backward()  # local grad accumulation; per-sample graph freed here
+    (sync_forward().float().sum() * 0.0).backward()  # the ONE synchronizing backward
+# {{/docs-fragment grpo_loss}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# The multi-node GRPO step. Every rank runs this function; gradients are averaged by DDP; rank 0
+# saves and uploads the new adapter + optimizer state and broadcasts their URIs so all ranks
+# return identical, correctly-typed outputs (rank 0's return IS the task output).
+# ----------------------------------------------------------------------------------------------------
+# {{docs-fragment train_step_clustered}}
+@train_env.task
+async def train_step_clustered(
+    base: flyte.io.Dir,
+    rollouts: list[Rollout],
+    rewards: list[float],
+    adapter: flyte.io.Dir,
+    version: int,
+    opt_state: flyte.io.Dir | None = None,
+) -> tuple[flyte.io.Dir, flyte.io.Dir, TrainMetrics]:
+    """One GRPO step across REPLICAS × NPROC_PER_NODE ranks (DDP over the LoRA adapter).
+
+    DDP, not FSDP, at this scale: the frozen 0.6B base fits every GPU, and DDP syncs only
+    parameters with requires_grad — i.e. the few-MB LoRA adapter — so cross-node traffic is
+    megabytes per step, comfortable on the clustered env's TCP interconnect. The FSDP swap
+    (shard the frozen base so bigger policies fit) is a later scale-up, marked below.
+    """
+    import tempfile
+    from datetime import timedelta
+
+    import torch
+    import torch.distributed as dist
+    from peft import PeftModel
+    from torch.nn.parallel import DistributedDataParallel as DDP
+    from transformers import AutoModelForCausalLM
+
+    ctx = flyte.ctx()
+
+    # Bind this rank to its local GPU BEFORE init_process_group so NCCL picks the right device.
+    if _BACKEND == "nccl" and torch.cuda.is_available():
+        torch.cuda.set_device(ctx.local_rank or 0)
+        device = torch.device(f"cuda:{ctx.local_rank or 0}")
+    else:
+        device = torch.device("cpu")
+
+    # torchrun already populated RANK / WORLD_SIZE / MASTER_ADDR / MASTER_PORT. Short timeout so a
+    # desynced collective surfaces as an error in minutes, not NCCL's 30-minute default.
+    dist.init_process_group(backend=_BACKEND, timeout=timedelta(minutes=10))
+    rank, world_size = dist.get_rank(), dist.get_world_size()
+    logger.info("[rank %d/%d] node %s/%s device=%s", rank, world_size, ctx.node_rank, ctx.nnodes, device)
+
+    local_base: str = await base.download()  # NB: every rank downloads — exercises the bundle path
+    local_adapter: str = await adapter.download()
+    local_opt: str | None = await opt_state.download() if opt_state is not None else None
+
+    # low_cpu_mem_usage: with nproc_per_node ranks per pod each loading the base, the default loader's
+    # full-size CPU staging copy per rank is what blows the pod's memory request on an 8B.
+    base_model: Any = AutoModelForCausalLM.from_pretrained(
+        local_base, torch_dtype=torch.bfloat16, trust_remote_code=True, low_cpu_mem_usage=True
+    ).to(device)
+    peft_model: Any = PeftModel.from_pretrained(base_model, local_adapter, is_trainable=True).to(device)
+    # FSDP swap for bigger policies goes here: wrap `peft_model` in FSDP(auto_wrap transformer
+    # blocks, use_orig_params=True) instead of DDP, and gather a full state dict before saving.
+    model = DDP(peft_model, device_ids=[device.index] if device.type == "cuda" else None)
+    model.train()
+
+    # Optimizer state persists across GRPO iterations through the object store, like the adapter.
+    # Every rank builds AdamW over the SAME param sequence and every rank loads the same state —
+    # they all step() on identical post-allreduce grads, so their states must match too.
+    # NOTE: a loaded state_dict's param_groups override the constructor lr — fine with a constant
+    # LR; revisit if a schedule is ever added.
+    trainable = [p for p in peft_model.parameters() if p.requires_grad]
+    optimizer: Any = torch.optim.AdamW(trainable, lr=LEARNING_RATE)
+    if local_opt is not None:
+        sd = torch.load(os.path.join(local_opt, "optimizer.pt"), map_location="cpu", weights_only=True)
+        optimizer.load_state_dict(sd)  # casts state tensors to the params' device
+
+    # Advantages are computed globally (group normalization must see whole groups, which may span
+    # shards). Validity is a property of the payload, so EVERY rank computes the same n_valid with
+    # zero communication — the loss normalization below depends on that.
+    advantages: list[float] = _group_normalized_advantages(rollouts, rewards)
+    valid = [
+        i for i, r in enumerate(rollouts) if len(r.token_ids) > 0 and len(r.logprobs) == len(r.token_ids)
+    ]
+    if not valid:
+        raise ValueError(
+            "No rollout carries token_ids/logprobs — these rollouts were generated by a pre-Part-2 "
+            "generate(); re-run generation with the updated module."
+        )
+    n_valid = len(valid)
+    # Contiguous shard of the *valid* indices; zero-advantage samples still train (the KL term
+    # anchors them) — skipping them would bias the KL and re-create data-dependent divergence.
+    shard = valid[rank * n_valid // world_size : (rank + 1) * n_valid // world_size]
+
+    sums = {"loss": 0.0, "ratio": 0.0, "kl": 0.0, "clip_frac": 0.0}
+
+    def make_sample_fn(i: int):
+        r = rollouts[i]
+
+        def fn() -> Any:
+            ids = torch.tensor([r.prompt_token_ids + r.token_ids], dtype=torch.long, device=device)
+            p, t = len(r.prompt_token_ids), len(r.token_ids)
+            # logits[p-1 : p-1+t] predict exactly the t completion tokens. Slice BEFORE the fp32
+            # upcast + log_softmax so the transient is (t, vocab), not (seq, vocab).
+            new_logp = (
+                model(ids).logits[0, p - 1 : p - 1 + t].float().log_softmax(-1)
+                .gather(-1, ids[0, p:].unsqueeze(-1)).squeeze(-1)
+            )
+            # Reference = same weights with LoRA disabled — one extra forward, no second model.
+            # Called on peft_model directly (not the DDP wrapper): no_grad forwards must not
+            # touch the DDP reducer.
+            with torch.no_grad(), peft_model.disable_adapter():
+                ref_logp = (
+                    peft_model(ids).logits[0, p - 1 : p - 1 + t].float().log_softmax(-1)
+                    .gather(-1, ids[0, p:].unsqueeze(-1)).squeeze(-1)
+                )
+            old_logp = torch.tensor(r.logprobs, dtype=torch.float32, device=device)
+            loss, stats = grpo_sample_loss(new_logp, old_logp, ref_logp, advantages[i])
+            for k in sums:
+                sums[k] += stats[k]
+            # Scale so the DDP-averaged gradient equals the single-process mean over ALL valid
+            # samples: avg_ranks(grad(Σ_shard (W/N)·l_i)) = (1/N)·Σ_all grad(l_i).
+            return loss * (world_size / n_valid)
+
+        return fn
+
+    grad_norm = 0.0
+    for _epoch in range(TRAIN_EPOCHS_PER_STEP):
+        for k in sums:
+            sums[k] = 0.0
+        optimizer.zero_grad(set_to_none=True)
+        ddp_shard_step(
+            model,
+            [make_sample_fn(i) for i in shard],
+            lambda: model(torch.zeros((1, 1), dtype=torch.long, device=device)).logits,
+        )
+        grad_norm = float(torch.nn.utils.clip_grad_norm_(trainable, 1.0))
+        optimizer.step()  # identical on every rank: grads were averaged by DDP
+
+    # Reduce metrics across ranks so the driver sees GLOBAL statistics, not rank 0's shard.
+    # (Stats are from the final epoch; contributing counts non-zero advantages, as a metric only.)
+    shard_contributing = sum(1 for i in shard if advantages[i] != 0.0)
+    stats_t = torch.tensor(
+        [sums["loss"], sums["ratio"], sums["kl"], sums["clip_frac"], float(len(shard)), float(shard_contributing)],
+        dtype=torch.float64,
+        device=device,
+    )
+    dist.all_reduce(stats_t, op=dist.ReduceOp.SUM)
+    n_global = max(int(stats_t[4]), 1)
+    metrics = TrainMetrics(
+        mean_loss=float(stats_t[0]) / n_global,
+        mean_ratio=float(stats_t[1]) / n_global,
+        mean_kl=float(stats_t[2]) / n_global,
+        clip_fraction=float(stats_t[3]) / n_global,
+        grad_norm=grad_norm,
+        contributing=int(stats_t[5]),
+        num_valid=n_valid,
+    )
+
+    # Rank 0 saves + uploads adapter and optimizer state, then broadcasts the URIs so every rank
+    # returns identical, correctly-typed outputs (the broadcast doubles as the pre-exit sync).
+    uris: list[str | None] = [None, None]
+    if rank == 0:
+        adapter_dir = tempfile.mkdtemp(prefix=f"adapter-v{version}-")
+        peft_model.save_pretrained(adapter_dir)  # PeftModel → adapter_config.json + safetensors only
+        opt_dir = tempfile.mkdtemp(prefix=f"optstate-v{version}-")
+        torch.save(optimizer.state_dict(), os.path.join(opt_dir, "optimizer.pt"))
+        uris = [(await flyte.io.Dir.from_local(adapter_dir)).path, (await flyte.io.Dir.from_local(opt_dir)).path]
+        logger.info(
+            "GRPO step v%d: %d valid rollouts (%d contributing), loss %.4f, ratio %.3f, clip %.3f, KL %.4f",
+            version, metrics.num_valid, metrics.contributing, metrics.mean_loss,
+            metrics.mean_ratio, metrics.clip_fraction, metrics.mean_kl,
+        )
+    dist.broadcast_object_list(uris, src=0)
+    new_adapter = flyte.io.Dir.from_existing_remote(uris[0])
+    new_opt_state = flyte.io.Dir.from_existing_remote(uris[1])
+
+    dist.barrier()
+    dist.destroy_process_group()
+    return new_adapter, new_opt_state, metrics
+# {{/docs-fragment train_step_clustered}}
+
+
+# ----------------------------------------------------------------------------------------------------
+# Datasets — the toy arithmetic set (wiring smoke test) or GSM8K (a real learning signal).
+# ----------------------------------------------------------------------------------------------------
+def _load_pairs(dataset: str) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Return (train_pairs, eval_pairs) of (question, gold-integer-answer-string).
+
+    ``arithmetic``: Part 1's 8 hardcoded questions. There is no held-out split at that size —
+    eval reuses the same 8, so its accuracy is a wiring check, not a generalization claim.
+    ``gsm8k``: HF ``openai/gsm8k`` (public, no token needed); train split for rollouts, the first
+    EVAL_SET_SIZE test items held out for eval. Gold answers keep GSM8K's '#### N' convention;
+    commas stripped ("1,200" → "1200") to match `_extract_answer`.
+    """
+    if dataset == "arithmetic":
+        return list(DATASET), list(DATASET)
+    if dataset == "gsm8k":
+        from datasets import load_dataset
+
+        ds = load_dataset("openai/gsm8k", "main")
+
+        def pair(ex: dict) -> tuple[str, str]:
+            return ex["question"], ex["answer"].rsplit("####", 1)[1].strip().replace(",", "")
+
+        train_pairs = [pair(ex) for ex in ds["train"]]
+        eval_pairs = [pair(ex) for ex in ds["test"].select(range(EVAL_SET_SIZE))]
+        return train_pairs, eval_pairs
+    raise ValueError(f"unknown dataset {dataset!r} (expected 'arithmetic' or 'gsm8k')")
+
+
+# ----------------------------------------------------------------------------------------------------
+# The async (pipelined) driver. Plain env — clustered tasks cannot call subtasks, so the loop
+# lives here. depends_on registers every environment the driver's tasks come from.
+# ----------------------------------------------------------------------------------------------------
+driver_env = flyte.TaskEnvironment(
+    name="rl-grpo-driver-v2",
+    image=image,
+    resources=flyte.Resources(cpu=1, memory="2Gi"),
+    depends_on=[rollout_env, reward_env, train_env, part1_train_env],
+    env_vars=_PROFILE_ENV_VARS,
+)
+
+
+async def _generate_and_score(
+    base: flyte.io.Dir,
+    pairs: list[tuple[str, str]],
+    iteration: int,
+    adapter: flyte.io.Dir,
+    version: int,
+    seed: int,
+) -> tuple[list[Rollout], list[float]]:
+    """Fan out one iteration's rollouts on the warm pool and score groups as they finish."""
+    import random
+
+    prompts = random.Random(seed * 100003 + iteration).sample(pairs, min(PROMPTS_PER_ITER, len(pairs)))
+    futs = [
+        asyncio.create_task(generate(base, q, a, adapter, version, group_id=gid))
+        for gid, (q, a) in enumerate(prompts)
+    ]
+    flat: list[Rollout] = []
+    reward_futs: list[asyncio.Task[list[float]]] = []
+    for fut in asyncio.as_completed(futs):
+        group = await fut
+        flat.extend(group)
+        reward_futs.append(asyncio.create_task(score_group(group)))
+    group_rewards = await asyncio.gather(*reward_futs)
+    return flat, [r for gr in group_rewards for r in gr]
+
+
+async def _timed_generate_and_score(*args: Any) -> tuple[list[Rollout], list[float], float]:
+    t0 = time.monotonic()
+    rollouts, rewards = await _generate_and_score(*args)
+    return rollouts, rewards, time.monotonic() - t0
+
+
+async def _publish(history: list[IterationMetrics], status: str, num_iterations: int, extra: dict) -> None:
+    await flyte.report.replace.aio(
+        render_report(
+            history,
+            status=status,
+            base_model=BASE_MODEL_REPO,
+            num_iterations=num_iterations,
+            group_size=GROUP_SIZE,
+            prompts_per_iter=PROMPTS_PER_ITER,
+            lora_rank=LORA_RANK,
+            learning_rate=LEARNING_RATE,
+            extra=extra,
+        ),
+        do_flush=True,
+    )
+
+
+# {{docs-fragment pipelined_driver}}
+@driver_env.task(report=True)
+async def train_rl_clustered(
+    base: flyte.io.Dir,
+    num_iterations: int = NUM_ITERATIONS,
+    dataset: str = DEFAULT_DATASET,
+    pipelined: bool = True,
+    seed: int = 17,
+) -> flyte.io.Dir:
+    """The Part-2 loop: train_step_clustered(N) runs CONCURRENTLY with generation of batch N+1.
+
+    Pipeline (one-step off-policy — batch N+1 is generated with the adapter from step N-1; the
+    trainer's clipped importance ratio is what makes that sound):
+
+        sequential:  [gen 0][train 0][gen 1][train 1]...
+        pipelined:   [gen 0][gen 1  ][gen 2  ]...
+                            [train 0][train 1]...   <- JobSet cold start hidden under generation
+                                     [eval 0 ][eval 1 ]  <- eval is off the critical path in BOTH modes
+
+    ``pipelined=False`` runs the identical loop strictly sequentially, so two runs give the
+    timing comparison chart. The held-out eval of step N is launched as a background task and
+    only awaited after step N+1's training, so it never sits between iterations; its row in the
+    report is back-filled one iteration late. Loop state (adapter, optimizer state, history,
+    baseline eval) is checkpointed each iteration so a preempted driver resumes mid-run.
+    """
+    ctx = flyte.ctx()
+    cp = ctx.checkpoint if ctx is not None else None
+
+    train_pairs, eval_pairs = _load_pairs(dataset)
+    eval_qs = [q for q, _ in eval_pairs]
+    eval_as = [a for _, a in eval_pairs]
+
+    start_iter = 0
+    version = 0
+    adapter: flyte.io.Dir | None = None
+    opt_state: flyte.io.Dir | None = None
+    baseline_accuracy: float | None = None
+    history: list[IterationMetrics] = []
+
+    # Resume from a prior driver attempt, if any.
+    if cp is not None:
+        prev = await cp.load()
+        if prev is not None:
+            state = json.loads(prev.read_text())
+            start_iter = state["iteration"] + 1
+            version = state["adapter_version"]
+            adapter = flyte.io.Dir.from_existing_remote(state["adapter_path"])
+            if state.get("opt_state_path"):
+                opt_state = flyte.io.Dir.from_existing_remote(state["opt_state_path"])
+            baseline_accuracy = state.get("baseline_accuracy")
+            history = [IterationMetrics(**row) for row in state.get("history", [])]
+            logger.info("Resumed from checkpoint at iteration %d (adapter v%d)", start_iter, version)
+
+    if adapter is None:
+        adapter = await init_adapter(base)
+        version = 0
+
+    # Pre-training baseline on the held-out set (base model, no adapter). Checkpoint-guarded so a
+    # resumed driver does not pay for it twice.
+    if baseline_accuracy is None:
+        with flyte.group("eval-baseline"):
+            baseline = await evaluate(base, eval_qs, eval_as, adapter=None)
+        baseline_accuracy = baseline.accuracy
+
+    extra = dict(
+        profile=PROFILE_NAME,
+        dataset=dataset,
+        pipelined=pipelined,
+        replicas=REPLICAS,
+        nproc_per_node=NPROC_PER_NODE,
+        clip_eps=CLIP_EPS,
+        kl_beta=KL_BETA,
+        baseline_accuracy=baseline_accuracy,
+    )
+    await _publish(history, "running", num_iterations, extra)
+
+    # The in-flight held-out eval (for the most recently trained adapter). On resume the previous
+    # attempt's in-flight eval is lost, so re-launch it if the last row is still un-scored.
+    pending_eval: asyncio.Task | None = None
+    if history and history[-1].eval_accuracy is None:
+        with flyte.group(f"iter-{history[-1].iteration}-eval"):
+            pending_eval = asyncio.create_task(evaluate(base, eval_qs, eval_as, adapter=adapter, version=version))
+
+    async def _settle_eval() -> None:
+        """Await the in-flight eval and back-fill its row (the row for the previous train step)."""
+        nonlocal pending_eval
+        if pending_eval is None:
+            return
+        ev = await pending_eval
+        pending_eval = None
+        for row in reversed(history):
+            if row.eval_accuracy is None:
+                row.eval_accuracy = ev.accuracy
+                logger.info("iter %d: held-out eval %.1f%%", row.iteration, 100 * ev.accuracy)
+                break
+
+    # Prime the pipeline: the first batch with the current adapter.
+    pending: asyncio.Task | None = None
+    last_state: dict | None = None
+    if start_iter < num_iterations:
+        with flyte.group(f"iter-{start_iter}-generate"):
+            pending = asyncio.create_task(
+                _timed_generate_and_score(base, train_pairs, start_iter, adapter, version, seed)
+            )
+
+    for it in range(start_iter, num_iterations):
+        t_iter = time.monotonic()
+        assert pending is not None
+        rollouts, rewards, gen_s = await pending
+
+        # PIPELINED: kick off the NEXT batch immediately with the CURRENT adapter (one step stale
+        # once training below lands) — the overlap covers the clustered trainer's whole lifetime,
+        # JobSet spin-up included.
+        if pipelined and it + 1 < num_iterations:
+            with flyte.group(f"iter-{it + 1}-generate"):
+                pending = asyncio.create_task(
+                    _timed_generate_and_score(base, train_pairs, it + 1, adapter, version, seed)
+                )
+
+        # Train on batch N (while batch N+1 generates on the warm pool, if pipelined).
+        t_train = time.monotonic()
+        version += 1
+        with flyte.group(f"iter-{it}-train"):
+            adapter, opt_state, tm = await train_step_clustered(
+                base, rollouts, rewards, adapter, version, opt_state
+            )
+        train_s = time.monotonic() - t_train
+        iter_s = time.monotonic() - t_iter  # gen (residual) + train; eval is off the critical path
+
+        # SEQUENTIAL: only now start the next batch, with the freshly-trained adapter.
+        if not pipelined and it + 1 < num_iterations:
+            with flyte.group(f"iter-{it + 1}-generate"):
+                pending = asyncio.create_task(
+                    _timed_generate_and_score(base, train_pairs, it + 1, adapter, version, seed)
+                )
+
+        # The PREVIOUS step's eval overlapped this step's training; settle it now (usually done).
+        # Then launch this step's eval in the background — it overlaps the NEXT train step.
+        await _settle_eval()
+        with flyte.group(f"iter-{it}-eval"):
+            pending_eval = asyncio.create_task(
+                evaluate(base, eval_qs, eval_as, adapter=adapter, version=version)
+            )
+
+        n = len(rollouts)
+        mean_reward = sum(rewards) / len(rewards) if rewards else 0.0
+        correct = sum(1 for r in rollouts if _extract_answer(r.completion) == r.answer)
+        formatted = sum(1 for r in rollouts if "####" in r.completion)
+        best_idx = max(range(n), key=lambda i: rewards[i]) if n else None
+        history.append(
+            IterationMetrics(
+                iteration=it,
+                adapter_version=version,
+                num_rollouts=n,
+                mean_reward=mean_reward,
+                max_reward=max(rewards) if rewards else 0.0,
+                accuracy=correct / n if n else 0.0,
+                format_rate=formatted / n if n else 0.0,
+                mean_loss=tm.mean_loss,
+                contributing=tm.contributing,
+                sample_question=rollouts[best_idx].question if best_idx is not None else "",
+                sample_completion=rollouts[best_idx].completion if best_idx is not None else "",
+                sample_reward=rewards[best_idx] if best_idx is not None else 0.0,
+                eval_accuracy=None,  # back-filled by _settle_eval after the next train step
+                mean_ratio=tm.mean_ratio,
+                clip_fraction=tm.clip_fraction,
+                mean_kl=tm.mean_kl,
+                gen_seconds=gen_s,
+                train_seconds=train_s,
+                iter_seconds=iter_s,
+            )
+        )
+        logger.info(
+            "iter %d: reward %.3f, loss %.4f, ratio %.3f, clip %.3f, KL %.4f, gen %.0fs, train %.0fs, iter %.0fs",
+            it, mean_reward, tm.mean_loss, tm.mean_ratio, tm.clip_fraction, tm.mean_kl, gen_s, train_s, iter_s,
+        )
+        await _publish(history, "running", num_iterations, extra)
+
+        # Persist loop state so a preempted driver resumes here (with its report history).
+        if cp is not None:
+            last_state = {
+                "iteration": it,
+                "adapter_version": version,
+                "adapter_path": adapter.path,
+                "opt_state_path": opt_state.path if opt_state is not None else None,
+                "baseline_accuracy": baseline_accuracy,
+                "dataset": dataset,
+                "seed": seed,
+                "history": [vars(m) for m in history],
+            }
+            await cp.save(json.dumps(last_state).encode())
+
+    # The final step's eval has nothing left to hide under — wait for it so the report is complete.
+    await _settle_eval()
+    if cp is not None and last_state is not None:
+        last_state["history"] = [vars(m) for m in history]
+        await cp.save(json.dumps(last_state).encode())
+    await _publish(history, "complete", num_iterations, extra)
+    assert adapter is not None
+    return adapter
+# {{/docs-fragment pipelined_driver}}
+
+
+if __name__ == "__main__":
+    import argparse
+    import inspect
+
+    import flyte.prefetch
+
+    parser = argparse.ArgumentParser(
+        description=f"Part 2: async multi-node GRPO (profile={PROFILE_NAME}; set GRPO_PROFILE=stress to scale)"
+    )
+    parser.add_argument("--dataset", choices=["arithmetic", "gsm8k"], default=DEFAULT_DATASET)
+    parser.add_argument("--iterations", type=int, default=NUM_ITERATIONS)
+    parser.add_argument("--sequential", action="store_true", help="disable pipelining (for the timing comparison)")
+    args = parser.parse_args()
+
+    flyte.init_from_config()
+    run = flyte.prefetch.hf_model(repo=BASE_MODEL_REPO, hf_token_key="hf-token")
+    run.wait()
+    outputs = run.outputs()
+    if inspect.isawaitable(outputs):
+        outputs = asyncio.run(outputs)
+
+    rl_run = flyte.run(
+        train_rl_clustered,
+        base=outputs[0],
+        num_iterations=args.iterations,
+        dataset=args.dataset,
+        pipelined=not args.sequential,
+    )
+    print(rl_run.url)
+    rl_run.wait()


### PR DESCRIPTION
## What this changes

Adds a tutorial built on top of an existing [rl_grpo_lora](https://github.com/unionai/unionai-examples/tree/main/v2/tutorials/rl_grpo_lora) tutorial we have but for clustered task environments. 


## Run

Run was tested here: https://demo.hosted.unionai.cloud/v2/domain/development/project/flytesnacks/runs/u7v66w2hvl6chvrsgj4b

## Checklist

- [ ] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [ ] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [ ] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered.
- [ ] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [ ] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).
