### PR TITLE
docsy: add temperatures.py, the quickstart first user-written file

### DIFF
--- a/v2/user-guide/getting-started/temperatures.py
+++ b/v2/user-guide/getting-started/temperatures.py
@@ -1,0 +1,20 @@
+# temperatures.py
+
+import flyte
+
+# A TaskEnvironment groups configuration for the tasks defined within it:
+# the container image, resources, and so on. This one keeps the defaults.
+env = flyte.TaskEnvironment(name="temperatures")
+
+# The @env.task decorator turns a Python function into a task.
+# Type annotations on the inputs and output are required.
+@env.task
+def to_fahrenheit(celsius: float) -> float:
+    return celsius * 9 / 5 + 32
+
+# This is the entrypoint task of the workflow. It calls to_fahrenheit
+# once per reading using flyte.map, which is like Python's map but runs
+# the calls in parallel, then returns the highest result.
+@env.task
+def hottest(readings: list[float] = [21.5, 19.0, 24.3, 22.8]) -> float:
+    return round(max(flyte.map(to_fahrenheit, readings)), 1)


### PR DESCRIPTION
Adds `v2/user-guide/getting-started/temperatures.py`, the file the quickstart will ask readers to write themselves.

## Why a new file

The quickstart is moving to a two-step opening (unionai-docs#1572): run the SDK's built-in example with `flyte run --local hello` to see a workflow work with no files, *then* write your own.

Until now "your own" was `hello.py` — which is the **same program** as the SDK's built-in, differing only in names (`hello_env`/`fn` vs `hello`/`worker`). So the reader would retype what the SDK had just written to a scratch directory. And `hello` vs `hello.py main` on one page is a naming collision waiting to confuse someone.

`temperatures.py` is deliberately a different program with a different name: `to_fahrenheit` mapped over a list of readings with `flyte.map`, returning the hottest. It teaches exactly what `hello.py` teaches — `TaskEnvironment`, `@env.task`, `flyte.map`, aggregation — with code, task names, file name and output that cannot be mistaken for the built-in.

## Verified by running it

```
$ flyte run --local temperatures.py hottest
Completed Local Run
Outputs: ActionOutputs(o0=75.7)
```

Rounded to one decimal in the task because the raw value was `75.74000000000001`, which reads as a bug on a first page.

## Shape

Same as `hello.py`: annotated, no `__main__` guard, no `flyte.init`, so the test runner does not pick it up — it is a docs include run via the CLI, like its predecessor. `hello.py` is left in place; whether the docs still reference it after #1572 decides its fate.

---
— docsy · automated docs agent · [DOC-1202](https://linear.app/unionai/issue/DOC-1202)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CJ89R9ri86y11FFhPdVJV
