### PR TITLE
triggers: add manual and programmatic trigger examples

### DIFF
--- a/v2/user-guide/task-configuration/triggers/manual.py
+++ b/v2/user-guide/task-configuration/triggers/manual.py
@@ -1,0 +1,92 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# main = "report_on_demand"
+# params = ""
+# ///
+
+"""Triggers without automation: a named, pre-bound launch configuration.
+
+Leave `automation` unset and the trigger becomes a saved way to run the task
+(default inputs, queue, env vars, notifications) that nothing fires on its own.
+It is fired on demand only, from the UI, the CLI, or `flyte.run` in Python.
+
+Deploy it with:
+
+    flyte deploy manual.py env
+    flyte get trigger
+"""
+
+# {{docs-fragment manual-triggers}}
+from datetime import datetime
+
+import flyte
+import flyte.notify
+from flyte.models import ActionPhase
+
+env = flyte.TaskEnvironment(name="manual_trigger_example")
+
+# No `automation=`: nothing schedules these. Each is a named set of inputs
+# plus what to do when the run ends.
+#
+# Trigger inputs override the task's own defaults (`region="all"`, `days=7`
+# below) for every run fired through the trigger. Inputs the trigger does not
+# mention keep the task default, so `quick-report` still gets `as_of=None`.
+quick_report = flyte.Trigger(
+    name="quick-report",
+    inputs={"region": "us-east", "days": 1},
+    description="Yesterday only, for a fast sanity check",
+    notifications=flyte.notify.Slack(
+        on_phase=(ActionPhase.FAILED, ActionPhase.TIMED_OUT),
+        webhook_url="https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+        message=":x: quick-report {{.Run.Name}} ended in {{.Phase}}: {{.Error}}",
+    ),
+)
+
+full_report = flyte.Trigger(
+    name="full-report",
+    inputs={"region": "all", "days": 30},
+    description="The full monthly report",
+    env_vars={"REPORT_VERBOSE": "1"},
+    notifications=(
+        flyte.notify.Email(
+            on_phase=ActionPhase.SUCCEEDED,
+            recipients=["reports@example.com"],
+            subject="Monthly report {{.Run.Name}} is ready",
+            body="Run: {{.Run.Name}}\nProject/Domain: {{.Run.Project}}/{{.Run.Domain}}",
+        ),
+        flyte.notify.Slack(
+            on_phase=ActionPhase.FAILED,
+            webhook_url="https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+            message=":rotating_light: full-report {{.Run.Name}} failed: {{.Error}}",
+        ),
+    ),
+)
+# {{/docs-fragment manual-triggers}}
+
+# {{docs-fragment manual-alongside-scheduled}}
+# A scheduled trigger can sit next to the manual ones on the same task. Only a
+# schedule can bind `flyte.TriggerTime`, since a manual trigger has no fire time.
+nightly = flyte.Trigger(
+    name="nightly",
+    automation=flyte.Cron("0 2 * * *"),
+    inputs={"as_of": flyte.TriggerTime, "region": "all", "days": 1},
+)
+
+
+@env.task(triggers=(quick_report, full_report, nightly))
+async def report_on_demand(region: str = "all", days: int = 7, as_of: datetime | None = None) -> str:
+    as_of = as_of or datetime.now()
+    msg = f"report for region={region!r} over the last {days} day(s), as of {as_of.isoformat()}"
+    print(msg)
+    return msg
+# {{/docs-fragment manual-alongside-scheduled}}
+
+
+# {{docs-fragment deploy}}
+if __name__ == "__main__":
+    flyte.init_from_config()
+    flyte.deploy(env)
+# {{/docs-fragment deploy}}

--- a/v2/user-guide/task-configuration/triggers/programmatic.py
+++ b/v2/user-guide/task-configuration/triggers/programmatic.py
@@ -1,0 +1,81 @@
+# /// script
+# requires-python = "==3.13"
+# dependencies = [
+#    "flyte>=2.0.0b52",
+# ]
+# ///
+
+"""Fire a deployed trigger from Python with `flyte.run`.
+
+A trigger is a saved launch configuration for a task: inputs, env vars, queue,
+notifications. Scheduled and artifact triggers fire on their own; a trigger
+with no automation (see `manual.py`) only fires when something asks for it.
+Either kind can be fired on demand by fetching it and passing it to
+`flyte.run`, exactly like a task.
+
+Run it after deploying `manual.py`:
+
+    flyte deploy manual.py env
+    python programmatic.py
+"""
+
+# {{docs-fragment run-trigger-as-deployed}}
+import flyte
+import flyte.remote
+
+TASK_NAME = "manual_trigger_example.report_on_demand"
+
+
+def fire_as_deployed() -> flyte.remote.Run:
+    """Fire `full-report` with exactly what it was deployed with (region="all", days=30)."""
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name=TASK_NAME)
+    return flyte.run(trigger)
+# {{/docs-fragment run-trigger-as-deployed}}
+
+
+# {{docs-fragment run-trigger-with-overrides}}
+def fire_with_overrides() -> flyte.remote.Run:
+    """Override one input; `region` keeps the trigger's value, `days` becomes 3."""
+    trigger = flyte.remote.Trigger.get(name="full-report", task_name=TASK_NAME)
+    return flyte.run(trigger, days=3)
+# {{/docs-fragment run-trigger-with-overrides}}
+
+
+# {{docs-fragment run-trigger-with-runcontext}}
+def fire_with_runcontext() -> flyte.remote.Run:
+    """Layer run-level overrides on top of the trigger's run spec.
+
+    The trigger's own env vars and notification rules are kept; `EXTRA_FLAG` is added and
+    the run gets a fixed name. Anything `with_runcontext` sets wins over the trigger's value.
+    """
+    trigger = flyte.remote.Trigger.get(name="quick-report", task_name=TASK_NAME)
+    return flyte.with_runcontext(env_vars={"EXTRA_FLAG": "1"}, name="quick-report-from-python").run(trigger)
+# {{/docs-fragment run-trigger-with-runcontext}}
+
+
+# {{docs-fragment run-every-trigger}}
+def fire_every_trigger_on_task() -> list[flyte.remote.Run]:
+    """Triggers from `listall()` can be fired too; their details are fetched on demand.
+
+    Scheduled triggers (`nightly` here) fire just fine off-schedule: the platform stamps the
+    run start time, and any `flyte.TriggerTime` input is filled from it.
+    """
+    runs = []
+    for trigger in flyte.remote.Trigger.listall(task_name=TASK_NAME):
+        runs.append(flyte.run(trigger))
+    return runs
+# {{/docs-fragment run-every-trigger}}
+
+
+# {{docs-fragment main}}
+if __name__ == "__main__":
+    flyte.init_from_config()
+
+    run = fire_with_overrides()
+    print(f"fired full-report with days=3: {run.url}")
+    run.wait()
+    print(f"phase={run.phase} inputs={run.inputs()} outputs={run.outputs()}")
+
+    run = fire_with_runcontext()
+    print(f"fired quick-report with run-context overrides: {run.url}")
+# {{/docs-fragment main}}

--- a/v2/user-guide/task-configuration/triggers/triggers.py
+++ b/v2/user-guide/task-configuration/triggers/triggers.py
@@ -19,11 +19,10 @@ def hourly_task(trigger_time: datetime, x: int = 1) -> str:
 # {{/docs-fragment hourly}}
 
 name="dummy_trigger"
-automation=flyte.Trigger.daily()  # Daily trigger
 # {{docs-fragment dummy-trigger}}
 flyte.Trigger(
     name,
-    automation,
+    automation=None,
     description="",
     auto_activate=True,
     inputs=None,


### PR DESCRIPTION
## What this changes

Two new examples under `v2/user-guide/task-configuration/triggers/`, plus a one-line tweak to `triggers.py`. They back the docs update in [unionai/unionai-docs#1578](https://github.com/unionai/unionai-docs/pull/1578) that documents triggers with no automation and firing any trigger on demand.

- **`manual.py`** — triggers with no `automation=`: saved launch configurations carrying inputs, env vars and notifications, next to a scheduled trigger on the same task. Fragments: `manual-triggers`, `manual-alongside-scheduled`, `deploy`.
- **`programmatic.py`** — fire a deployed trigger from Python with `flyte.run(trigger, ...)`: as deployed, with keyword overrides, layered with `with_runcontext`, and over `Trigger.listall()`. Fragments: `run-trigger-as-deployed`, `run-trigger-with-overrides`, `run-trigger-with-runcontext`, `run-every-trigger`, `main`.
- **`triggers.py`** — the `dummy-trigger` fragment now shows `automation=None`, matching the documented default.

`programmatic.py` needs `manual.py` deployed first, so like the app deploy examples it carries a PEP 723 header without a `main` entry.

## Checklist

- [x] The example is under `v2/` in the directory matching its docs location (not `v1/`).
- [x] It uses the Flyte 2 `flyte` SDK and has a `__main__` guard + a `flyte.init...` call (so the harness discovers it).
- [x] Complete PEP 723 header: `dependencies` pins `flyte` and every import; `main`/`params` are correct.
- [ ] `make test-local FILE=<path>` passes locally, and `make test-preview` shows it discovered. (Not run: `programmatic.py` is remote-only by design; `manual.py` compiles and its task runs locally with defaults.)
- [x] Regions embedded by the docs are wrapped in `# {{docs-fragment ...}}` markers; any renamed/moved file or fragment referenced by the docs has been updated or flagged.
- [x] For a tutorial: `README.md` stays on the example side of the examples-vs-product-docs boundary (demonstrates and links out, rather than duplicating product docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHPiCa8Yx7b3jNNxv9zEd6

